### PR TITLE
fix(security): fix output races in CWD, panics, and cross-device rename in the Ghidra lifter

### DIFF
--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -12,7 +12,9 @@ use crate::program::{Program, Function};
 /// `hash` is a hash value generated from the content of the source file
 /// to ensure uniqueness and avoid overwriting files with the same name.
 pub fn dest_file_name(program_path: &Path) -> Result<String> {
-    let file_name = program_path.file_stem().unwrap().to_string_lossy();
+    let file_name = program_path.file_stem()
+        .ok_or_else(|| Error::Parse(format!("{}: cannot determine the file stem", program_path.display())))?
+        .to_string_lossy();
     let hash = get_hash(program_path);
     let new_filename = format!("{file_name}_{}.json", hash?);
     Ok(new_filename)
@@ -25,20 +27,26 @@ fn get_hash(path: &Path) -> Result<String> {
 
     let mut file = std::fs::File::open(path).map_err(|e| Error::Io(pbuf.clone(), e))?;
     let len = file.metadata().map_err(|e| Error::Io(pbuf.clone(), e))?.len();
-    let mut buffer = Vec::new();
+
+    let mut hasher = sha2::Sha256::new();
+    // the file length participates in the hash so that same-prefix/suffix
+    // files of different sizes never collide
+    hasher.update(len.to_le_bytes());
 
     // Read the first 4KB of the file for hashing
     let mut head = vec![0; 4096.min(len as usize)];
     file.read_exact(&mut head).map_err(|e| Error::Io(pbuf.clone(), e))?;
-    buffer.extend(head);
+    hasher.update(&head);
 
     if len > 4096 {
-        let mut tail = vec![0; 4096.min(len as usize - 4096)];
-        file.seek(std::io::SeekFrom::End(-4096)).map_err(|e| Error::Io(pbuf.clone(), e))?;
+        // Read the last (up to) 4KB of the file, without overlapping the head
+        let tail_len = 4096.min(len as usize - 4096);
+        let mut tail = vec![0; tail_len];
+        file.seek(std::io::SeekFrom::End(-(tail_len as i64))).map_err(|e| Error::Io(pbuf.clone(), e))?;
         file.read_exact(&mut tail).map_err(|e| Error::Io(pbuf.clone(), e))?;
-        buffer.extend(tail);
+        hasher.update(&tail);
     }
-    let hash = sha2::Sha256::digest(&buffer);
+    let hash = hasher.finalize();
     Ok(format!("{:x}", hash)[..8].to_string())
 }
 
@@ -171,6 +179,33 @@ mod tests {
         let name = dest_file_name(&file_path).unwrap();
         assert!(name.starts_with("large_test_"));
         assert!(name.ends_with(".json"));
+    }
+
+    #[test]
+    fn test_get_hash_reflects_tail_difference() {
+        // Two files sharing the same first 4KB but differing after it must
+        // yield different hashes; otherwise their birthmark files collide.
+        let dir = tempdir().unwrap();
+        let path1 = dir.path().join("a.bin");
+        let path2 = dir.path().join("b.bin");
+        let mut data1 = vec![0u8; 5000];
+        let mut data2 = vec![0u8; 5000];
+        data1[4500] = 1;
+        data2[4500] = 2;
+        std::fs::write(&path1, &data1).unwrap();
+        std::fs::write(&path2, &data2).unwrap();
+        assert_ne!(get_hash(&path1).unwrap(), get_hash(&path2).unwrap());
+    }
+
+    #[test]
+    fn test_get_hash_is_deterministic() {
+        let dir = tempdir().unwrap();
+        let path1 = dir.path().join("a.bin");
+        let path2 = dir.path().join("b.bin");
+        let data = vec![7u8; 10240];
+        std::fs::write(&path1, &data).unwrap();
+        std::fs::write(&path2, &data).unwrap();
+        assert_eq!(get_hash(&path1).unwrap(), get_hash(&path2).unwrap());
     }
 
     #[test]

--- a/src/ghidra/lifter.rs
+++ b/src/ghidra/lifter.rs
@@ -24,7 +24,8 @@ impl Lifter for GhidraLifter {
         }
 
         let (script_path, _temp_dir) = if let Some(s) = &self.script {
-            (s.to_path_buf(), None)
+            let s = std::fs::canonicalize(s).map_err(|e| Error::Io(s.clone(), e))?;
+            (s, None)
         } else {
             let temp_dir = tempfile::Builder::new().prefix("oinkie_script").tempdir().map_err(|e| Error::Io(PathBuf::from("temp"), e))?;
             let script_file = temp_dir.path().join("HighPCodeLifter.java");
@@ -32,6 +33,10 @@ impl Lifter for GhidraLifter {
                 .map_err(|e| Error::Io(script_file.clone(), e))?;
             (script_file, Some(temp_dir))
         };
+        let script_dir = script_path.parent()
+            .ok_or_else(|| Error::Parse(format!("Invalid script path: {:?}", script_path)))?;
+        let script_name = script_path.file_name()
+            .ok_or_else(|| Error::Parse(format!("Invalid script path: {:?}", script_path)))?;
 
         let (proj_dir, _temp_proj_dir) = if let Some(i) = &self.intermediate_dir {
             (i.to_path_buf(), None)
@@ -40,14 +45,24 @@ impl Lifter for GhidraLifter {
             (temp_proj.path().to_path_buf(), Some(temp_proj))
         };
 
-        let proj_name = input.file_name().ok_or_else(|| Error::Parse(format!("Invalid input path: {:?}", input)))?.to_str().unwrap();
-        
+        let proj_name = input.file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| Error::Parse(format!("Invalid input path: {:?}", input)))?;
+        // the working directory of the Ghidra process is the project directory,
+        // so relative paths must be resolved beforehand
+        let input = std::fs::canonicalize(input).map_err(|e| Error::Io(input.to_path_buf(), e))?;
+
         let mut command = std::process::Command::new(&analyze_headless);
         command.arg(&proj_dir)
                .arg(proj_name)
-               .arg("-import").arg(input)
-               .arg("-scriptPath").arg(script_path.parent().unwrap())
-               .arg("-postScript").arg(script_path.file_name().unwrap());
+               .arg("-import").arg(&input)
+               .arg("-scriptPath").arg(script_dir)
+               .arg("-postScript").arg(script_name)
+               // The lifter script writes "{program name}.json" into the working
+               // directory of the Ghidra process. Run it inside the project
+               // directory so that concurrent lifts of same-named binaries do not
+               // race on a single path in the user's current directory.
+               .current_dir(&proj_dir);
 
         log::info!("Executing Ghidra: {:?}", command);
         let output_res = command.output().map_err(|e| Error::Io(analyze_headless, e))?;
@@ -58,10 +73,15 @@ impl Lifter for GhidraLifter {
         }
 
         // Move the generated JSON to the destination
-        let generated_json = std::env::current_dir().unwrap().join(format!("{}.json", proj_name));
+        let generated_json = proj_dir.join(format!("{}.json", proj_name));
         if generated_json.exists() {
-            std::fs::rename(&generated_json, output)
-                .map_err(|e| Error::Io(output.to_path_buf(), e))?;
+            // rename fails across file systems (e.g., temp dir on another
+            // volume); fall back to copy + remove in that case
+            if std::fs::rename(&generated_json, output).is_err() {
+                std::fs::copy(&generated_json, output)
+                    .map_err(|e| Error::Io(output.to_path_buf(), e))?;
+                let _ = std::fs::remove_file(&generated_json);
+            }
         } else {
             return Err(Error::Parse(format!("Expected Ghidra to generate {:?}, but it was not found.", generated_json)));
         }


### PR DESCRIPTION
## Problem (security / robustness)

`src/ghidra/lifter.rs` had three issues.

1. **Output file races under parallel execution**: the lifter script writes `{program name}.json` into the working directory of the Ghidra process, and the old code collected it from the CWD of the oinkie process. Since `oinkie lift` runs in parallel via rayon, lifting two binaries with the same file name (e.g., same-named files in different directories) **raced on a single path in the user's current directory**, potentially producing corrupted or swapped P-code JSON. It also polluted the user's CWD with intermediate files.
2. **Panics**: `to_str().unwrap()` panicked on non-UTF-8 file names, and `parent().unwrap()` panicked when a bare file name was given as the script path.
3. **Cross-device rename**: the generated JSON was moved with `fs::rename`, which always fails when the temporary directory and the destination live on different volumes.

## Changes

- Set `current_dir` of the Ghidra process to the (per-invocation) project directory and collect the generated JSON from there
- Canonicalize the input path and the user-provided script path so they survive the working-directory change
- Replace each `unwrap()` with a proper error
- Fall back to copy + remove when `rename` fails

## Verification

- `cargo test --lib`: 22 passed
- E2E against a real Ghidra installation (`cargo test --test cli_test test_lift_command`): passed

**Merge order**: merge after #12 (stacked PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)