### PR TITLE
fix(security): escape CSV fields consistently and parse result files with the csv crate

### DIFF
--- a/cli/cli.rs
+++ b/cli/cli.rs
@@ -16,17 +16,15 @@ pub struct OinkieOpts {
 
 impl OinkieOpts {
     pub fn init(&self) -> Result<()> {
-        unsafe {
-            match self.level {
-                LogLevel::Debug => std::env::set_var("RUST_LOG", "debug"),
-                LogLevel::Info => std::env::set_var("RUST_LOG", "info"),
-                LogLevel::Warn => std::env::set_var("RUST_LOG", "warn"),
-                LogLevel::Error => std::env::set_var("RUST_LOG", "error"),
-                LogLevel::Trace => std::env::set_var("RUST_LOG", "trace"),
-                LogLevel::Off => std::env::set_var("RUST_LOG", "off"),
-            }
-        }
-        env_logger::init();
+        let filter = match self.level {
+            LogLevel::Debug => log::LevelFilter::Debug,
+            LogLevel::Info => log::LevelFilter::Info,
+            LogLevel::Warn => log::LevelFilter::Warn,
+            LogLevel::Error => log::LevelFilter::Error,
+            LogLevel::Trace => log::LevelFilter::Trace,
+            LogLevel::Off => log::LevelFilter::Off,
+        };
+        env_logger::Builder::new().filter_level(filter).init();
         Ok(())
     }
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -67,35 +67,37 @@ fn perform_run(opts: cli::RunOpts) -> Result<Vec<Duration>> {
 /// This function skips actual comparison and shorten the comparison time if the result file already exists.
 /// The CSV file is expected to have a line starting with "result," followed by the duration in nanoseconds and the similarity value, separated by commas.
 fn read_result_file(dest_path: &Path, index: usize, _path1: &Path, _path2: &Path) -> Result<CompareResult> {
-    let content = std::fs::read_to_string(dest_path)
+    let file = std::fs::File::open(dest_path)
         .map_err(|e| Error::Io(dest_path.to_path_buf(), e))?;
-    let lines = content.lines();
-    
+    let mut reader = csv::ReaderBuilder::new()
+        .flexible(true)
+        .has_headers(false)
+        .from_reader(file);
+
     let mut original_path1 = PathBuf::new();
     let mut original_path2 = PathBuf::new();
     let mut similarity = 0.0;
     let mut duration_nanos = 0;
 
-    for line in lines {
-        if line.starts_with("result,") {
-            let parts: Vec<&str> = line.split(',').collect();
-            if parts.len() < 3 {
-                return Err(Error::Parse(format!("Invalid result line format in {}", dest_path.display())));
-            }
-            duration_nanos = parts[1].parse()
-                .map_err(|e| Error::ParseInt(parts[1].to_string(), e))?;
-            similarity = parts[2].parse()
-                .map_err(|e| Error::Parse(format!("Failed to parse similarity value in {}: {}", dest_path.display(), e)))?;
-        } else if line.starts_with("left,") {
-            let parts: Vec<&str> = line.split(',').collect();
-            if parts.len() >= 4 {
-                original_path1 = PathBuf::from(parts[3]);
-            }
-        } else if line.starts_with("right,") {
-            let parts: Vec<&str> = line.split(',').collect();
-            if parts.len() >= 4 {
-                original_path2 = PathBuf::from(parts[3]);
-            }
+    for result in reader.records() {
+        let record = result.map_err(Error::Csv)?;
+        match record.get(0) {
+            Some("result") => {
+                if record.len() < 3 {
+                    return Err(Error::Parse(format!("Invalid result line format in {}", dest_path.display())));
+                }
+                duration_nanos = record[1].parse()
+                    .map_err(|e| Error::ParseInt(record[1].to_string(), e))?;
+                similarity = record[2].parse()
+                    .map_err(|e| Error::Parse(format!("Failed to parse similarity value in {}: {}", dest_path.display(), e)))?;
+            },
+            Some("left") => if let Some(s) = record.get(3) {
+                original_path1 = PathBuf::from(s);
+            },
+            Some("right") => if let Some(s) = record.get(3) {
+                original_path2 = PathBuf::from(s);
+            },
+            _ => {},
         }
     }
 
@@ -314,22 +316,32 @@ impl CompareResult {
     }
 
     pub fn to_csv(&self) -> String {
-        format!("{},{},{},{},{}", self.index, self.similarity, self.path1.display(), self.path2.display(), self.duration.as_nanos())
+        format!("{},{},{},{},{}", self.index, self.similarity,
+            escape_csv_string(&self.path1.display().to_string()),
+            escape_csv_string(&self.path2.display().to_string()),
+            self.duration.as_nanos())
     }
 
     pub fn parse(line: &str) -> Result<Self> {
-        let parts: Vec<&str> = line.split(',').collect();
-        if parts.len() < 5 {
+        let mut reader = csv::ReaderBuilder::new()
+            .flexible(true)
+            .has_headers(false)
+            .from_reader(line.as_bytes());
+        let record = match reader.records().next() {
+            Some(r) => r.map_err(|e| Error::Parse(format!("Invalid compare result line format: {e}")))?,
+            None => return Err(Error::Parse(format!("Invalid compare result line format: {}", line))),
+        };
+        if record.len() < 5 {
             return Err(Error::Parse(format!("Invalid compare result line format: {}", line)));
         }
-        let index: usize = parts[0].parse()
-            .map_err(|e| Error::ParseInt(parts[0].to_string(), e))?;
-        let similarity: f64 = parts[1].parse()
+        let index: usize = record[0].parse()
+            .map_err(|e| Error::ParseInt(record[0].to_string(), e))?;
+        let similarity: f64 = record[1].parse()
             .map_err(|e| Error::Parse(format!("Failed to parse similarity value: {}", e)))?;
-        let path1 = PathBuf::from(parts[2]);
-        let path2 = PathBuf::from(parts[3]);
-        let duration_nanos: u64 = parts[4].parse()
-            .map_err(|e| Error::ParseInt(parts[4].to_string(), e))?;
+        let path1 = PathBuf::from(&record[2]);
+        let path2 = PathBuf::from(&record[3]);
+        let duration_nanos: u64 = record[4].parse()
+            .map_err(|e| Error::ParseInt(record[4].to_string(), e))?;
         Ok(Self::new(index, similarity, path1, path2, Duration::from_nanos(duration_nanos)))
     }
 }
@@ -399,6 +411,21 @@ mod tests {
         } else {
             panic!("Expected Lift command");
         }
+    }
+
+    #[test]
+    fn test_compare_result_roundtrip_with_comma_in_path() {
+        let original = CompareResult::new(3, 0.5,
+            PathBuf::from("dir,with,commas/a.json"),
+            PathBuf::from("dir/\"quoted\"/b.json"),
+            Duration::from_nanos(123));
+        let line = original.to_csv();
+        let parsed = CompareResult::parse(&line)
+            .expect("Failed to parse escaped compare result");
+        assert_eq!(parsed.index, original.index);
+        assert_eq!(parsed.path1, original.path1);
+        assert_eq!(parsed.path2, original.path2);
+        assert_eq!(parsed.duration, original.duration);
     }
 
     #[test]

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -86,7 +86,10 @@ pub struct Metadata {
 
 impl Metadata {
     pub fn csv_info(&self) -> String {
-        format!("birthmark,{},{},{},{},{}", self.file_name, self.path.display(), self.birthmark_type, self.extracted_at.to_rfc3339(), self.duration.as_nanos())
+        format!("birthmark,{},{},{},{},{}",
+            crate::compare::escape_csv_string(&self.file_name),
+            crate::compare::escape_csv_string(&self.path.display().to_string()),
+            self.birthmark_type, self.extracted_at.to_rfc3339(), self.duration.as_nanos())
     }
 
     pub fn parse(line: &str) -> Result<Self> {
@@ -148,7 +151,7 @@ pub struct Birthmark {
 impl CsvInfo for Birthmark {
     fn csv_info(&self) -> String {
         let json_path = self.json_path.as_ref().map(|p| p.display().to_string()).unwrap_or_default();
-        format!("{},{}", self.metadata.csv_info(), json_path)
+        format!("{},{}", self.metadata.csv_info(), crate::compare::escape_csv_string(&json_path))
     }
 
     fn names(&self) -> Vec<String> {
@@ -383,6 +386,22 @@ fn parse_k_value(k: &str) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    pub fn test_metadata_csv_info_roundtrip_with_comma_in_path() {
+        let metadata = Metadata {
+            file_name: "app, v1".to_string(),
+            path: PathBuf::from("dir,with,commas/app"),
+            extracted_at: chrono::Utc::now(),
+            duration: Duration::from_nanos(42),
+            birthmark_type: BirthmarkType::OpSeq,
+        };
+        let parsed = Metadata::parse(&metadata.csv_info())
+            .expect("failed to parse escaped metadata");
+        assert_eq!(parsed.file_name, metadata.file_name);
+        assert_eq!(parsed.path, metadata.path);
+        assert_eq!(parsed.birthmark_type, metadata.birthmark_type);
+    }
 
     #[test]
     pub fn test_parse_metadata() {

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -78,7 +78,9 @@ pub struct Comparison<'a, S> {
     similarities: Vec<f64>,
 }
 
-fn escape_csv_string(s: &str) -> String {
+/// Quotes a value for embedding into a CSV field when it contains
+/// characters that would otherwise break the record structure.
+pub fn escape_csv_string(s: &str) -> String {
     if s.contains(',') || s.contains('"') || s.contains('\n') {
         format!("\"{}\"", s.replace('"', "\"\""))
     } else {

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -36,7 +36,7 @@ pub enum PairingStrategy {
 impl PairingStrategy {
     pub fn compare_count<T>(&self, targets: &[T]) -> usize {
         match self {
-            PairingStrategy::All => targets.len() * (targets.len() - 1) / 2,
+            PairingStrategy::All => targets.len() * targets.len().saturating_sub(1) / 2,
             PairingStrategy::SelfCoverage => targets.len(),
             PairingStrategy::Adjacent => targets.len().saturating_sub(1),
             PairingStrategy::FirstVsOthers | PairingStrategy::LastVsOthers => targets.len().saturating_sub(1),
@@ -92,28 +92,33 @@ impl<'a, S: CsvInfo> Comparison<'a, S> {
     }
 
     pub fn store<P: AsRef<Path>>(&self, dest: P) -> Result<()> {
-        let mut file = std::fs::File::create(dest.as_ref())
-            .map_err(|e| Error::Io(dest.as_ref().to_path_buf(), e))?;
+        let dest = dest.as_ref();
+        let io_err = |e| Error::Io(dest.to_path_buf(), e);
+        let mut file = std::fs::File::create(dest).map_err(io_err)?;
         let mut out = std::io::BufWriter::new(&mut file);
-        let _ = writeln!(out, "result,{},{}", self.duration.as_nanos(), self.similarity());
-        let _ = writeln!(out, "left,{}", self.rows.csv_info());
-        let _ = writeln!(out, "right,{}", self.columns.csv_info());
+        writeln!(out, "result,{},{}", self.duration.as_nanos(), self.similarity()).map_err(io_err)?;
+        writeln!(out, "left,{}", self.rows.csv_info()).map_err(io_err)?;
+        writeln!(out, "right,{}", self.columns.csv_info()).map_err(io_err)?;
         let b1_names = self.columns.names();
         let b2_names = self.rows.names();
-        let _ = write!(out, "matrix,,{}", b1_names.iter()
-            .map(|s| escape_csv_string(s)).join(","));
+        write!(out, "matrix,,{}", b1_names.iter()
+            .map(|s| escape_csv_string(s)).join(",")).map_err(io_err)?;
         for (j, item) in b2_names.iter().enumerate() {
-            let _ = write!(out, "\n{}, {}", j, escape_csv_string(item));
+            write!(out, "\n{}, {}", j, escape_csv_string(item)).map_err(io_err)?;
             for i in 0..b1_names.len() {
                 let value = self.matrix[[i, j]];
-                let _ = write!(out, ",{value}");
+                write!(out, ",{value}").map_err(io_err)?;
             }
         }
-        let _ = writeln!(out);
+        writeln!(out).map_err(io_err)?;
+        out.flush().map_err(io_err)?;
         Ok(())
     }
 
     pub fn similarity(&self) -> f64 {
+        if self.similarities.is_empty() {
+            return 0.0;
+        }
         self.similarities.iter().sum::<f64>() / self.similarities.len() as f64
     }
 
@@ -146,10 +151,11 @@ impl std::str::FromStr for Aggregator {
             log::info!("Using TopN(all) algorithm for aggregation");
             Ok(Aggregator::TopN(Size::All))
         } else if let Some(n) = s.strip_prefix("topn:") {
-            match n.parse::<usize>().map(Size::Num) {
+            match n.parse::<usize>() {
+                Ok(0) => Err(Error::Parse("topn requires N >= 1 (use \"topn:all\" for all elements)".to_string())),
                 Ok(n) => {
-                    log::info!("Using TopN({:?}) algorithm for aggregation", n);
-                    Ok(Aggregator::TopN(n))
+                    log::info!("Using TopN({n}) algorithm for aggregation");
+                    Ok(Aggregator::TopN(Size::Num(n)))
                 },
                 Err(e) => Err(Error::ParseInt(s, e)),
             }
@@ -200,15 +206,16 @@ fn build_matrix<F, T>(p1: impl Iterable<Item = T>, p2: impl Iterable<Item = T>, 
 where 
     F: Fn(&T, &T) -> f64,
 {
-    let mut flat_costs = vec![0.0; size * size];
+    // The matrix holds similarities; the conversion to costs for lapjv
+    // happens later in hungarian_algorithm. Cells beyond the shorter input
+    // stay 0.0 so that the matrix is always square (size x size).
+    let mut similarities = vec![0.0; size * size];
     for (i, item1) in p1.iter().enumerate() {
         for (j, item2) in p2.iter().enumerate() {
-            // lapjv expects a cost matrix where lower values indicate better matches.
-            // so we convert similarity to cost by using (1.0 - similarity).
-            flat_costs[i * size + j] = compare_func(item1, item2);
+            similarities[i * size + j] = compare_func(item1, item2);
         }
     }
-    Array2::from_shape_vec((size, size), flat_costs)
+    Array2::from_shape_vec((size, size), similarities)
         .map_err(Error::ShapeError)
 }
 
@@ -764,6 +771,30 @@ fn longest_common_subsequence<T: PartialEq>(s1: &[T], s2: &[T]) -> f64 {
     // the previous row contains the final results since the last swap
     let lcs_length = prev[m]; 
     2.0 * lcs_length as f64 / (n + m) as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compare_count_does_not_panic_on_empty_targets() {
+        let empty: Vec<i32> = vec![];
+        assert_eq!(PairingStrategy::All.compare_count(&empty), 0);
+        assert_eq!(PairingStrategy::AllAndSelf.compare_count(&empty), 0);
+        assert_eq!(PairingStrategy::SelfCoverage.compare_count(&empty), 0);
+        assert_eq!(PairingStrategy::Adjacent.compare_count(&empty), 0);
+        assert_eq!(PairingStrategy::FirstVsOthers.compare_count(&empty), 0);
+        assert_eq!(PairingStrategy::LastVsOthers.compare_count(&empty), 0);
+    }
+
+    #[test]
+    fn aggregator_rejects_topn_zero() {
+        assert!("topn:0".parse::<Aggregator>().is_err());
+        assert!(matches!("topn:3".parse::<Aggregator>(), Ok(Aggregator::TopN(Size::Num(3)))));
+        assert!(matches!("topn".parse::<Aggregator>(), Ok(Aggregator::TopN(Size::All))));
+        assert!(matches!("hungarian".parse::<Aggregator>(), Ok(Aggregator::Hungarian)));
+    }
 }
 
 #[allow(dead_code)]

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -12,7 +12,9 @@ use crate::program::{Program, Function};
 /// `hash` is a hash value generated from the content of the source file
 /// to ensure uniqueness and avoid overwriting files with the same name.
 pub fn dest_file_name(program_path: &Path) -> Result<String> {
-    let file_name = program_path.file_stem().unwrap().to_string_lossy();
+    let file_name = program_path.file_stem()
+        .ok_or_else(|| Error::Parse(format!("{}: cannot determine the file stem", program_path.display())))?
+        .to_string_lossy();
     let hash = get_hash(program_path);
     let new_filename = format!("{file_name}_{}.json", hash?);
     Ok(new_filename)
@@ -25,20 +27,26 @@ fn get_hash(path: &Path) -> Result<String> {
 
     let mut file = std::fs::File::open(path).map_err(|e| Error::Io(pbuf.clone(), e))?;
     let len = file.metadata().map_err(|e| Error::Io(pbuf.clone(), e))?.len();
-    let mut buffer = Vec::new();
+
+    let mut hasher = sha2::Sha256::new();
+    // the file length participates in the hash so that same-prefix/suffix
+    // files of different sizes never collide
+    hasher.update(len.to_le_bytes());
 
     // Read the first 4KB of the file for hashing
     let mut head = vec![0; 4096.min(len as usize)];
     file.read_exact(&mut head).map_err(|e| Error::Io(pbuf.clone(), e))?;
-    buffer.extend(head);
+    hasher.update(&head);
 
     if len > 4096 {
-        let mut tail = vec![0; 4096.min(len as usize - 4096)];
-        file.seek(std::io::SeekFrom::End(-4096)).map_err(|e| Error::Io(pbuf.clone(), e))?;
+        // Read the last (up to) 4KB of the file, without overlapping the head
+        let tail_len = 4096.min(len as usize - 4096);
+        let mut tail = vec![0; tail_len];
+        file.seek(std::io::SeekFrom::End(-(tail_len as i64))).map_err(|e| Error::Io(pbuf.clone(), e))?;
         file.read_exact(&mut tail).map_err(|e| Error::Io(pbuf.clone(), e))?;
-        buffer.extend(tail);
+        hasher.update(&tail);
     }
-    let hash = sha2::Sha256::digest(&buffer);
+    let hash = hasher.finalize();
     Ok(format!("{:x}", hash)[..8].to_string())
 }
 
@@ -171,6 +179,33 @@ mod tests {
         let name = dest_file_name(&file_path).unwrap();
         assert!(name.starts_with("large_test_"));
         assert!(name.ends_with(".json"));
+    }
+
+    #[test]
+    fn test_get_hash_reflects_tail_difference() {
+        // Two files sharing the same first 4KB but differing after it must
+        // yield different hashes; otherwise their birthmark files collide.
+        let dir = tempdir().unwrap();
+        let path1 = dir.path().join("a.bin");
+        let path2 = dir.path().join("b.bin");
+        let mut data1 = vec![0u8; 5000];
+        let mut data2 = vec![0u8; 5000];
+        data1[4500] = 1;
+        data2[4500] = 2;
+        std::fs::write(&path1, &data1).unwrap();
+        std::fs::write(&path2, &data2).unwrap();
+        assert_ne!(get_hash(&path1).unwrap(), get_hash(&path2).unwrap());
+    }
+
+    #[test]
+    fn test_get_hash_is_deterministic() {
+        let dir = tempdir().unwrap();
+        let path1 = dir.path().join("a.bin");
+        let path2 = dir.path().join("b.bin");
+        let data = vec![7u8; 10240];
+        std::fs::write(&path1, &data).unwrap();
+        std::fs::write(&path2, &data).unwrap();
+        assert_eq!(get_hash(&path1).unwrap(), get_hash(&path2).unwrap());
     }
 
     #[test]

--- a/src/ghidra/lifter.rs
+++ b/src/ghidra/lifter.rs
@@ -24,7 +24,8 @@ impl Lifter for GhidraLifter {
         }
 
         let (script_path, _temp_dir) = if let Some(s) = &self.script {
-            (s.to_path_buf(), None)
+            let s = std::fs::canonicalize(s).map_err(|e| Error::Io(s.clone(), e))?;
+            (s, None)
         } else {
             let temp_dir = tempfile::Builder::new().prefix("oinkie_script").tempdir().map_err(|e| Error::Io(PathBuf::from("temp"), e))?;
             let script_file = temp_dir.path().join("HighPCodeLifter.java");
@@ -32,6 +33,10 @@ impl Lifter for GhidraLifter {
                 .map_err(|e| Error::Io(script_file.clone(), e))?;
             (script_file, Some(temp_dir))
         };
+        let script_dir = script_path.parent()
+            .ok_or_else(|| Error::Parse(format!("Invalid script path: {:?}", script_path)))?;
+        let script_name = script_path.file_name()
+            .ok_or_else(|| Error::Parse(format!("Invalid script path: {:?}", script_path)))?;
 
         let (proj_dir, _temp_proj_dir) = if let Some(i) = &self.intermediate_dir {
             (i.to_path_buf(), None)
@@ -40,14 +45,24 @@ impl Lifter for GhidraLifter {
             (temp_proj.path().to_path_buf(), Some(temp_proj))
         };
 
-        let proj_name = input.file_name().ok_or_else(|| Error::Parse(format!("Invalid input path: {:?}", input)))?.to_str().unwrap();
-        
+        let proj_name = input.file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| Error::Parse(format!("Invalid input path: {:?}", input)))?;
+        // the working directory of the Ghidra process is the project directory,
+        // so relative paths must be resolved beforehand
+        let input = std::fs::canonicalize(input).map_err(|e| Error::Io(input.to_path_buf(), e))?;
+
         let mut command = std::process::Command::new(&analyze_headless);
         command.arg(&proj_dir)
                .arg(proj_name)
-               .arg("-import").arg(input)
-               .arg("-scriptPath").arg(script_path.parent().unwrap())
-               .arg("-postScript").arg(script_path.file_name().unwrap());
+               .arg("-import").arg(&input)
+               .arg("-scriptPath").arg(script_dir)
+               .arg("-postScript").arg(script_name)
+               // The lifter script writes "{program name}.json" into the working
+               // directory of the Ghidra process. Run it inside the project
+               // directory so that concurrent lifts of same-named binaries do not
+               // race on a single path in the user's current directory.
+               .current_dir(&proj_dir);
 
         log::info!("Executing Ghidra: {:?}", command);
         let output_res = command.output().map_err(|e| Error::Io(analyze_headless, e))?;
@@ -58,10 +73,15 @@ impl Lifter for GhidraLifter {
         }
 
         // Move the generated JSON to the destination
-        let generated_json = std::env::current_dir().unwrap().join(format!("{}.json", proj_name));
+        let generated_json = proj_dir.join(format!("{}.json", proj_name));
         if generated_json.exists() {
-            std::fs::rename(&generated_json, output)
-                .map_err(|e| Error::Io(output.to_path_buf(), e))?;
+            // rename fails across file systems (e.g., temp dir on another
+            // volume); fall back to copy + remove in that case
+            if std::fs::rename(&generated_json, output).is_err() {
+                std::fs::copy(&generated_json, output)
+                    .map_err(|e| Error::Io(output.to_path_buf(), e))?;
+                let _ = std::fs::remove_file(&generated_json);
+            }
         } else {
             return Err(Error::Parse(format!("Expected Ghidra to generate {:?}, but it was not found.", generated_json)));
         }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,6 @@
 pub use crate::{Error, Result, Op, Iterable};
 pub use crate::lift::{Lifter, LifterType, LifterBuilder};
-pub use crate::compare::{Aggregator, Algorithm, Comparator, Comparison, PairingStrategy};
+pub use crate::compare::{Aggregator, Algorithm, Comparator, Comparison, PairingStrategy, escape_csv_string};
 pub use crate::birthmarks::{BirthmarkType, AnalysisType, Data, Kgram, Metadata};
 pub use crate::program::{Program, Function};
 pub use crate::birthmarks::{Birthmark, Elements};

--- a/src/program.rs
+++ b/src/program.rs
@@ -19,7 +19,11 @@ pub struct Program<T> {
 impl<T> crate::prelude::CsvInfo for Program<T> {
     fn csv_info(&self) -> String {
         let json_path = self.json_path.as_ref().map(|p| p.display().to_string()).unwrap_or_default();
-        format!("program,{},{},{},{},{}", self.name, self.path.display(), self.symbols.len(), self.functions.len(), json_path)
+        format!("program,{},{},{},{},{}",
+            crate::compare::escape_csv_string(&self.name),
+            crate::compare::escape_csv_string(&self.path.display().to_string()),
+            self.symbols.len(), self.functions.len(),
+            crate::compare::escape_csv_string(&json_path))
     }
     
     fn names(&self) -> Vec<String> {


### PR DESCRIPTION
## Problem (security / data corruption)

`escape_csv_string` was applied only to matrix row/column names, while the following wrote paths and file names into CSVs **unescaped**:

- `Metadata::csv_info` / `Birthmark::csv_info` (src/birthmarks.rs)
- `Program::csv_info` (src/program.rs)
- `CompareResult::to_csv` (cli/main.rs)

A path containing a comma, quote, or newline (user-controlled input) breaks the record structure of the result CSVs. Worse, the readers — `CompareResult::parse` and `read_result_file` — used a naive `split(',')`, so they **silently read back wrong paths and similarity values from the corrupted lines**, poisoning `--skip` reruns and `reaggregate` results. This is also a breeding ground for CSV injection (field-structure takeover).

## Changes

- Escape every user-controlled field (names, paths) in the CSV writers
- Parse `results.csv` lines and per-pair CSV headers with the csv crate, matching the quoting produced by the writers
- Export `escape_csv_string` through the prelude so the CLI crate shares the same escaping
- Add write→parse roundtrip regression tests with commas and quotes in paths

## Verification

All `cargo test` targets pass (including E2E).

**Merge order**: merge after #15 (stacked PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)