### PR TITLE
feat: implement lift subcommand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ indicatif = "0.18.4"
 itertools = "0.14.0"
 katexit = "0.1.5"
 lapjv = "0.3.0"
-log = "0.4.29"
+log = "0.4.32"
 ndarray = "0.16"
 num-derive = "0.4.2"
 num-traits = "0.2.19"
 rayon = "1.12.0"
 rustc-hash = "2.1.2"
 serde = { version = "1.0.228", features = [ "derive" ] }
-serde_json = "1.0.149"
+serde_json = "1.0.150"
 sha2 = "0.10.9"
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ rustc-hash = "2.1.2"
 serde = { version = "1.0.228", features = [ "derive" ] }
 serde_json = "1.0.150"
 sha2 = "0.10.9"
+tempfile = "3.10.1"
 
 [[bin]]
 name = "oinkie"

--- a/cli/README.md
+++ b/cli/README.md
@@ -10,12 +10,12 @@ Birthmarking toolkit for Ghidra P-Code
 Usage: oinkie [OPTIONS] <COMMAND>
 
 Commands:
-  compare      Compare birthmarks and output the similarity score
-  extract      Extract birthmarks from a lifted binary file (JSON format)
-  run          Extract birthmarks and compare them in one command
-  reaggregate  Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score
-  lift         Lift binary files to P-code JSON files using a specified lifter
   info         Display information about the application
+  lift         Lift binary files to P-code JSON files using a specified lifter
+  extract      Extract birthmarks from a lifted binary file (JSON format)
+  compare      Compare birthmarks and output the similarity score
+  reaggregate  Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score
+  run          Extract birthmarks and compare them in one command
   help         Print this message or the help of the given subcommand(s)
 
 Options:

--- a/cli/README.md
+++ b/cli/README.md
@@ -10,11 +10,13 @@ Birthmarking toolkit for Ghidra P-Code
 Usage: oinkie [OPTIONS] <COMMAND>
 
 Commands:
-  compare  Compare birthmarks and output the similarity score
-  extract  Extract birthmarks from a lifted binary file (JSON format)
-  run      Extract birthmarks and compare them in one command
-  info     Display information about the application
-  help     Print this message or the help of the given subcommand(s)
+  compare      Compare birthmarks and output the similarity score
+  extract      Extract birthmarks from a lifted binary file (JSON format)
+  run          Extract birthmarks and compare them in one command
+  reaggregate  Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score
+  lift         Lift binary files to P-code JSON files using a specified lifter
+  info         Display information about the application
+  help         Print this message or the help of the given subcommand(s)
 
 Options:
   -l, --level <LEVEL>  Log level for the application [default: warn]
@@ -23,7 +25,44 @@ Options:
   -V, --version        Print version
 ```
 
+### `lift` command
+
+This command lifts binary files into Oinkie-IR files (P-code JSON format), which are used as inputs for the `extract` command.
+
+```sh
+Lift binary files to P-code JSON files using a specified lifter
+
+Usage: oinkie lift [OPTIONS] [FILES]...
+
+Arguments:
+  [FILES]...  Path to the binary or intermediate files to lift
+
+Options:
+  -d, --dest <DIRECTORY>
+          Specify the directory for putting the resultant JSON files for the lifted P-code
+          (default: './pcodes' directory) [default: pcodes]
+  -l, --lifter-type <LIFTER_TYPE>
+          Specify the lifter type [default: ghidra]
+          [possible values: ghidra, llvm, binary-ninja]
+  -H, --home <HOME>
+          Specify the path to the home directory of the lifter (e.g., GHIDRA_HOME for Ghidra).
+          If not specified, the environment variable (e.g., GHIDRA_HOME) or default paths are searched.
+  -i, --intermediate <DIRECTORY>
+          Directory to keep intermediate files like Ghidra project directories.
+          If not specified, a temporary directory is used and deleted.
+      --script <SCRIPT>
+          Path to a custom lifting script. Interpretation depends on the lifter type.
+          For Ghidra, it's the path to a Java script.
+  -S, --skip
+          Skip if the resultant JSON file already exists
+  -h, --help
+          Print help
+```
+
 ### `extract` command
+
+This command extracts birthmarks from the given lifted binary files.
+The lifted binary files are obtained by [`lift` command](#lift-command)
 
 ```sh
 Extract birthmarks from a lifted binary file (JSON format)
@@ -74,9 +113,6 @@ Options:
       - topn:N     For each element in the first birthmark, consider only the top N most similar elements in the
                    second birthmark when calculating the overall similarity score. This can reduce noise from less
                    relevant matches and focus on the most significant similarities. [default: hungarian]
-  -A, --aggregator <METHOD>
-      Specify the aggregator for combining element-wise similarity scores into a birthmark-wise similarity score. 
-      [default: hungarian] [possible values: hungarian, topn:N]
   -s, --strategy <STRATEGY>
       Specify the pairing strategy for comparing files. [default: all-and-self]
       [possible values: all-and-self, all, self-coverage, adjacent, first-vs-others]
@@ -86,6 +122,34 @@ Options:
       Skip if the similarity file already exists for the pair of birthmarks
   -h, --help
       Print help (see more with '--help')
+```
+
+### `reaggregate` command
+
+Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score.
+
+```sh
+Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score
+
+Usage: oinkie reaggregate [OPTIONS] <SCORE_DIRECTORY>
+
+Arguments:
+  <SCORE_DIRECTORY>  Path to the directory containing the element-wise similarity scores
+
+Options:
+  -A, --aggregator <METHOD>
+          Specify the aggregator for combining element-wise similarity scores into a birthmark-wise similarity score.
+          Available:
+          - hungarian  Use the Hungarian algorithm to find the optimal matching between elements of two birthmarks,
+                       maximizing the total similarity score.
+          - topn:N     For each element in the first birthmark, consider only the top N most similar elements in the
+                       second birthmark when calculating the overall similarity score. This can reduce noise from less
+                       relevant matches and focus on the most significant similarities. [default: hungarian]
+  -d, --dest-file <RESULT.CSV>
+          Specify the result CSV file of the comparing results to reaggregate.
+          The file contains the birthmark-wise similarity score list. [default: reaggregate.csv]
+  -h, --help
+          Print help
 ```
 
 ### `run` command

--- a/cli/cli.rs
+++ b/cli/cli.rs
@@ -54,8 +54,81 @@ pub enum OinkieCommand {
     #[command(name="reaggregate", about = "Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score")]
     Reaggregate(ReaggregateOpts),
 
+    #[command(name="lift", about = "Lift binary files to P-code JSON files using a specified lifter")]
+    Lift(LiftOpts),
+
     #[command(name="info", about = "Display information about the application")]
     Info,
+}
+
+#[derive(Debug, clap::Parser, ValueEnum, Clone)]
+#[clap(rename_all = "kebab-case")]
+pub enum LifterType {
+    Ghidra,
+    Llvm,
+    BinaryNinja,
+}
+
+#[derive(Debug, clap::Parser)]
+pub struct LiftOpts {
+    #[clap(short, long, default_value = "pcodes", value_name = "DIRECTORY", help = "Specify the directory for putting the resultant JSON files for the lifted P-code (default: './pcodes' directory)")]
+    dest: PathBuf,
+
+    #[clap(short = 'l', long, value_enum, default_value_t = LifterType::Ghidra, help = "Specify the lifter type")]
+    lifter_type: LifterType,
+
+    #[clap(short = 'H', long, value_name = "HOME", help = "Specify the path to the home directory of the lifter (e.g., GHIDRA_HOME for Ghidra). If not specified, the environment variable (e.g., GHIDRA_HOME) or default paths are searched.")]
+    home: Option<PathBuf>,
+
+    #[clap(short = 'i', long = "intermediate", value_name = "DIRECTORY", help = "Directory to keep intermediate files like Ghidra project directories. If not specified, a temporary directory is used and deleted.")]
+    intermediate_dir: Option<PathBuf>,
+
+    #[clap(long, value_name = "SCRIPT", help = "Path to a custom lifting script. Interpretation depends on the lifter type. For Ghidra, it's the path to a Java script.")]
+    script: Option<PathBuf>,
+
+    #[clap(short = 'S', long, default_value_t = false, help = "Skip if the resultant JSON file already exists")]
+    skip: bool,
+
+    #[clap(index = 1, value_name = "FILES", help = "Path to the binary or intermediate files to lift")]
+    files: Vec<PathBuf>,
+}
+
+impl LiftOpts {
+    pub fn dest(&self) -> &Path {
+        &self.dest
+    }
+
+    pub fn lifter_type(&self) -> &LifterType {
+        &self.lifter_type
+    }
+
+    pub fn home(&self) -> Option<&Path> {
+        self.home.as_deref()
+    }
+
+    pub fn intermediate_dir(&self) -> Option<&Path> {
+        self.intermediate_dir.as_deref()
+    }
+
+    pub fn script(&self) -> Option<&Path> {
+        self.script.as_deref()
+    }
+
+    pub fn is_skip(&self) -> bool {
+        self.skip
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &PathBuf> {
+        self.files.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.files.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.files.is_empty()
+    }
 }
 
 #[derive(Debug, clap::Parser, ValueEnum, Clone)]

--- a/cli/cli.rs
+++ b/cli/cli.rs
@@ -43,22 +43,24 @@ pub enum LogLevel {
 
 #[derive(Debug, clap::Parser)]
 pub enum OinkieCommand {
-    #[command(name="compare", about = "Compare birthmarks and output the similarity score")]
-    Compare(CompareOpts),
-    #[command(name="extract", about = "Extract birthmarks from a lifted binary file (JSON format)")]
-    Extract(ExtractOpts),
-    // #[command(name="execute", about = "Execute a command on the JSON files")]
-    // Execute(ExecuteOpts),
-    #[command(name="run", about = "Extract birthmarks and compare them in one command")]
-    Run(RunOpts),
-    #[command(name="reaggregate", about = "Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score")]
-    Reaggregate(ReaggregateOpts),
+    #[command(name="info", about = "Display information about the application")]
+    Info,
 
     #[command(name="lift", about = "Lift binary files to P-code JSON files using a specified lifter")]
     Lift(LiftOpts),
 
-    #[command(name="info", about = "Display information about the application")]
-    Info,
+    #[command(name="extract", about = "Extract birthmarks from a lifted binary file (JSON format)")]
+    Extract(ExtractOpts),
+
+    #[command(name="compare", about = "Compare birthmarks and output the similarity score")]
+    Compare(CompareOpts),
+    // #[command(name="execute", about = "Execute a command on the JSON files")]
+    // Execute(ExecuteOpts),
+    #[command(name="reaggregate", about = "Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score")]
+    Reaggregate(ReaggregateOpts),
+
+    #[command(name="run", about = "Extract birthmarks and compare them in one command")]
+    Run(RunOpts),
 }
 
 #[derive(Debug, clap::Parser, ValueEnum, Clone)]

--- a/cli/cli.rs
+++ b/cli/cli.rs
@@ -125,10 +125,6 @@ impl LiftOpts {
     pub fn len(&self) -> usize {
         self.files.len()
     }
-
-    pub fn is_empty(&self) -> bool {
-        self.files.is_empty()
-    }
 }
 
 #[derive(Debug, clap::Parser, ValueEnum, Clone)]

--- a/cli/cli.rs
+++ b/cli/cli.rs
@@ -63,14 +63,6 @@ pub enum OinkieCommand {
     Run(RunOpts),
 }
 
-#[derive(Debug, clap::Parser, ValueEnum, Clone)]
-#[clap(rename_all = "kebab-case")]
-pub enum LifterType {
-    Ghidra,
-    Llvm,
-    BinaryNinja,
-}
-
 #[derive(Debug, clap::Parser)]
 pub struct LiftOpts {
     #[clap(short, long, default_value = "pcodes", value_name = "DIRECTORY", help = "Specify the directory for putting the resultant JSON files for the lifted P-code (default: './pcodes' directory)")]
@@ -100,8 +92,8 @@ impl LiftOpts {
         &self.dest
     }
 
-    pub fn lifter_type(&self) -> &LifterType {
-        &self.lifter_type
+    pub fn lifter_type(&self) -> LifterType {
+        self.lifter_type
     }
 
     pub fn home(&self) -> Option<&Path> {

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -11,8 +11,6 @@ use rayon::prelude::*;
 use oinkie::prelude::*;
 use oinkie::ghidra::Op;
 
-const DEFAULT_GHIDRA_SCRIPT: &str = include_str!("../lifter/scripts/HighPCodeLifter.java");
-
 fn load<T>(path: PathBuf) -> Result<T> 
 where 
     T: TryFrom<PathBuf, Error = Error>
@@ -270,103 +268,34 @@ fn perform_lift(opts: cli::LiftOpts) -> Result<Vec<Duration>> {
     std::fs::create_dir_all(dest)
         .map_err(|e| Error::Io(dest.to_path_buf(), e))?;
 
+    let lifter: Box<dyn Lifter + Sync> = match opts.lifter_type() {
+        cli::LifterType::Ghidra => {
+            let home = oinkie::ghidra::lifter::find_ghidra_home(opts.home())?;
+            Box::new(oinkie::ghidra::lifter::GhidraLifter::new(
+                home,
+                opts.script().map(|p| p.to_path_buf()),
+                opts.intermediate_dir().map(|p| p.to_path_buf())
+            ))
+        },
+        cli::LifterType::Llvm => return Err(Error::Parse("LLVM lifter is not yet implemented.".to_string())),
+        cli::LifterType::BinaryNinja => return Err(Error::Parse("Binary Ninja lifter is not yet implemented.".to_string())),
+    };
+
     let start = Instant::now();
     let r = opts.iter().par_bridge().map(|path| {
         let e1 = Instant::now();
-        let r = match opts.lifter_type() {
-            cli::LifterType::Ghidra => lift_ghidra_impl(path, &opts),
-            cli::LifterType::Llvm => Err(Error::Parse("LLVM lifter is not yet implemented.".to_string())),
-            cli::LifterType::BinaryNinja => Err(Error::Parse("Binary Ninja lifter is not yet implemented.".to_string())),
-        };
+        let dest_file = dest.join(format!("{}.json", path.file_name().unwrap().to_str().unwrap()));
+        if dest_file.exists() && opts.is_skip() {
+            log::info!("Lifted JSON for {:?} already exists. Skipping lifting.", path);
+            return Ok(e1.elapsed());
+        }
+        lifter.lift(path, &dest_file)?;
         pb.inc(1);
-        r.map(|_| e1.elapsed())
+        Ok(e1.elapsed())
     }).collect::<Result<Vec<_>>>();
     let duration = start.elapsed();
     println!("Lifting completed in {} nsec ({})", duration.as_nanos(), format_duration(duration));
     r
-}
-
-fn lift_ghidra_impl(path: &Path, opts: &cli::LiftOpts) -> Result<()> {
-    let ghidra_home = find_ghidra_home(opts.home())?;
-    let analyze_headless = ghidra_home.join("support/analyzeHeadless");
-    if !analyze_headless.exists() {
-        return Err(Error::Parse(format!("Ghidra headless analyzer not found at {:?}", analyze_headless)));
-    }
-
-    let dest_file = opts.dest().join(format!("{}.json", path.file_name().unwrap().to_str().unwrap()));
-    if dest_file.exists() && opts.is_skip() {
-        log::info!("Lifted JSON for {:?} already exists. Skipping lifting.", path);
-        return Ok(());
-    }
-
-    let (script_path, _temp_dir) = if let Some(s) = opts.script() {
-        (s.to_path_buf(), None)
-    } else {
-        let temp_dir = tempfile::Builder::new().prefix("oinkie_script").tempdir().map_err(|e| Error::Io(PathBuf::from("temp"), e))?;
-        let script_file = temp_dir.path().join("HighPCodeLifter.java");
-        std::fs::write(&script_file, DEFAULT_GHIDRA_SCRIPT)
-            .map_err(|e| Error::Io(script_file.clone(), e))?;
-        (script_file, Some(temp_dir))
-    };
-
-    let (proj_dir, _temp_proj_dir) = if let Some(i) = opts.intermediate_dir() {
-        (i.to_path_buf(), None)
-    } else {
-        let temp_proj = tempfile::Builder::new().prefix("oinkie_proj").tempdir().map_err(|e| Error::Io(PathBuf::from("temp"), e))?;
-        (temp_proj.path().to_path_buf(), Some(temp_proj))
-    };
-
-    let proj_name = path.file_name().unwrap().to_str().unwrap();
-    
-    let mut command = std::process::Command::new(&analyze_headless);
-    command.arg(&proj_dir)
-           .arg(proj_name)
-           .arg("-import").arg(path)
-           .arg("-scriptPath").arg(script_path.parent().unwrap())
-           .arg("-postScript").arg(script_path.file_name().unwrap());
-
-    log::info!("Executing Ghidra: {:?}", command);
-    let output = command.output().map_err(|e| Error::Io(analyze_headless, e))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        return Err(Error::Parse(format!("Ghidra failed with status {}.\nSTDOUT: {}\nSTDERR: {}", output.status, stdout, stderr)));
-    }
-
-    // Move the generated JSON to the destination
-    let generated_json = std::env::current_dir().unwrap().join(format!("{}.json", proj_name));
-    if generated_json.exists() {
-        std::fs::rename(&generated_json, &dest_file)
-            .map_err(|e| Error::Io(dest_file, e))?;
-    } else {
-        return Err(Error::Parse(format!("Expected Ghidra to generate {:?}, but it was not found.", generated_json)));
-    }
-
-    Ok(())
-}
-
-fn find_ghidra_home(home_opt: Option<&Path>) -> Result<PathBuf> {
-    if let Some(h) = home_opt {
-        return Ok(h.to_path_buf());
-    }
-    if let Ok(h) = std::env::var("GHIDRA_HOME") {
-        return Ok(PathBuf::from(h));
-    }
-
-    let candidates = [
-        "/opt/homebrew/opt/ghidra/libexec",
-        "/usr/local/opt/ghidra/libexec",
-        "/opt/ghidra/libexec",
-    ];
-
-    for c in candidates {
-        let p = PathBuf::from(c);
-        if p.exists() {
-            return Ok(p);
-        }
-    }
-
-    Err(Error::Parse("GHIDRA_HOME not found. Please specify it via --home option or GHIDRA_HOME environment variable.".to_string()))
 }
 
 pub struct CompareResult {
@@ -437,7 +366,7 @@ mod tests {
     #[test]
     fn test_find_ghidra_home_from_opt() {
         let opt = PathBuf::from("/custom/path");
-        let result = find_ghidra_home(Some(&opt)).unwrap();
+        let result = oinkie::ghidra::lifter::find_ghidra_home(Some(&opt)).unwrap();
         assert_eq!(result, opt);
     }
 
@@ -446,7 +375,7 @@ mod tests {
         unsafe {
             std::env::set_var("GHIDRA_HOME", "/env/path");
         }
-        let result = find_ghidra_home(None).unwrap();
+        let result = oinkie::ghidra::lifter::find_ghidra_home(None).unwrap();
         assert_eq!(result, PathBuf::from("/env/path"));
         unsafe {
             std::env::remove_var("GHIDRA_HOME");

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -435,6 +435,42 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_find_ghidra_home_from_opt() {
+        let opt = PathBuf::from("/custom/path");
+        let result = find_ghidra_home(Some(&opt)).unwrap();
+        assert_eq!(result, opt);
+    }
+
+    #[test]
+    fn test_find_ghidra_home_from_env() {
+        unsafe {
+            std::env::set_var("GHIDRA_HOME", "/env/path");
+        }
+        let result = find_ghidra_home(None).unwrap();
+        assert_eq!(result, PathBuf::from("/env/path"));
+        unsafe {
+            std::env::remove_var("GHIDRA_HOME");
+        }
+    }
+
+    #[test]
+    fn test_parse_lift_opts() {
+        let args = vec!["oinkie", "lift", "--home", "/ghidra", "--dest", "out", "--skip", "bin1", "bin2"];
+        let opts = cli::OinkieOpts::try_parse_from(args).unwrap();
+        if let cli::OinkieCommand::Lift(lift_opts) = opts.command {
+            assert_eq!(lift_opts.home(), Some(Path::new("/ghidra")));
+            assert_eq!(lift_opts.dest(), Path::new("out"));
+            assert!(lift_opts.is_skip());
+            let files: Vec<_> = lift_opts.iter().collect();
+            assert_eq!(files.len(), 2);
+            assert_eq!(files[0], &PathBuf::from("bin1"));
+            assert_eq!(files[1], &PathBuf::from("bin2"));
+        } else {
+            panic!("Expected Lift command");
+        }
+    }
+
+    #[test]
     fn test_parse_compare_result() {
         let line = "21,0.9920060729565723,birthmarks/experiment0/bzip2-1.0.4_a83e5e24.json,birthmarks/experiment0/bzip2-1.0.8_981e34d2.json,515602167";
         let cr = CompareResult::parse(line)

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -11,6 +11,8 @@ use rayon::prelude::*;
 use oinkie::prelude::*;
 use oinkie::ghidra::Op;
 
+const DEFAULT_GHIDRA_SCRIPT: &str = include_str!("../lifter/scripts/HighPCodeLifter.java");
+
 fn load<T>(path: PathBuf) -> Result<T> 
 where 
     T: TryFrom<PathBuf, Error = Error>
@@ -255,8 +257,116 @@ fn perform(opts: cli::OinkieOpts) -> Result<Vec<Duration>> {
         Extract(opts) => validate_extract_opts(opts)
             .and_then(perform_extract),
         Reaggregate(opts) => reaggregator::perform(opts),
+        Lift(opts) => perform_lift(opts),
         Info => perform_info(),
     }
+}
+
+fn perform_lift(opts: cli::LiftOpts) -> Result<Vec<Duration>> {
+    let dest = opts.dest();
+    let pb = ProgressBar::new(opts.len() as u64)
+            .with_style(indicatif::ProgressStyle::with_template("[{elapsed_precise}] {bar:40.magenta/blue} {pos:>7}/{len:7} {msg}").unwrap())
+            .with_message("Lifting binaries...");
+    std::fs::create_dir_all(dest)
+        .map_err(|e| Error::Io(dest.to_path_buf(), e))?;
+
+    let start = Instant::now();
+    let r = opts.iter().par_bridge().map(|path| {
+        let e1 = Instant::now();
+        let r = match opts.lifter_type() {
+            cli::LifterType::Ghidra => lift_ghidra_impl(path, &opts),
+            cli::LifterType::Llvm => Err(Error::Parse("LLVM lifter is not yet implemented.".to_string())),
+            cli::LifterType::BinaryNinja => Err(Error::Parse("Binary Ninja lifter is not yet implemented.".to_string())),
+        };
+        pb.inc(1);
+        r.map(|_| e1.elapsed())
+    }).collect::<Result<Vec<_>>>();
+    let duration = start.elapsed();
+    println!("Lifting completed in {} nsec ({})", duration.as_nanos(), format_duration(duration));
+    r
+}
+
+fn lift_ghidra_impl(path: &Path, opts: &cli::LiftOpts) -> Result<()> {
+    let ghidra_home = find_ghidra_home(opts.home())?;
+    let analyze_headless = ghidra_home.join("support/analyzeHeadless");
+    if !analyze_headless.exists() {
+        return Err(Error::Parse(format!("Ghidra headless analyzer not found at {:?}", analyze_headless)));
+    }
+
+    let dest_file = opts.dest().join(format!("{}.json", path.file_name().unwrap().to_str().unwrap()));
+    if dest_file.exists() && opts.is_skip() {
+        log::info!("Lifted JSON for {:?} already exists. Skipping lifting.", path);
+        return Ok(());
+    }
+
+    let (script_path, _temp_dir) = if let Some(s) = opts.script() {
+        (s.to_path_buf(), None)
+    } else {
+        let temp_dir = tempfile::Builder::new().prefix("oinkie_script").tempdir().map_err(|e| Error::Io(PathBuf::from("temp"), e))?;
+        let script_file = temp_dir.path().join("HighPCodeLifter.java");
+        std::fs::write(&script_file, DEFAULT_GHIDRA_SCRIPT)
+            .map_err(|e| Error::Io(script_file.clone(), e))?;
+        (script_file, Some(temp_dir))
+    };
+
+    let (proj_dir, _temp_proj_dir) = if let Some(i) = opts.intermediate_dir() {
+        (i.to_path_buf(), None)
+    } else {
+        let temp_proj = tempfile::Builder::new().prefix("oinkie_proj").tempdir().map_err(|e| Error::Io(PathBuf::from("temp"), e))?;
+        (temp_proj.path().to_path_buf(), Some(temp_proj))
+    };
+
+    let proj_name = path.file_name().unwrap().to_str().unwrap();
+    
+    let mut command = std::process::Command::new(&analyze_headless);
+    command.arg(&proj_dir)
+           .arg(proj_name)
+           .arg("-import").arg(path)
+           .arg("-scriptPath").arg(script_path.parent().unwrap())
+           .arg("-postScript").arg(script_path.file_name().unwrap());
+
+    log::info!("Executing Ghidra: {:?}", command);
+    let output = command.output().map_err(|e| Error::Io(analyze_headless, e))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        return Err(Error::Parse(format!("Ghidra failed with status {}.\nSTDOUT: {}\nSTDERR: {}", output.status, stdout, stderr)));
+    }
+
+    // Move the generated JSON to the destination
+    let generated_json = std::env::current_dir().unwrap().join(format!("{}.json", proj_name));
+    if generated_json.exists() {
+        std::fs::rename(&generated_json, &dest_file)
+            .map_err(|e| Error::Io(dest_file, e))?;
+    } else {
+        return Err(Error::Parse(format!("Expected Ghidra to generate {:?}, but it was not found.", generated_json)));
+    }
+
+    Ok(())
+}
+
+fn find_ghidra_home(home_opt: Option<&Path>) -> Result<PathBuf> {
+    if let Some(h) = home_opt {
+        return Ok(h.to_path_buf());
+    }
+    if let Ok(h) = std::env::var("GHIDRA_HOME") {
+        return Ok(PathBuf::from(h));
+    }
+
+    let candidates = [
+        "/opt/homebrew/opt/ghidra/libexec",
+        "/usr/local/opt/ghidra/libexec",
+        "/opt/ghidra/libexec",
+    ];
+
+    for c in candidates {
+        let p = PathBuf::from(c);
+        if p.exists() {
+            return Ok(p);
+        }
+    }
+
+    Err(Error::Parse("GHIDRA_HOME not found. Please specify it via --home option or GHIDRA_HOME environment variable.".to_string()))
 }
 
 pub struct CompareResult {

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -268,18 +268,11 @@ fn perform_lift(opts: cli::LiftOpts) -> Result<Vec<Duration>> {
     std::fs::create_dir_all(dest)
         .map_err(|e| Error::Io(dest.to_path_buf(), e))?;
 
-    let lifter: Box<dyn Lifter + Sync> = match opts.lifter_type() {
-        cli::LifterType::Ghidra => {
-            let home = oinkie::ghidra::lifter::find_ghidra_home(opts.home())?;
-            Box::new(oinkie::ghidra::lifter::GhidraLifter::new(
-                home,
-                opts.script().map(|p| p.to_path_buf()),
-                opts.intermediate_dir().map(|p| p.to_path_buf())
-            ))
-        },
-        cli::LifterType::Llvm => return Err(Error::Parse("LLVM lifter is not yet implemented.".to_string())),
-        cli::LifterType::BinaryNinja => return Err(Error::Parse("Binary Ninja lifter is not yet implemented.".to_string())),
-    };
+    let lifter: Box<dyn Lifter + Sync> = LifterBuilder::new(opts.lifter_type())
+        .home(opts.home().map(|p| p.to_path_buf()))
+        .script(opts.script().map(|p| p.to_path_buf()))
+        .intermediate_dir(opts.intermediate_dir().map(|p| p.to_path_buf()))
+        .build()?;
 
     let start = Instant::now();
     let r = opts.iter().par_bridge().map(|path| {
@@ -366,7 +359,7 @@ mod tests {
     #[test]
     fn test_find_ghidra_home_from_opt() {
         let opt = PathBuf::from("/custom/path");
-        let result = oinkie::ghidra::lifter::find_ghidra_home(Some(&opt)).unwrap();
+        let result = oinkie::lift::find_ghidra_home(Some(&opt)).unwrap();
         assert_eq!(result, opt);
     }
 
@@ -375,7 +368,7 @@ mod tests {
         unsafe {
             std::env::set_var("GHIDRA_HOME", "/env/path");
         }
-        let result = oinkie::ghidra::lifter::find_ghidra_home(None).unwrap();
+        let result = oinkie::lift::find_ghidra_home(None).unwrap();
         assert_eq!(result, PathBuf::from("/env/path"));
         unsafe {
             std::env::remove_var("GHIDRA_HOME");

--- a/cli/reaggregator.rs
+++ b/cli/reaggregator.rs
@@ -140,7 +140,7 @@ mod tests {
 
     #[test]
     fn test_load_comparison() {
-        let _ = load_comparison_file(1, &Path::new("testdata/comparison_data"))
+        let _ = load_comparison_file(1, Path::new("testdata/comparison_data"))
             .expect("failed to load comparison file");
         
     }

--- a/scripts/fix_csv.py
+++ b/scripts/fix_csv.py
@@ -1,0 +1,64 @@
+import sys
+import csv
+import argparse
+
+def parse_arguments():
+    """Parse command line arguments for the CSV fixer."""
+    parser = argparse.ArgumentParser(
+        description="Fix CSV files while preserving 4-line headers."
+    )
+    parser.add_argument("input_file", help="Path to the input CSV file")
+    parser.add_argument(
+        "--data-cols", 
+        type=int, 
+        help="Number of data columns (auto-calculated from 5th line if omitted)"
+    )
+    return parser.parse_args()
+
+def get_data_col_count(file_path, manual_count):
+    """Determine the data column count from the 5th line (first data row)."""
+    if manual_count is not None:
+        return manual_count
+    with open(file_path, 'r', newline='', encoding='utf-8') as f:
+        # Skip 4 header lines to find the first data row
+        for _ in range(4):
+            f.readline()
+        first_data_line = f.readline().strip()
+        if not first_data_line:
+            return 0
+        return len(first_data_line.split(',')) - 2
+
+def process_row(parts, data_cols):
+    """Split data parts into [ID, FullName, ...Data] with quoting."""
+    if len(parts) <= data_cols + 1:
+        return None
+    row_id = parts[0]
+    data_fields = parts[-data_cols:]
+    name_parts = parts[1:-data_cols]
+    full_name = ",".join(name_parts)
+    return [row_id, full_name] + data_fields
+
+def run_fixer(args, data_cols):
+    """Pass headers through and fix data rows."""
+    try:
+        with open(args.input_file, 'r', newline='', encoding='utf-8') as f:
+            # 1. Output the first 4 header lines exactly as they are
+            for _ in range(4):
+                sys.stdout.write(f.readline())
+            
+            # 2. Process remaining data rows
+            writer = csv.writer(sys.stdout, quoting=csv.QUOTE_MINIMAL)
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                row = process_row(line.split(','), data_cols)
+                if row:
+                    writer.writerow(row)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+
+if __name__ == "__main__":
+    args = parse_arguments()
+    cols = get_data_col_count(args.input_file, args.data_cols)
+    run_fixer(args, cols)

--- a/scripts/results2image.sh
+++ b/scripts/results2image.sh
@@ -2,9 +2,9 @@ if [ -z "$1" ]; then
     echo "Usage: $0 <base>"
     exit 1
 fi
-base=$(cd $1; pwd)
+base="$(cd "$1" && pwd)"
 
-mkdir -p $base/{images,results,tables}
+mkdir -p "$base/images" "$base/results" "$base/tables"
 for i in cosine dice levenshtein lcs jaccard euclidean simpson weighted-jaccard
 do
     echo "Processing $i..."

--- a/src/ghidra.rs
+++ b/src/ghidra.rs
@@ -6,7 +6,7 @@ use crate::ghidra::pcode::PcodeOp;
 use crate::program::Program;
 
 mod pcode;
-pub mod lifter;
+pub(crate) mod lifter;
 
 impl<T> TryFrom<PathBuf> for Program<T> 
 where

--- a/src/ghidra.rs
+++ b/src/ghidra.rs
@@ -181,7 +181,7 @@ mod tests {
         assert_eq!(r.path(), std::path::Path::new("/Users/tamada/researches/2026snpd_tamada/executables/arm64-linux/gcc_O3/bzip2"));
         assert_eq!(r.len(), 85);
 
-        let f1 = r.iter().nth(0).unwrap();
+        let f1 = r.iter().next().unwrap();
         assert_eq!(f1.name(), "_init");
         let op1 = f1.get(0).unwrap();
         assert_eq!(op1.mnemonic(), "SUBPIECE");

--- a/src/ghidra.rs
+++ b/src/ghidra.rs
@@ -6,6 +6,7 @@ use crate::ghidra::pcode::PcodeOp;
 use crate::program::Program;
 
 mod pcode;
+pub mod lifter;
 
 impl<T> TryFrom<PathBuf> for Program<T> 
 where

--- a/src/ghidra/lifter.rs
+++ b/src/ghidra/lifter.rs
@@ -1,0 +1,94 @@
+use std::path::{Path, PathBuf};
+use crate::{Result, Error, Lifter};
+
+pub const DEFAULT_GHIDRA_SCRIPT: &str = include_str!("../../lifter/scripts/HighPCodeLifter.java");
+
+pub struct GhidraLifter {
+    home: PathBuf,
+    script: Option<PathBuf>,
+    intermediate_dir: Option<PathBuf>,
+}
+
+impl GhidraLifter {
+    pub fn new(home: PathBuf, script: Option<PathBuf>, intermediate_dir: Option<PathBuf>) -> Self {
+        Self { home, script, intermediate_dir }
+    }
+}
+
+impl Lifter for GhidraLifter {
+    fn lift(&self, input: &Path, output: &Path) -> Result<()> {
+        let analyze_headless = self.home.join("support/analyzeHeadless");
+        if !analyze_headless.exists() {
+            return Err(Error::Parse(format!("Ghidra headless analyzer not found at {:?}", analyze_headless)));
+        }
+
+        let (script_path, _temp_dir) = if let Some(s) = &self.script {
+            (s.to_path_buf(), None)
+        } else {
+            let temp_dir = tempfile::Builder::new().prefix("oinkie_script").tempdir().map_err(|e| Error::Io(PathBuf::from("temp"), e))?;
+            let script_file = temp_dir.path().join("HighPCodeLifter.java");
+            std::fs::write(&script_file, DEFAULT_GHIDRA_SCRIPT)
+                .map_err(|e| Error::Io(script_file.clone(), e))?;
+            (script_file, Some(temp_dir))
+        };
+
+        let (proj_dir, _temp_proj_dir) = if let Some(i) = &self.intermediate_dir {
+            (i.to_path_buf(), None)
+        } else {
+            let temp_proj = tempfile::Builder::new().prefix("oinkie_proj").tempdir().map_err(|e| Error::Io(PathBuf::from("temp"), e))?;
+            (temp_proj.path().to_path_buf(), Some(temp_proj))
+        };
+
+        let proj_name = input.file_name().ok_or_else(|| Error::Parse(format!("Invalid input path: {:?}", input)))?.to_str().unwrap();
+        
+        let mut command = std::process::Command::new(&analyze_headless);
+        command.arg(&proj_dir)
+               .arg(proj_name)
+               .arg("-import").arg(input)
+               .arg("-scriptPath").arg(script_path.parent().unwrap())
+               .arg("-postScript").arg(script_path.file_name().unwrap());
+
+        log::info!("Executing Ghidra: {:?}", command);
+        let output_res = command.output().map_err(|e| Error::Io(analyze_headless, e))?;
+        if !output_res.status.success() {
+            let stderr = String::from_utf8_lossy(&output_res.stderr);
+            let stdout = String::from_utf8_lossy(&output_res.stdout);
+            return Err(Error::Parse(format!("Ghidra failed with status {}.\nSTDOUT: {}\nSTDERR: {}", output_res.status, stdout, stderr)));
+        }
+
+        // Move the generated JSON to the destination
+        let generated_json = std::env::current_dir().unwrap().join(format!("{}.json", proj_name));
+        if generated_json.exists() {
+            std::fs::rename(&generated_json, output)
+                .map_err(|e| Error::Io(output.to_path_buf(), e))?;
+        } else {
+            return Err(Error::Parse(format!("Expected Ghidra to generate {:?}, but it was not found.", generated_json)));
+        }
+
+        Ok(())
+    }
+}
+
+pub fn find_ghidra_home(home_opt: Option<&Path>) -> Result<PathBuf> {
+    if let Some(h) = home_opt {
+        return Ok(h.to_path_buf());
+    }
+    if let Ok(h) = std::env::var("GHIDRA_HOME") {
+        return Ok(PathBuf::from(h));
+    }
+
+    let candidates = [
+        "/opt/homebrew/opt/ghidra/libexec",
+        "/usr/local/opt/ghidra/libexec",
+        "/opt/ghidra/libexec",
+    ];
+
+    for c in candidates {
+        let p = PathBuf::from(c);
+        if p.exists() {
+            return Ok(p);
+        }
+    }
+
+    Err(Error::Parse("GHIDRA_HOME not found. Please specify it via --home option or GHIDRA_HOME environment variable.".to_string()))
+}

--- a/src/ghidra/lifter.rs
+++ b/src/ghidra/lifter.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
-use crate::{Result, Error, Lifter};
+use crate::{Result, Error};
+use crate::lift::Lifter;
 
 pub const DEFAULT_GHIDRA_SCRIPT: &str = include_str!("../../lifter/scripts/HighPCodeLifter.java");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,3 +102,7 @@ pub trait Iterable {
     type Item;
     fn iter(&self) -> Box<dyn Iterator<Item = &Self::Item> + '_>;
 }
+
+pub trait Lifter {
+    fn lift(&self, input: &std::path::Path, output: &std::path::Path) -> Result<()>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use ndarray::ShapeError;
 
 use crate::prelude::BirthmarkType;
 
+pub mod lift;
 pub mod ghidra;
 pub mod prelude;
 pub mod extractor;
@@ -101,8 +102,4 @@ pub trait Op {
 pub trait Iterable {
     type Item;
     fn iter(&self) -> Box<dyn Iterator<Item = &Self::Item> + '_>;
-}
-
-pub trait Lifter {
-    fn lift(&self, input: &std::path::Path, output: &std::path::Path) -> Result<()>;
 }

--- a/src/lift.rs
+++ b/src/lift.rs
@@ -1,0 +1,68 @@
+use std::path::{Path, PathBuf};
+use serde::{Deserialize, Serialize};
+use clap::ValueEnum;
+use crate::Result;
+
+pub trait Lifter {
+    fn lift(&self, input: &Path, output: &Path) -> Result<()>;
+}
+
+#[derive(Debug, ValueEnum, Clone, Copy, Serialize, Deserialize)]
+#[clap(rename_all = "kebab-case")]
+pub enum LifterType {
+    Ghidra,
+    Llvm,
+    BinaryNinja,
+}
+
+pub struct LifterBuilder {
+    lifter_type: LifterType,
+    home: Option<PathBuf>,
+    script: Option<PathBuf>,
+    intermediate_dir: Option<PathBuf>,
+}
+
+impl LifterBuilder {
+    pub fn new(lifter_type: LifterType) -> Self {
+        Self {
+            lifter_type,
+            home: None,
+            script: None,
+            intermediate_dir: None,
+        }
+    }
+
+    pub fn home(mut self, home: Option<PathBuf>) -> Self {
+        self.home = home;
+        self
+    }
+
+    pub fn script(mut self, script: Option<PathBuf>) -> Self {
+        self.script = script;
+        self
+    }
+
+    pub fn intermediate_dir(mut self, dir: Option<PathBuf>) -> Self {
+        self.intermediate_dir = dir;
+        self
+    }
+
+    pub fn build(self) -> Result<Box<dyn Lifter + Sync>> {
+        match self.lifter_type {
+            LifterType::Ghidra => {
+                let home = find_ghidra_home(self.home.as_deref())?;
+                Ok(Box::new(crate::ghidra::lifter::GhidraLifter::new(
+                    home,
+                    self.script,
+                    self.intermediate_dir,
+                )))
+            }
+            LifterType::Llvm => Err(crate::Error::Parse("LLVM lifter is not yet implemented.".to_string())),
+            LifterType::BinaryNinja => Err(crate::Error::Parse("Binary Ninja lifter is not yet implemented.".to_string())),
+        }
+    }
+}
+
+pub fn find_ghidra_home(home_opt: Option<&Path>) -> Result<PathBuf> {
+    crate::ghidra::lifter::find_ghidra_home(home_opt)
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
-pub use crate::{Error, Result, Op, Iterable};
+pub use crate::{Error, Result, Op, Iterable, Lifter};
 pub use crate::compare::{Aggregator, Algorithm, Comparator, Comparison, PairingStrategy};
 pub use crate::birthmarks::{BirthmarkType, AnalysisType, Data, Kgram, Metadata};
 pub use crate::program::{Program, Function};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,5 @@
-pub use crate::{Error, Result, Op, Iterable, Lifter};
+pub use crate::{Error, Result, Op, Iterable};
+pub use crate::lift::{Lifter, LifterType, LifterBuilder};
 pub use crate::compare::{Aggregator, Algorithm, Comparator, Comparison, PairingStrategy};
 pub use crate::birthmarks::{BirthmarkType, AnalysisType, Data, Kgram, Metadata};
 pub use crate::program::{Program, Function};


### PR DESCRIPTION
This PR implements the `lift` subcommand in the Oinkie CLI.

### Changes:
- Added `lift` subcommand to Oinkie CLI.
- Implemented `Lifter` trait in the library (`src/`) to provide a reusable API for lifting.
- Implemented `GhidraLifter` as the default backend.
- Added support for custom lifting scripts and intermediate directory management.
- Implemented robust Ghidra home path discovery in the library.
- Added `tempfile` dependency for managing temporary projects and scripts.
- Designed for future extensibility with placeholders for LLVM and Binary Ninja backends.

### Verification:
- Manually verified lifting `/bin/ls` using Ghidra.
- Verified `--skip` and `--intermediate` flags.
- Verified help message and CLI options.
- Added unit tests for CLI parsing and home path discovery.