### PR TITLE
Improve path handling in CSV outputs

### DIFF
--- a/cli/cli.rs
+++ b/cli/cli.rs
@@ -51,7 +51,7 @@ pub enum OinkieCommand {
     // Execute(ExecuteOpts),
     #[command(name="run", about = "Extract birthmarks and compare them in one command")]
     Run(RunOpts),
-    #[command(name="reaggregate", about = "Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score", hide = true)]
+    #[command(name="reaggregate", about = "Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score")]
     Reaggregate(ReaggregateOpts),
 
     #[command(name="info", about = "Display information about the application")]

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -40,16 +40,18 @@ fn perform_run(opts: cli::RunOpts) -> Result<Vec<Duration>> {
             read_result_file(&dest_file, i, path1, path2)
         } else {
             pbar.set_message(format!("Loading program from {:?}", path1.display()));
-            let p1: Program<Op> = load(path1.to_path_buf())?;
+            let mut p1: Program<Op> = load(path1.to_path_buf())?;
+            p1.set_json_path(path1.to_path_buf());
             pbar.inc(1);
             pbar.set_message(format!("Loading program from {:?}", path2.display()));
-            let p2: Program<Op> = load(path2.to_path_buf())?;
+            let mut p2: Program<Op> = load(path2.to_path_buf())?;
+            p2.set_json_path(path2.to_path_buf());
             pbar.inc(1);
             pbar.set_message(format!("Comparing two programs ({}/{})", i + 1, comparing_count));
             let result = atype.comparator().compare_programs(&p1, &p2, aggregator)?;
             pbar.inc(1);
             result.store(&dest_file)?;
-            Ok(CompareResult::new(i, result.similarity(), path1.to_path_buf(), path2.to_path_buf(), result.duration()))
+            Ok(CompareResult::new(i, result.similarity(), p1.path().to_path_buf(), p2.path().to_path_buf(), result.duration()))
         }
     }).collect::<Vec<_>>();
     pbar.finish();
@@ -61,21 +63,44 @@ fn perform_run(opts: cli::RunOpts) -> Result<Vec<Duration>> {
 /// Read the comparison result from the given CSV file and return a CompareResult struct.
 /// This function skips actual comparison and shorten the comparison time if the result file already exists.
 /// The CSV file is expected to have a line starting with "result," followed by the duration in nanoseconds and the similarity value, separated by commas.
-fn read_result_file(dest_path: &Path, index: usize, path1: &Path, path2: &Path) -> Result<CompareResult> {
+fn read_result_file(dest_path: &Path, index: usize, _path1: &Path, _path2: &Path) -> Result<CompareResult> {
     let content = std::fs::read_to_string(dest_path)
         .map_err(|e| Error::Io(dest_path.to_path_buf(), e))?;
-    let mut lines = content.lines();
-    let result_line = lines.find(|line| line.starts_with("result,"))
-        .ok_or_else(|| Error::Parse(format!("Result line not found in {}", dest_path.display())))?;
-    let parts: Vec<&str> = result_line.split(',').collect();
-    if parts.len() < 3 {
-        return Err(Error::Parse(format!("Invalid result line format in {}", dest_path.display())));
+    let lines = content.lines();
+    
+    let mut original_path1 = PathBuf::new();
+    let mut original_path2 = PathBuf::new();
+    let mut similarity = 0.0;
+    let mut duration_nanos = 0;
+
+    for line in lines {
+        if line.starts_with("result,") {
+            let parts: Vec<&str> = line.split(',').collect();
+            if parts.len() < 3 {
+                return Err(Error::Parse(format!("Invalid result line format in {}", dest_path.display())));
+            }
+            duration_nanos = parts[1].parse()
+                .map_err(|e| Error::ParseInt(parts[1].to_string(), e))?;
+            similarity = parts[2].parse()
+                .map_err(|e| Error::Parse(format!("Failed to parse similarity value in {}: {}", dest_path.display(), e)))?;
+        } else if line.starts_with("left,") {
+            let parts: Vec<&str> = line.split(',').collect();
+            if parts.len() >= 4 {
+                original_path1 = PathBuf::from(parts[3]);
+            }
+        } else if line.starts_with("right,") {
+            let parts: Vec<&str> = line.split(',').collect();
+            if parts.len() >= 4 {
+                original_path2 = PathBuf::from(parts[3]);
+            }
+        }
     }
-    let duration_nanos: u64 = parts[1].parse()
-        .map_err(|e| Error::ParseInt(parts[1].to_string(), e))?;
-    let similarity: f64 = parts[2].parse()
-        .map_err(|e| Error::Parse(format!("Failed to parse similarity value in {}: {}", dest_path.display(), e)))?;
-    Ok(CompareResult::new(index, similarity, path1.to_path_buf(), path2.to_path_buf(), Duration::from_nanos(duration_nanos)))
+
+    if original_path1.as_os_str().is_empty() || original_path2.as_os_str().is_empty() {
+        return Err(Error::Parse(format!("Birthmark paths not found in {}", dest_path.display())));
+    }
+
+    Ok(CompareResult::new(index, similarity, original_path1, original_path2, Duration::from_nanos(duration_nanos)))
 }
 
 fn new_progress_bar(len: usize) -> ProgressBar {
@@ -127,18 +152,20 @@ fn compare_impl(tuple: (usize, (&Path, &Path)), comparator: &Comparator, dest: &
     } else {
         log::info!("Loading birthmark from {:?}", path2.display());
         pbar.set_message(format!("Loading birthmark from {:?}", path1.display()));
-        let b1: Birthmark = load(path1.to_path_buf()).unwrap();
+        let mut b1: Birthmark = load(path1.to_path_buf())?;
+        b1.set_json_path(path1.to_path_buf());
         pbar.inc(1);
         log::info!("Loading birthmark from {:?}", path2.display());
         pbar.set_message(format!("Loading birthmark from {:?}", path2.display()));
-        let b2: Birthmark = load(path2.to_path_buf()).unwrap();
+        let mut b2: Birthmark = load(path2.to_path_buf())?;
+        b2.set_json_path(path2.to_path_buf());
         pbar.inc(1);
         log::info!("Comparing birthmarks (len: {} x {}) progress: {}/{comparing_count}", b1.len(), b2.len(), i + 1);
         pbar.set_message(format!("Comparing birthmarks (len: {} x {}) progress: {}/{comparing_count}", b1.len(), b2.len(), i + 1));
         let result = comparator.compare_birthmarks(&b1, &b2, aggregator)?;
         pbar.inc(1);
-        result.store(&dest_file).unwrap();
-        Ok(CompareResult::new(i, result.similarity(), path1.to_path_buf(), path2.to_path_buf(), result.duration()))
+        result.store(&dest_file)?;
+        Ok(CompareResult::new(i, result.similarity(), b1.path().to_path_buf(), b2.path().to_path_buf(), result.duration()))
     }
 }
 

--- a/cli/reaggregator.rs
+++ b/cli/reaggregator.rs
@@ -50,14 +50,12 @@ fn scan_directory_for_results(score_dir: &Path) -> Result<Vec<CompareResult>> {
                 .map_err(|e| Error::Io(score_dir.to_path_buf(), e))? {
         let entry = entry.map_err(|e| Error::Io(score_dir.to_path_buf(), e))?;
         let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) == Some("csv") {
-            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-                if stem.chars().all(|c| c.is_numeric()) {
-                    let index = stem.parse::<usize>().map_err(|e| Error::ParseInt(stem.to_string(), e))?;
-                    let cr = CompareResult::new(index, 0.0, PathBuf::new(), PathBuf::new(), Duration::from_secs(0));
-                    results.push(cr);
-                }
-            }
+        if path.extension().and_then(|s| s.to_str()) == Some("csv")
+                && let Some(stem) = path.file_stem().and_then(|s| s.to_str())
+                && stem.chars().all(|c| c.is_numeric()) {
+            let index = stem.parse::<usize>().map_err(|e| Error::ParseInt(stem.to_string(), e))?;
+            let cr = CompareResult::new(index, 0.0, PathBuf::new(), PathBuf::new(), Duration::from_secs(0));
+            results.push(cr);
         }
     }
     Ok(results)

--- a/cli/reaggregator.rs
+++ b/cli/reaggregator.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use std::io::{BufRead, BufReader};
 
@@ -21,28 +21,57 @@ pub(crate) fn perform(opts: cli::ReaggregateOpts) -> Result<Vec<Duration>> {
 }
 
 fn reaggregate(cr: &CompareResult, score_dir: &Path, aggregator: &Aggregator) -> Result<(CompareResult, Duration)> {
+    let start = std::time::Instant::now();
     match load_comparison_file(cr.index, score_dir) {
-        Ok(matrix) => {
+        Ok((matrix, p1, p2, duration)) => {
             let (rows, cols) = matrix.dim();
             let size = std::cmp::max(rows, cols);
             let mut square_matrix = Array2::zeros((size, size));
             square_matrix.slice_mut(ndarray::s![0..rows, 0..cols]).assign(&matrix);
             let similarities = aggregator.aggregate(&square_matrix)?;
             let similarity = similarities.iter().sum::<f64>() / similarities.len() as f64;
-            Ok((CompareResult::new(cr.index, similarity, cr.path1.clone(), cr.path2.clone(), cr.duration), cr.duration))
+            Ok((CompareResult::new(cr.index, similarity, p1, p2, duration), start.elapsed()))
         },
         Err(e) => Err(e),
     }
 }
 
 fn load_results(score_dir: &Path) -> Result<Vec<CompareResult>> {
+    if score_dir.join("results.csv").exists() {
+        load_results_impl(score_dir)
+    } else {
+        scan_directory_for_results(score_dir)
+    }
+}
+
+fn scan_directory_for_results(score_dir: &Path) -> Result<Vec<CompareResult>> {
+    let mut results = Vec::new();
+    for entry in std::fs::read_dir(score_dir)
+                .map_err(|e| Error::Io(score_dir.to_path_buf(), e))? {
+        let entry = entry.map_err(|e| Error::Io(score_dir.to_path_buf(), e))?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) == Some("csv") {
+            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                if stem.chars().all(|c| c.is_numeric()) {
+                    let index = stem.parse::<usize>().map_err(|e| Error::ParseInt(stem.to_string(), e))?;
+                    let cr = CompareResult::new(index, 0.0, PathBuf::new(), PathBuf::new(), Duration::from_secs(0));
+                    results.push(cr);
+                }
+            }
+        }
+    }
+    Ok(results)
+}
+
+fn load_results_impl(score_dir: &Path) -> Result<Vec<CompareResult>> {
     let result_file = score_dir.join("results.csv");
     let mut reader = std::fs::File::open(result_file.clone())
         .map_err(|e| Error::Io(result_file.clone(), e))?;
     let mut results = Vec::new();
     let bufr = BufReader::new(&mut reader);
     for line in bufr.lines().map_while(|r| r.ok()) {
-        if line.strip_prefix("total duration,").is_some() {
+        let lower = line.to_lowercase();
+        if lower.strip_prefix("total duration,").is_some() {
             break;
         } else {
             let cr = CompareResult::parse(&line)?;
@@ -52,7 +81,7 @@ fn load_results(score_dir: &Path) -> Result<Vec<CompareResult>> {
     Ok(results)
 }
 
-fn load_comparison_file(index: usize, score_dir: &Path) -> Result<Array2<f64>> {
+fn load_comparison_file(index: usize, score_dir: &Path) -> Result<(Array2<f64>, PathBuf, PathBuf, Duration)> {
     let file_name = format!("{index:05}.csv");
     let path = score_dir.join(file_name);
     let r = load_comparison(&path);
@@ -60,35 +89,51 @@ fn load_comparison_file(index: usize, score_dir: &Path) -> Result<Array2<f64>> {
     r
 }
 
-fn load_comparison<P: AsRef<Path>>(path: P) -> Result<Array2<f64>> {
+fn load_comparison<P: AsRef<Path>>(path: P) -> Result<(Array2<f64>, PathBuf, PathBuf, Duration)> {
     let mut file = std::fs::File::open(path.as_ref())
         .map_err(|e| Error::Io(path.as_ref().to_path_buf(), e))?;
-    let csv_reader = csv::ReaderBuilder::new()
+    let mut csv_reader = csv::ReaderBuilder::new()
         .flexible(true)
         .has_headers(false)
         .from_reader(&mut file);
-    let mut iter = csv_reader.into_records();
-    let _result_line = iter.next().unwrap().map_err(Error::Csv)?;
-    let _left_line = iter.next().unwrap().map_err(Error::Csv)?;
-    let _right_line = iter.next().unwrap().map_err(Error::Csv)?;
-    let col_names_line = iter.next().unwrap().map_err(Error::Csv)?;
-    let cols = col_names_line.iter().skip(2).map(|s| s.to_string()).collect::<Vec<_>>();
-    let mut items = vec![];
-    let mut rows = vec![];
-    for line in iter {
-        let line = line.map_err(Error::Csv)?;
-        let row_item = line.get(1).unwrap();
-        rows.push(row_item.to_string());
-        log::info!("load comparison file row {:?} ({}) {:?}", row_item, line.len(), line.iter().skip(2).collect::<Vec<_>>());
-        for value in line.iter().skip(2) {
-            items.push(value.parse::<f64>().map_err(|e| Error::ParseFloat(value.to_string(), e))?);
+    let mut col_names = Vec::new();
+    let mut rows = Vec::new();
+    let mut items = Vec::new();
+    let mut path1 = PathBuf::new();
+    let mut path2 = PathBuf::new();
+    let mut duration = Duration::from_nanos(0);
+
+    for results in csv_reader.records() {
+        let record = results.map_err(Error::Csv)?;
+        let prefix = record.get(0).unwrap_or("");
+        match prefix {
+            "result" => if let Some(d_str) = record.get(1) {
+                let nanos = d_str.parse::<u64>().unwrap_or(0);
+                duration = Duration::from_nanos(nanos);
+            },
+            "left" => if let Some(s) = record.get(3) {
+                path1 = PathBuf::from(s);
+            },
+            "right" => if let Some(s) = record.get(3) {
+                path2 = PathBuf::from(s);
+            },
+            "matrix" => col_names = record.iter().skip(2).map(|s| s.to_string()).collect(),
+            _ if prefix.chars().all(|c| c.is_numeric()) && !prefix.is_empty() => {
+                rows.push(record.get(1).unwrap_or("").to_string());
+                for value in record.iter().skip(2) {
+                    items.push(value.parse::<f64>().map_err(|e| Error::ParseFloat(value.to_string(), e))?);
+                }
+            },
+            _ => continue,
         }
     }
-    log::info!("reshape vector (length: {}) with {} cols and {} rows", items.len(), cols.len(), rows.len());
-    let matrix = Array2::from_shape_vec((rows.len(), cols.len()), items)
-        .map_err(Error::ShapeError)?;
-
-    Ok(matrix)
+    if col_names.is_empty() || rows.is_empty() {
+        Err(Error::Parse(format!("Valid matrix data not found in {}", path.as_ref().display())))
+    } else {
+        let matrix = Array2::from_shape_vec((rows.len(), col_names.len()), items)
+            .map_err(Error::ShapeError)?;
+        Ok((matrix, path1, path2, duration))
+    }
 }
 
 #[cfg(test)]

--- a/cli/reaggregator.rs
+++ b/cli/reaggregator.rs
@@ -101,8 +101,8 @@ fn load_comparison<P: AsRef<Path>>(path: P) -> Result<(Array2<f64>, PathBuf, Pat
     let mut path2 = PathBuf::new();
     let mut duration = Duration::from_nanos(0);
 
-    for results in csv_reader.records() {
-        let record = results.map_err(Error::Csv)?;
+    for result in csv_reader.records() {
+        let record = result.map_err(Error::Csv)?;
         let prefix = record.get(0).unwrap_or("");
         match prefix {
             "result" => if let Some(d_str) = record.get(1) {

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -141,11 +141,14 @@ where
 pub struct Birthmark {
     pub metadata: Metadata,
     pub elements: Vec<Elements>,
+    #[serde(skip)]
+    pub json_path: Option<PathBuf>,
 }
 
 impl CsvInfo for Birthmark {
     fn csv_info(&self) -> String {
-        self.metadata.csv_info()
+        let json_path = self.json_path.as_ref().map(|p| p.display().to_string()).unwrap_or_default();
+        format!("{},{}", self.metadata.csv_info(), json_path)
     }
 
     fn names(&self) -> Vec<String> {
@@ -154,6 +157,10 @@ impl CsvInfo for Birthmark {
 }
 
 impl Birthmark {
+    pub fn set_json_path(&mut self, path: PathBuf) {
+        self.json_path = Some(path);
+    }
+
     pub fn comparable_with(&self, other: &Birthmark) -> bool {
         self.metadata.birthmark_type == other.metadata.birthmark_type
     }

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -98,21 +98,16 @@ impl<'a, S: CsvInfo> Comparison<'a, S> {
         let _ = writeln!(out, "result,{},{}", self.duration.as_nanos(), self.similarity());
         let _ = writeln!(out, "left,{}", self.rows.csv_info());
         let _ = writeln!(out, "right,{}", self.columns.csv_info());
-        let col_names = self.columns.names();
-        let row_names = self.rows.names();
-        let column_size = col_names.len();
-        let _ = write!(out, "matrix,,{}", col_names.join(","));
-        for ((row, col), value) in self.matrix.indexed_iter() {
-            if row >= row_names.len() {
-                break;
+        let b1_names = self.columns.names();
+        let b2_names = self.rows.names();
+        let _ = write!(out, "matrix,,{}", b1_names.iter()
+            .map(|s| escape_csv_string(s)).join(","));
+        for j in 0..b2_names.len() {
+            let _ = write!(out, "\n{}, {}", j, escape_csv_string(&b2_names[j]));
+            for i in 0..b1_names.len() {
+                let value = self.matrix[[i, j]];
+                let _ = write!(out, ",{value}");
             }
-            if col == 0 {
-                let _ = writeln!(out);
-                let _ = write!(out, "{row},{}", escape_csv_string(&row_names[row]));
-            } else if col >= column_size {
-                continue;
-            }
-            let _ = write!(out, ",{value}");
         }
         let _ = writeln!(out);
         Ok(())

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -102,8 +102,8 @@ impl<'a, S: CsvInfo> Comparison<'a, S> {
         let b2_names = self.rows.names();
         let _ = write!(out, "matrix,,{}", b1_names.iter()
             .map(|s| escape_csv_string(s)).join(","));
-        for j in 0..b2_names.len() {
-            let _ = write!(out, "\n{}, {}", j, escape_csv_string(&b2_names[j]));
+        for (j, item) in b2_names.iter().enumerate() {
+            let _ = write!(out, "\n{}, {}", j, escape_csv_string(item));
             for i in 0..b1_names.len() {
                 let value = self.matrix[[i, j]];
                 let _ = write!(out, ",{value}");

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -85,6 +85,7 @@ fn extract_birthmark_op<T: crate::Op>(p: &Program<T>, bt: &BirthmarkType) -> Res
     Ok(Birthmark {
         metadata,
         elements,
+        json_path: None,
     })
 }
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -12,11 +12,14 @@ pub struct Program<T> {
     path: PathBuf,
     symbols: FxHashMap<String, String>,
     functions: Vec<Function<T>>,
+    #[serde(skip)]
+    pub json_path: Option<PathBuf>,
 }
 
 impl<T> crate::prelude::CsvInfo for Program<T> {
     fn csv_info(&self) -> String {
-        format!("program,{},{},{},{}", self.name, self.path.display(), self.symbols.len(), self.functions.len())
+        let json_path = self.json_path.as_ref().map(|p| p.display().to_string()).unwrap_or_default();
+        format!("program,{},{},{},{},{}", self.name, self.path.display(), self.symbols.len(), self.functions.len(), json_path)
     }
     
     fn names(&self) -> Vec<String> {
@@ -25,8 +28,12 @@ impl<T> crate::prelude::CsvInfo for Program<T> {
 }
 
 impl<T> Program<T> {
+    pub fn set_json_path(&mut self, path: PathBuf) {
+        self.json_path = Some(path);
+    }
+
     pub fn new(name: String, path: PathBuf, symbols: FxHashMap<String, String>, functions: Vec<Function<T>>) -> Self {
-        Self { name, path, symbols, functions }
+        Self { name, path, symbols, functions, json_path: None }
     }
 
     pub fn name(&self) -> &str {


### PR DESCRIPTION
This PR improves how paths are handled in CSV outputs. It ensures individual comparison CSVs include the JSON path for reaggregation while the summary results (results.csv) consistently point to the original binary files.