### PR TITLE
fix: harden the compare module against panics, NaN results, and swallowed write errors

### DIFF
--- a/cli/cli.rs
+++ b/cli/cli.rs
@@ -16,17 +16,15 @@ pub struct OinkieOpts {
 
 impl OinkieOpts {
     pub fn init(&self) -> Result<()> {
-        unsafe {
-            match self.level {
-                LogLevel::Debug => std::env::set_var("RUST_LOG", "debug"),
-                LogLevel::Info => std::env::set_var("RUST_LOG", "info"),
-                LogLevel::Warn => std::env::set_var("RUST_LOG", "warn"),
-                LogLevel::Error => std::env::set_var("RUST_LOG", "error"),
-                LogLevel::Trace => std::env::set_var("RUST_LOG", "trace"),
-                LogLevel::Off => std::env::set_var("RUST_LOG", "off"),
-            }
-        }
-        env_logger::init();
+        let filter = match self.level {
+            LogLevel::Debug => log::LevelFilter::Debug,
+            LogLevel::Info => log::LevelFilter::Info,
+            LogLevel::Warn => log::LevelFilter::Warn,
+            LogLevel::Error => log::LevelFilter::Error,
+            LogLevel::Trace => log::LevelFilter::Trace,
+            LogLevel::Off => log::LevelFilter::Off,
+        };
+        env_logger::Builder::new().filter_level(filter).init();
         Ok(())
     }
 }

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -36,7 +36,7 @@ pub enum PairingStrategy {
 impl PairingStrategy {
     pub fn compare_count<T>(&self, targets: &[T]) -> usize {
         match self {
-            PairingStrategy::All => targets.len() * (targets.len() - 1) / 2,
+            PairingStrategy::All => targets.len() * targets.len().saturating_sub(1) / 2,
             PairingStrategy::SelfCoverage => targets.len(),
             PairingStrategy::Adjacent => targets.len().saturating_sub(1),
             PairingStrategy::FirstVsOthers | PairingStrategy::LastVsOthers => targets.len().saturating_sub(1),
@@ -92,28 +92,33 @@ impl<'a, S: CsvInfo> Comparison<'a, S> {
     }
 
     pub fn store<P: AsRef<Path>>(&self, dest: P) -> Result<()> {
-        let mut file = std::fs::File::create(dest.as_ref())
-            .map_err(|e| Error::Io(dest.as_ref().to_path_buf(), e))?;
+        let dest = dest.as_ref();
+        let io_err = |e| Error::Io(dest.to_path_buf(), e);
+        let mut file = std::fs::File::create(dest).map_err(io_err)?;
         let mut out = std::io::BufWriter::new(&mut file);
-        let _ = writeln!(out, "result,{},{}", self.duration.as_nanos(), self.similarity());
-        let _ = writeln!(out, "left,{}", self.rows.csv_info());
-        let _ = writeln!(out, "right,{}", self.columns.csv_info());
+        writeln!(out, "result,{},{}", self.duration.as_nanos(), self.similarity()).map_err(io_err)?;
+        writeln!(out, "left,{}", self.rows.csv_info()).map_err(io_err)?;
+        writeln!(out, "right,{}", self.columns.csv_info()).map_err(io_err)?;
         let b1_names = self.columns.names();
         let b2_names = self.rows.names();
-        let _ = write!(out, "matrix,,{}", b1_names.iter()
-            .map(|s| escape_csv_string(s)).join(","));
+        write!(out, "matrix,,{}", b1_names.iter()
+            .map(|s| escape_csv_string(s)).join(",")).map_err(io_err)?;
         for (j, item) in b2_names.iter().enumerate() {
-            let _ = write!(out, "\n{}, {}", j, escape_csv_string(item));
+            write!(out, "\n{}, {}", j, escape_csv_string(item)).map_err(io_err)?;
             for i in 0..b1_names.len() {
                 let value = self.matrix[[i, j]];
-                let _ = write!(out, ",{value}");
+                write!(out, ",{value}").map_err(io_err)?;
             }
         }
-        let _ = writeln!(out);
+        writeln!(out).map_err(io_err)?;
+        out.flush().map_err(io_err)?;
         Ok(())
     }
 
     pub fn similarity(&self) -> f64 {
+        if self.similarities.is_empty() {
+            return 0.0;
+        }
         self.similarities.iter().sum::<f64>() / self.similarities.len() as f64
     }
 
@@ -146,10 +151,11 @@ impl std::str::FromStr for Aggregator {
             log::info!("Using TopN(all) algorithm for aggregation");
             Ok(Aggregator::TopN(Size::All))
         } else if let Some(n) = s.strip_prefix("topn:") {
-            match n.parse::<usize>().map(Size::Num) {
+            match n.parse::<usize>() {
+                Ok(0) => Err(Error::Parse("topn requires N >= 1 (use \"topn:all\" for all elements)".to_string())),
                 Ok(n) => {
-                    log::info!("Using TopN({:?}) algorithm for aggregation", n);
-                    Ok(Aggregator::TopN(n))
+                    log::info!("Using TopN({n}) algorithm for aggregation");
+                    Ok(Aggregator::TopN(Size::Num(n)))
                 },
                 Err(e) => Err(Error::ParseInt(s, e)),
             }
@@ -200,15 +206,16 @@ fn build_matrix<F, T>(p1: impl Iterable<Item = T>, p2: impl Iterable<Item = T>, 
 where 
     F: Fn(&T, &T) -> f64,
 {
-    let mut flat_costs = vec![0.0; size * size];
+    // The matrix holds similarities; the conversion to costs for lapjv
+    // happens later in hungarian_algorithm. Cells beyond the shorter input
+    // stay 0.0 so that the matrix is always square (size x size).
+    let mut similarities = vec![0.0; size * size];
     for (i, item1) in p1.iter().enumerate() {
         for (j, item2) in p2.iter().enumerate() {
-            // lapjv expects a cost matrix where lower values indicate better matches.
-            // so we convert similarity to cost by using (1.0 - similarity).
-            flat_costs[i * size + j] = compare_func(item1, item2);
+            similarities[i * size + j] = compare_func(item1, item2);
         }
     }
-    Array2::from_shape_vec((size, size), flat_costs)
+    Array2::from_shape_vec((size, size), similarities)
         .map_err(Error::ShapeError)
 }
 
@@ -764,6 +771,30 @@ fn longest_common_subsequence<T: PartialEq>(s1: &[T], s2: &[T]) -> f64 {
     // the previous row contains the final results since the last swap
     let lcs_length = prev[m]; 
     2.0 * lcs_length as f64 / (n + m) as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compare_count_does_not_panic_on_empty_targets() {
+        let empty: Vec<i32> = vec![];
+        assert_eq!(PairingStrategy::All.compare_count(&empty), 0);
+        assert_eq!(PairingStrategy::AllAndSelf.compare_count(&empty), 0);
+        assert_eq!(PairingStrategy::SelfCoverage.compare_count(&empty), 0);
+        assert_eq!(PairingStrategy::Adjacent.compare_count(&empty), 0);
+        assert_eq!(PairingStrategy::FirstVsOthers.compare_count(&empty), 0);
+        assert_eq!(PairingStrategy::LastVsOthers.compare_count(&empty), 0);
+    }
+
+    #[test]
+    fn aggregator_rejects_topn_zero() {
+        assert!("topn:0".parse::<Aggregator>().is_err());
+        assert!(matches!("topn:3".parse::<Aggregator>(), Ok(Aggregator::TopN(Size::Num(3)))));
+        assert!(matches!("topn".parse::<Aggregator>(), Ok(Aggregator::TopN(Size::All))));
+        assert!(matches!("hungarian".parse::<Aggregator>(), Ok(Aggregator::Hungarian)));
+    }
 }
 
 #[allow(dead_code)]

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -12,7 +12,9 @@ use crate::program::{Program, Function};
 /// `hash` is a hash value generated from the content of the source file
 /// to ensure uniqueness and avoid overwriting files with the same name.
 pub fn dest_file_name(program_path: &Path) -> Result<String> {
-    let file_name = program_path.file_stem().unwrap().to_string_lossy();
+    let file_name = program_path.file_stem()
+        .ok_or_else(|| Error::Parse(format!("{}: cannot determine the file stem", program_path.display())))?
+        .to_string_lossy();
     let hash = get_hash(program_path);
     let new_filename = format!("{file_name}_{}.json", hash?);
     Ok(new_filename)
@@ -25,20 +27,26 @@ fn get_hash(path: &Path) -> Result<String> {
 
     let mut file = std::fs::File::open(path).map_err(|e| Error::Io(pbuf.clone(), e))?;
     let len = file.metadata().map_err(|e| Error::Io(pbuf.clone(), e))?.len();
-    let mut buffer = Vec::new();
+
+    let mut hasher = sha2::Sha256::new();
+    // the file length participates in the hash so that same-prefix/suffix
+    // files of different sizes never collide
+    hasher.update(len.to_le_bytes());
 
     // Read the first 4KB of the file for hashing
     let mut head = vec![0; 4096.min(len as usize)];
     file.read_exact(&mut head).map_err(|e| Error::Io(pbuf.clone(), e))?;
-    buffer.extend(head);
+    hasher.update(&head);
 
     if len > 4096 {
-        let mut tail = vec![0; 4096.min(len as usize - 4096)];
-        file.seek(std::io::SeekFrom::End(-4096)).map_err(|e| Error::Io(pbuf.clone(), e))?;
+        // Read the last (up to) 4KB of the file, without overlapping the head
+        let tail_len = 4096.min(len as usize - 4096);
+        let mut tail = vec![0; tail_len];
+        file.seek(std::io::SeekFrom::End(-(tail_len as i64))).map_err(|e| Error::Io(pbuf.clone(), e))?;
         file.read_exact(&mut tail).map_err(|e| Error::Io(pbuf.clone(), e))?;
-        buffer.extend(tail);
+        hasher.update(&tail);
     }
-    let hash = sha2::Sha256::digest(&buffer);
+    let hash = hasher.finalize();
     Ok(format!("{:x}", hash)[..8].to_string())
 }
 
@@ -171,6 +179,33 @@ mod tests {
         let name = dest_file_name(&file_path).unwrap();
         assert!(name.starts_with("large_test_"));
         assert!(name.ends_with(".json"));
+    }
+
+    #[test]
+    fn test_get_hash_reflects_tail_difference() {
+        // Two files sharing the same first 4KB but differing after it must
+        // yield different hashes; otherwise their birthmark files collide.
+        let dir = tempdir().unwrap();
+        let path1 = dir.path().join("a.bin");
+        let path2 = dir.path().join("b.bin");
+        let mut data1 = vec![0u8; 5000];
+        let mut data2 = vec![0u8; 5000];
+        data1[4500] = 1;
+        data2[4500] = 2;
+        std::fs::write(&path1, &data1).unwrap();
+        std::fs::write(&path2, &data2).unwrap();
+        assert_ne!(get_hash(&path1).unwrap(), get_hash(&path2).unwrap());
+    }
+
+    #[test]
+    fn test_get_hash_is_deterministic() {
+        let dir = tempdir().unwrap();
+        let path1 = dir.path().join("a.bin");
+        let path2 = dir.path().join("b.bin");
+        let data = vec![7u8; 10240];
+        std::fs::write(&path1, &data).unwrap();
+        std::fs::write(&path2, &data).unwrap();
+        assert_eq!(get_hash(&path1).unwrap(), get_hash(&path2).unwrap());
     }
 
     #[test]

--- a/src/ghidra/lifter.rs
+++ b/src/ghidra/lifter.rs
@@ -24,7 +24,8 @@ impl Lifter for GhidraLifter {
         }
 
         let (script_path, _temp_dir) = if let Some(s) = &self.script {
-            (s.to_path_buf(), None)
+            let s = std::fs::canonicalize(s).map_err(|e| Error::Io(s.clone(), e))?;
+            (s, None)
         } else {
             let temp_dir = tempfile::Builder::new().prefix("oinkie_script").tempdir().map_err(|e| Error::Io(PathBuf::from("temp"), e))?;
             let script_file = temp_dir.path().join("HighPCodeLifter.java");
@@ -32,6 +33,10 @@ impl Lifter for GhidraLifter {
                 .map_err(|e| Error::Io(script_file.clone(), e))?;
             (script_file, Some(temp_dir))
         };
+        let script_dir = script_path.parent()
+            .ok_or_else(|| Error::Parse(format!("Invalid script path: {:?}", script_path)))?;
+        let script_name = script_path.file_name()
+            .ok_or_else(|| Error::Parse(format!("Invalid script path: {:?}", script_path)))?;
 
         let (proj_dir, _temp_proj_dir) = if let Some(i) = &self.intermediate_dir {
             (i.to_path_buf(), None)
@@ -40,14 +45,24 @@ impl Lifter for GhidraLifter {
             (temp_proj.path().to_path_buf(), Some(temp_proj))
         };
 
-        let proj_name = input.file_name().ok_or_else(|| Error::Parse(format!("Invalid input path: {:?}", input)))?.to_str().unwrap();
-        
+        let proj_name = input.file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| Error::Parse(format!("Invalid input path: {:?}", input)))?;
+        // the working directory of the Ghidra process is the project directory,
+        // so relative paths must be resolved beforehand
+        let input = std::fs::canonicalize(input).map_err(|e| Error::Io(input.to_path_buf(), e))?;
+
         let mut command = std::process::Command::new(&analyze_headless);
         command.arg(&proj_dir)
                .arg(proj_name)
-               .arg("-import").arg(input)
-               .arg("-scriptPath").arg(script_path.parent().unwrap())
-               .arg("-postScript").arg(script_path.file_name().unwrap());
+               .arg("-import").arg(&input)
+               .arg("-scriptPath").arg(script_dir)
+               .arg("-postScript").arg(script_name)
+               // The lifter script writes "{program name}.json" into the working
+               // directory of the Ghidra process. Run it inside the project
+               // directory so that concurrent lifts of same-named binaries do not
+               // race on a single path in the user's current directory.
+               .current_dir(&proj_dir);
 
         log::info!("Executing Ghidra: {:?}", command);
         let output_res = command.output().map_err(|e| Error::Io(analyze_headless, e))?;
@@ -58,10 +73,15 @@ impl Lifter for GhidraLifter {
         }
 
         // Move the generated JSON to the destination
-        let generated_json = std::env::current_dir().unwrap().join(format!("{}.json", proj_name));
+        let generated_json = proj_dir.join(format!("{}.json", proj_name));
         if generated_json.exists() {
-            std::fs::rename(&generated_json, output)
-                .map_err(|e| Error::Io(output.to_path_buf(), e))?;
+            // rename fails across file systems (e.g., temp dir on another
+            // volume); fall back to copy + remove in that case
+            if std::fs::rename(&generated_json, output).is_err() {
+                std::fs::copy(&generated_json, output)
+                    .map_err(|e| Error::Io(output.to_path_buf(), e))?;
+                let _ = std::fs::remove_file(&generated_json);
+            }
         } else {
             return Err(Error::Parse(format!("Expected Ghidra to generate {:?}, but it was not found.", generated_json)));
         }


### PR DESCRIPTION
## Problem (code smell / robustness)

`src/compare.rs` had four issues.

1. **Underflow panic**: `compare_count` for `PairingStrategy::All` computed `len() - 1` which underflows on an empty list (panic in debug builds). The other strategies already used `saturating_sub`, so this was inconsistent.
2. **NaN propagation**: `Comparison::similarity()` divided by zero and returned NaN when the aggregated similarity list was empty, writing NaN into the result CSVs. Reachable in practice by specifying `topn:0`.
3. **Missing input validation**: `Aggregator::from_str` accepted `topn:0` (the path to issue 2). It is now rejected with an error.
4. **Swallowed write errors**: `Comparison::store` ignored every write with `let _ =`, so a full disk produced **truncated CSVs reported as success**. Errors are now propagated and the BufWriter is flushed explicitly.

Also fixed the misleading comment in `build_matrix` claiming it converts similarities to costs — it stores similarities as-is; the cost conversion happens in `hungarian_algorithm`.

## Verification

All `cargo test` targets pass. Added regression tests for empty target lists and `topn:0`.

**Merge order**: merge after #14 (stacked PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)