### PR TITLE
test: raise coverage of birthmarks.rs and compare.rs to ~99%

### DIFF
--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -411,4 +411,208 @@ mod tests {
             .with_timezone(&chrono::Utc));
         assert_eq!(metadata.duration, Duration::from_nanos(4462500));
     }
+
+    #[test]
+    fn test_parse_metadata_rejects_wrong_field_count() {
+        let err = Metadata::parse("birthmark,name,path").unwrap_err();
+        assert!(matches!(err, Error::Parse(msg) if msg.contains("expected 6 items")));
+    }
+
+    #[test]
+    fn test_parse_metadata_rejects_empty_line() {
+        assert!(Metadata::parse("").is_err());
+    }
+
+    #[test]
+    fn test_parse_metadata_rejects_bad_datetime_and_duration() {
+        assert!(Metadata::parse("birthmark,n,p,op-seq,not-a-date,1").is_err());
+        assert!(Metadata::parse("birthmark,n,p,op-seq,2026-04-17T04:57:55+00:00,x").is_err());
+    }
+
+    #[test]
+    fn test_birthmark_type_try_from_str() {
+        let cases = [
+            ("fc-seq", BirthmarkType::FcSeq),
+            ("fc-set", BirthmarkType::FcSet),
+            ("fc-freq", BirthmarkType::FcFreq),
+            ("op-freq", BirthmarkType::OpFreq),
+            ("op-seq", BirthmarkType::OpSeq),
+            ("op-set", BirthmarkType::OpSet),
+            ("op-3gram-seq", BirthmarkType::OpKgramSeq(3)),
+            ("op-4gram-set", BirthmarkType::OpKgramSet(4)),
+            ("op-5gram-freq", BirthmarkType::OpKgramFreq(5)),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(BirthmarkType::try_from(input).unwrap(), expected, "input: {input}");
+            // parsing must be case insensitive
+            assert_eq!(BirthmarkType::try_from(input.to_uppercase().as_str()).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn test_birthmark_type_try_from_str_rejects_unknown() {
+        for input in ["", "op-unknown", "op-xgram-seq", "op-3gram-unknown"] {
+            assert!(BirthmarkType::try_from(input).is_err(), "input: {input}");
+        }
+    }
+
+    #[test]
+    fn test_birthmark_type_display_roundtrips() {
+        let types = [
+            BirthmarkType::FcSeq, BirthmarkType::FcSet, BirthmarkType::FcFreq,
+            BirthmarkType::OpFreq, BirthmarkType::OpSeq, BirthmarkType::OpSet,
+            BirthmarkType::OpKgramSeq(2), BirthmarkType::OpKgramFreq(3), BirthmarkType::OpKgramSet(4),
+        ];
+        for bt in types {
+            let rendered = bt.to_string();
+            assert_eq!(BirthmarkType::try_from(rendered.as_str()).unwrap(), bt, "rendered: {rendered}");
+        }
+    }
+
+    #[test]
+    fn test_analysis_type_try_from_named_combinations() {
+        let names = [
+            "op-freq-cosine", "op-set-dice", "op-freq-euclidean", "op-set-jaccard",
+            "op-seq-levenshtein", "op-set-simpson", "op-freq-weightedjaccard",
+        ];
+        for name in names {
+            assert!(AnalysisType::try_from(name).is_ok(), "name: {name}");
+            // the String and &str impls must agree
+            assert!(AnalysisType::try_from(name.to_string()).is_ok(), "name: {name}");
+        }
+    }
+
+    #[test]
+    fn test_analysis_type_try_from_kgram_combinations() {
+        let cases = [
+            ("op-2gram-set-jaccard", BirthmarkType::OpKgramSet(2)),
+            ("op-3gram-set-dice", BirthmarkType::OpKgramSet(3)),
+            ("op-3gram-set-simpson", BirthmarkType::OpKgramSet(3)),
+            ("op-4gram-seq-levenshtein", BirthmarkType::OpKgramSeq(4)),
+            ("op-5gram-freq-cosine", BirthmarkType::OpKgramFreq(5)),
+            ("op-5gram-freq-euclidean", BirthmarkType::OpKgramFreq(5)),
+            ("op-6gram-freq-weightedjaccard", BirthmarkType::OpKgramFreq(6)),
+        ];
+        for (name, expected) in cases {
+            let at = AnalysisType::try_from(name)
+                .unwrap_or_else(|e| panic!("{name}: {e}"));
+            assert_eq!(at.birthmark, expected, "name: {name}");
+        }
+    }
+
+    #[test]
+    fn test_analysis_type_try_from_rejects_unknown() {
+        for name in ["", "unknown", "op-2gram-set-unknown", "fc-set-jaccard-extra"] {
+            assert!(AnalysisType::try_from(name).is_err(), "name: {name}");
+        }
+    }
+
+    #[test]
+    fn test_data_len_and_iter_for_every_variant() {
+        let kgram = Kgram::new(vec!["A".to_string(), "B".to_string()]);
+        let variants = [
+            Data::Seq(vec!["A".to_string(), "B".to_string()]),
+            Data::Set(["A".to_string(), "B".to_string()].into_iter().collect()),
+            Data::Freq([("A".to_string(), 1), ("B".to_string(), 2)].into_iter().collect()),
+            Data::KgramSeq(vec![kgram.clone()]),
+            Data::KgramSet([kgram.clone()].into_iter().collect()),
+            Data::KgramFreq([(kgram, 1)].into_iter().collect()),
+        ];
+        for data in variants {
+            let elements = Elements { name: "f".to_string(), data };
+            // every variant above carries two mnemonics in total
+            assert_eq!(elements.ops().count(), 2);
+            assert!(!elements.is_empty());
+            assert_eq!(elements.name(), "f");
+        }
+    }
+
+    #[test]
+    fn test_elements_is_empty_on_empty_data() {
+        let elements = Elements { name: "f".to_string(), data: Data::Seq(vec![]) };
+        assert!(elements.is_empty());
+        assert_eq!(elements.len(), 0);
+        assert_eq!(elements.ops().count(), 0);
+    }
+
+    fn sample_birthmark() -> Birthmark {
+        Birthmark {
+            metadata: Metadata {
+                file_name: "sample".to_string(),
+                path: PathBuf::from("/tmp/sample"),
+                extracted_at: chrono::Utc::now(),
+                duration: Duration::from_nanos(7),
+                birthmark_type: BirthmarkType::OpSeq,
+            },
+            elements: vec![Elements {
+                name: "main".to_string(),
+                data: Data::Seq(vec!["COPY".to_string()]),
+            }],
+            json_path: None,
+        }
+    }
+
+    #[test]
+    fn test_birthmark_accessors() {
+        let mut b = sample_birthmark();
+        assert_eq!(b.name(), "sample");
+        assert_eq!(b.path(), Path::new("/tmp/sample"));
+        assert_eq!(b.duration(), Duration::from_nanos(7));
+        assert_eq!(b.birthmark_type(), &BirthmarkType::OpSeq);
+        assert_eq!(b.len(), 1);
+        assert!(!b.is_empty());
+        assert!(b.extracted_at() <= chrono::Utc::now());
+
+        // csv_info leaves the json path empty until it is set
+        assert!(b.csv_info().ends_with(','));
+        b.set_json_path(PathBuf::from("/tmp/sample.json"));
+        assert!(b.csv_info().ends_with("/tmp/sample.json"));
+        assert_eq!(b.names(), vec!["main".to_string()]);
+    }
+
+    #[test]
+    fn test_birthmark_comparable_with() {
+        let b1 = sample_birthmark();
+        let mut b2 = sample_birthmark();
+        assert!(b1.comparable_with(&b2));
+        b2.metadata.birthmark_type = BirthmarkType::OpSet;
+        assert!(!b1.comparable_with(&b2));
+    }
+
+    #[test]
+    fn test_birthmark_iterable_for_value_and_reference() {
+        // Iterable is implemented for both Birthmark and &Birthmark; going
+        // through a generic function exercises each impl distinctly.
+        fn count_elements<I: crate::Iterable>(iterable: I) -> usize {
+            iterable.iter().count()
+        }
+        let b = sample_birthmark();
+        assert_eq!(count_elements(&b), 1);
+        assert_eq!(count_elements(b), 1);
+    }
+
+    #[test]
+    fn test_birthmark_try_from_path_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("b.json");
+        let b = sample_birthmark();
+        std::fs::write(&path, serde_json::to_string(&b).unwrap()).unwrap();
+
+        // both the PathBuf and the &Path impls must work
+        let loaded = Birthmark::try_from(path.as_path()).expect("failed to load birthmark");
+        assert_eq!(loaded.name(), b.name());
+        assert_eq!(loaded.len(), b.len());
+        assert!(Birthmark::try_from(path.clone()).is_ok());
+    }
+
+    #[test]
+    fn test_birthmark_try_from_path_reports_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("missing.json");
+        assert!(matches!(Birthmark::try_from(missing).unwrap_err(), Error::Io(..)));
+
+        let broken = dir.path().join("broken.json");
+        std::fs::write(&broken, b"{ not json").unwrap();
+        assert!(matches!(Birthmark::try_from(broken).unwrap_err(), Error::Json(..)));
+    }
 }

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -775,9 +775,27 @@ fn longest_common_subsequence<T: PartialEq>(s1: &[T], s2: &[T]) -> f64 {
     2.0 * lcs_length as f64 / (n + m) as f64
 }
 
+#[allow(dead_code)]
+fn longest_common_subsequence_full_memory<T: PartialEq>(s1: &[T], s2: &[T]) -> f64 {
+    let mut dp = Array2::<usize>::zeros((s1.len() + 1, s2.len() + 1));
+    for i in 1..=s1.len() {
+        for j in 1..=s2.len() {
+            if s1[i - 1] == s2[j - 1] {
+                dp[[i, j]] = dp[[i - 1, j - 1]] + 1;
+            } else {
+                dp[[i, j]] = dp[[i - 1, j]].max(dp[[i, j - 1]]);
+            }
+        }
+    }
+    let lcs_length = dp[[s1.len(), s2.len()]];
+    2.0 * lcs_length as f64 / (s1.len() + s2.len()) as f64
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::birthmarks::Metadata;
+    use std::path::PathBuf;
 
     #[test]
     fn compare_count_does_not_panic_on_empty_targets() {
@@ -797,20 +815,305 @@ mod tests {
         assert!(matches!("topn".parse::<Aggregator>(), Ok(Aggregator::TopN(Size::All))));
         assert!(matches!("hungarian".parse::<Aggregator>(), Ok(Aggregator::Hungarian)));
     }
-}
 
-#[allow(dead_code)]
-fn longest_common_subsequence_full_memory<T: PartialEq>(s1: &[T], s2: &[T]) -> f64 {
-    let mut dp = Array2::<usize>::zeros((s1.len() + 1, s2.len() + 1));
-    for i in 1..=s1.len() {
-        for j in 1..=s2.len() {
-            if s1[i - 1] == s2[j - 1] {
-                dp[[i, j]] = dp[[i - 1, j - 1]] + 1;
-            } else {
-                dp[[i, j]] = dp[[i - 1, j]].max(dp[[i, j - 1]]);
-            }
+    #[test]
+    fn aggregator_rejects_malformed_input() {
+        // a non-numeric N and an entirely unknown name take separate error paths
+        assert!(matches!("topn:abc".parse::<Aggregator>(), Err(Error::ParseInt(..))));
+        assert!(matches!("nonsense".parse::<Aggregator>(), Err(Error::Parse(_))));
+        // parsing is case insensitive
+        assert!(matches!("HUNGARIAN".parse::<Aggregator>(), Ok(Aggregator::Hungarian)));
+        assert!(matches!("TopN:All".parse::<Aggregator>(), Ok(Aggregator::TopN(Size::All))));
+    }
+
+    #[test]
+    fn pairs_on_empty_targets_yield_nothing() {
+        let empty: Vec<i32> = vec![];
+        for strategy in [PairingStrategy::FirstVsOthers, PairingStrategy::LastVsOthers,
+                         PairingStrategy::All, PairingStrategy::AllAndSelf,
+                         PairingStrategy::Adjacent, PairingStrategy::SelfCoverage] {
+            assert_eq!(strategy.pairs(&empty).count(), 0, "strategy: {strategy:?}");
         }
     }
-    let lcs_length = dp[[s1.len(), s2.len()]];
-    2.0 * lcs_length as f64 / (s1.len() + s2.len()) as f64
+
+    #[test]
+    fn pairs_match_compare_count() {
+        let targets = vec![1, 2, 3, 4];
+        for strategy in [PairingStrategy::All, PairingStrategy::AllAndSelf,
+                         PairingStrategy::Adjacent, PairingStrategy::SelfCoverage,
+                         PairingStrategy::FirstVsOthers, PairingStrategy::LastVsOthers] {
+            assert_eq!(strategy.pairs(&targets).count(), strategy.compare_count(&targets),
+                "strategy: {strategy:?}");
+        }
+    }
+
+    #[test]
+    fn algorithm_display_is_defined_for_every_variant() {
+        let cases = [
+            (Algorithm::Cosine, "Cosine Similarity"),
+            (Algorithm::Dice, "Dice Coefficient"),
+            (Algorithm::Euclidean, "Euclidean Distance"),
+            (Algorithm::Jaccard, "Jaccard Index"),
+            (Algorithm::Levenshtein, "Levenshtein Distance"),
+            (Algorithm::Lcs, "Longest Common Subsequence"),
+            (Algorithm::Simpson, "Simpson's Coefficient"),
+            (Algorithm::WeightedJaccard, "Weighted Jaccard Index"),
+        ];
+        for (algorithm, expected) in cases {
+            assert_eq!(algorithm.to_string(), expected);
+        }
+    }
+
+    fn elements(name: &str, data: Data) -> Elements {
+        Elements { name: name.to_string(), data }
+    }
+
+    fn seq(items: &[&str]) -> Data {
+        Data::Seq(items.iter().map(|s| s.to_string()).collect())
+    }
+
+    fn set(items: &[&str]) -> Data {
+        Data::Set(items.iter().map(|s| s.to_string()).collect())
+    }
+
+    fn freq(items: &[&str]) -> Data {
+        Data::Freq(seq2freq(&items.iter().map(|s| s.to_string()).collect::<Vec<_>>()))
+    }
+
+    fn kgram_seq(items: &[&str]) -> Data {
+        Data::KgramSeq(items.iter().map(|s| Kgram::new(vec![s.to_string()])).collect())
+    }
+
+    fn kgram_set(items: &[&str]) -> Data {
+        Data::KgramSet(items.iter().map(|s| Kgram::new(vec![s.to_string()])).collect())
+    }
+
+    fn kgram_freq(items: &[&str]) -> Data {
+        Data::KgramFreq(seq2freq(&items.iter().map(|s| Kgram::new(vec![s.to_string()])).collect::<Vec<_>>()))
+    }
+
+    /// Every set-like comparator must report 1.0 for identical inputs across
+    /// each Data representation it claims to support.
+    #[test]
+    fn set_like_comparators_accept_every_supported_representation() {
+        let builders: [fn(&[&str]) -> Data; 6] = [seq, set, freq, kgram_seq, kgram_set, kgram_freq];
+        for build in builders {
+            let e1 = elements("f", build(&["A", "B", "C"]));
+            let e2 = elements("g", build(&["A", "B", "C"]));
+            assert!((Jaccard.compare_elements(&e1, &e2) - 1.0).abs() < 1e-9);
+            assert!((Dice.compare_elements(&e1, &e2) - 1.0).abs() < 1e-9);
+            assert!((Simpson.compare_elements(&e1, &e2) - 1.0).abs() < 1e-9);
+        }
+    }
+
+    #[test]
+    fn sequence_comparators_accept_seq_representations() {
+        let builders: [fn(&[&str]) -> Data; 2] = [seq, kgram_seq];
+        for build in builders {
+            let e1 = elements("f", build(&["A", "B", "C"]));
+            let e2 = elements("g", build(&["A", "B", "C"]));
+            assert!((Levenshtein.compare_elements(&e1, &e2) - 1.0).abs() < 1e-9);
+            assert!((Lcs.compare_elements(&e1, &e2) - 1.0).abs() < 1e-9);
+        }
+    }
+
+    #[test]
+    fn frequency_comparators_accept_every_supported_representation() {
+        let builders: [fn(&[&str]) -> Data; 4] = [seq, freq, kgram_seq, kgram_freq];
+        for build in builders {
+            let e1 = elements("f", build(&["A", "B", "C"]));
+            let e2 = elements("g", build(&["A", "B", "C"]));
+            assert!((Cosine.compare_elements(&e1, &e2) - 1.0).abs() < 1e-9);
+            assert!((WeightedJaccard.compare_elements(&e1, &e2) - 1.0).abs() < 1e-9);
+            assert!((Euclidean.compare_elements(&e1, &e2) - 1.0).abs() < 1e-9);
+        }
+    }
+
+    /// Mismatched or unsupported representations fall through to 0.0 rather
+    /// than panicking.
+    #[test]
+    fn comparators_return_zero_for_unsupported_representations() {
+        let s = elements("f", seq(&["A"]));
+        let st = elements("g", set(&["A"]));
+        // Data variants that do not pair up
+        assert_eq!(Jaccard.compare_elements(&s, &st), 0.0);
+        assert_eq!(Dice.compare_elements(&s, &st), 0.0);
+        assert_eq!(Simpson.compare_elements(&s, &st), 0.0);
+        assert_eq!(Cosine.compare_elements(&s, &st), 0.0);
+        assert_eq!(Euclidean.compare_elements(&s, &st), 0.0);
+        assert_eq!(WeightedJaccard.compare_elements(&s, &st), 0.0);
+        // Levenshtein and LCS only support sequences at all
+        assert_eq!(Levenshtein.compare_elements(&st, &st), 0.0);
+        assert_eq!(Lcs.compare_elements(&st, &st), 0.0);
+    }
+
+    fn birthmark(name: &str, funcs: &[(&str, &[&str])]) -> Birthmark {
+        Birthmark {
+            metadata: Metadata {
+                file_name: name.to_string(),
+                path: PathBuf::from(format!("/tmp/{name}")),
+                extracted_at: chrono::Utc::now(),
+                duration: std::time::Duration::from_nanos(1),
+                birthmark_type: BirthmarkType::OpSeq,
+            },
+            elements: funcs.iter().map(|(n, ops)| elements(n, seq(ops))).collect(),
+            json_path: None,
+        }
+    }
+
+    #[test]
+    fn compare_birthmarks_rejects_mismatched_types() {
+        let b1 = birthmark("a", &[("main", &["A"])]);
+        let mut b2 = birthmark("b", &[("main", &["A"])]);
+        b2.metadata.birthmark_type = BirthmarkType::OpSet;
+        match Jaccard.compare_birthmarks(&b1, &b2, &Aggregator::Hungarian) {
+            Err(Error::Mismatch(..)) => {},
+            Err(e) => panic!("unexpected error: {e}"),
+            Ok(_) => panic!("expected a mismatch error"),
+        }
+    }
+
+    #[test]
+    fn compare_birthmarks_handles_empty_operands() {
+        let empty = birthmark("empty", &[]);
+        let filled = birthmark("filled", &[("main", &["A"])]);
+
+        // both empty means identical
+        let both = Jaccard.compare_birthmarks(&empty, &empty, &Aggregator::Hungarian).unwrap();
+        assert_eq!(both.similarity(), 1.0);
+
+        // exactly one empty means nothing in common
+        let one = Jaccard.compare_birthmarks(&empty, &filled, &Aggregator::Hungarian).unwrap();
+        assert_eq!(one.similarity(), 0.0);
+        let other = Jaccard.compare_birthmarks(&filled, &empty, &Aggregator::Hungarian).unwrap();
+        assert_eq!(other.similarity(), 0.0);
+    }
+
+    #[test]
+    fn compare_birthmarks_of_identical_inputs_scores_one() {
+        let b = birthmark("a", &[("f", &["A", "B"]), ("g", &["C"])]);
+        for aggregator in [Aggregator::Hungarian, Aggregator::TopN(Size::All), Aggregator::TopN(Size::Num(1))] {
+            let c = Jaccard.compare_birthmarks(&b, &b, &aggregator).unwrap();
+            assert!((c.similarity() - 1.0).abs() < 1e-9, "aggregator: {aggregator:?}");
+        }
+    }
+
+    #[test]
+    fn top_n_selection_limits_the_number_of_scores() {
+        let matrix = Array2::from_shape_vec((3, 3), vec![
+            1.0, 0.0, 0.0,
+            0.0, 1.0, 0.0,
+            0.0, 0.0, 1.0,
+        ]).unwrap();
+        // Size::Num(k) keeps k row maxima plus k column maxima
+        let picked = top_n_selection(&matrix, &Size::Num(2)).unwrap();
+        assert_eq!(picked.len(), 4);
+        assert!(picked.iter().all(|v| (*v - 1.0).abs() < 1e-9));
+        // Size::All keeps every row and column maximum
+        let all = top_n_selection(&matrix, &Size::All).unwrap();
+        assert_eq!(all.len(), 6);
+    }
+
+    #[test]
+    fn comparison_similarity_is_zero_when_no_scores_were_aggregated() {
+        let b = birthmark("a", &[("f", &["A"])]);
+        let c = Comparison::new(&b, &b, Array2::zeros((0, 0)), vec![], std::time::Duration::from_nanos(0));
+        assert_eq!(c.similarity(), 0.0, "an empty aggregation must not produce NaN");
+        assert_eq!(c.duration(), std::time::Duration::from_nanos(0));
+    }
+
+    #[test]
+    fn comparison_store_writes_a_parsable_matrix() {
+        let b1 = birthmark("left", &[("f", &["A", "B"]), ("g", &["B"])]);
+        let b2 = birthmark("right", &[("h", &["A"]), ("i", &["B"])]);
+        let c = Jaccard.compare_birthmarks(&b1, &b2, &Aggregator::Hungarian).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("00000.csv");
+        c.store(&dest).expect("failed to store the comparison");
+
+        let content = std::fs::read_to_string(&dest).unwrap();
+        assert!(content.starts_with("result,"));
+        // NOTE: Comparison::new takes (columns, rows) and compare_birthmarks
+        // passes (b1, b2), while store writes the "left" record from `rows`.
+        // The stored "left" is therefore the *second* birthmark, and "right"
+        // the first. This asserts the behaviour as it currently stands.
+        assert!(content.contains("\nleft,birthmark,right,"));
+        assert!(content.contains("\nright,birthmark,left,"));
+        assert!(content.contains("\nmatrix,,"));
+        // one line per row element, each prefixed with its index
+        assert_eq!(content.lines().filter(|l| l.starts_with('0') || l.starts_with('1')).count(), 2);
+    }
+
+    #[test]
+    fn comparison_store_reports_io_errors() {
+        let b = birthmark("a", &[("f", &["A"])]);
+        let c = Jaccard.compare_birthmarks(&b, &b, &Aggregator::Hungarian).unwrap();
+        // a directory that does not exist cannot receive the result file
+        let err = c.store("no/such/directory/out.csv").unwrap_err();
+        assert!(matches!(err, Error::Io(..)));
+    }
+
+    #[test]
+    fn comparator_dispatches_every_algorithm() {
+        let b = birthmark("a", &[("f", &["A", "B"])]);
+        for algorithm in [Algorithm::Cosine, Algorithm::Dice, Algorithm::Euclidean,
+                          Algorithm::Jaccard, Algorithm::Levenshtein, Algorithm::Lcs,
+                          Algorithm::Simpson, Algorithm::WeightedJaccard] {
+            let comparator = algorithm.comparator();
+            let c = comparator.compare_birthmarks(&b, &b, &Aggregator::Hungarian)
+                .unwrap_or_else(|e| panic!("{algorithm}: {e}"));
+            assert!((c.similarity() - 1.0).abs() < 1e-9, "algorithm: {algorithm}");
+        }
+    }
+
+    #[test]
+    fn similarity_functions_agree_with_their_full_memory_variants() {
+        let a = ["A", "B", "C", "D"];
+        let b = ["A", "C", "D", "E"];
+        assert!((longest_common_subsequence(&a, &b) - longest_common_subsequence_full_memory(&a, &b)).abs() < 1e-9);
+        assert!((levenshtein_distance(&a, &b) - levenshtein_distance_full_memory(&a, &b)).abs() < 1e-9);
+        // the row/column swap for the shorter sequence must not change the score
+        let short = ["A", "B"];
+        assert!((longest_common_subsequence(&a, &short) - longest_common_subsequence(&short, &a)).abs() < 1e-9);
+        assert!((levenshtein_distance(&a, &short) - levenshtein_distance(&short, &a)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn similarity_functions_handle_empty_sequences() {
+        let empty: [&str; 0] = [];
+        let one = ["A"];
+        assert_eq!(levenshtein_distance(&empty, &empty), 1.0);
+        assert_eq!(levenshtein_distance(&empty, &one), 0.0);
+        assert_eq!(levenshtein_distance(&one, &empty), 0.0);
+        assert_eq!(longest_common_subsequence(&empty, &one), 0.0);
+        assert_eq!(longest_common_subsequence(&one, &empty), 0.0);
+    }
+
+    #[test]
+    fn set_indices_handle_empty_inputs() {
+        let empty: FxHashSet<&str> = FxHashSet::default();
+        let one: FxHashSet<&str> = ["A"].into_iter().collect();
+        for f in [jaccard_index, dice_index, simpson_index] {
+            assert_eq!(f(&empty, &empty), 1.0);
+            assert_eq!(f(&empty, &one), 0.0);
+            assert_eq!(f(&one, &empty), 0.0);
+        }
+    }
+
+    #[test]
+    fn frequency_metrics_handle_empty_inputs() {
+        let empty: FxHashMap<&str, usize> = FxHashMap::default();
+        // an empty vector has no direction, so both are treated as identical
+        assert_eq!(cosine_similarity(&empty, &empty), 1.0);
+        assert_eq!(weighted_jaccard(&empty, &empty), 1.0);
+    }
+
+    #[test]
+    fn escape_csv_string_quotes_only_when_needed() {
+        assert_eq!(escape_csv_string("plain"), "plain");
+        assert_eq!(escape_csv_string("a,b"), "\"a,b\"");
+        assert_eq!(escape_csv_string("a\"b"), "\"a\"\"b\"");
+        assert_eq!(escape_csv_string("a\nb"), "\"a\nb\"");
+    }
 }


### PR DESCRIPTION
## Motivation

`src/birthmarks.rs` sat at **46.44%** line coverage and `src/compare.rs` at **76.55%**. The string-parsing entry points (`BirthmarkType::try_from`, `AnalysisType::try_from`, `parse_kgram_and_algorithm`) and most comparator dispatch paths were never executed by any test, despite being pure functions that are cheap to cover.

## Changes

### `src/birthmarks.rs` — 46.44% → **99.76%** lines

- Table-driven tests for `BirthmarkType` parsing, `Display`, and their roundtrip, including case-insensitivity and rejection of malformed input
- `AnalysisType` parsing for both the named combinations (`op-freq-cosine`, …) and the k-gram combinations (`op-3gram-set-dice`, …), through both the `&str` and `String` impls
- `Data::iter`/`len` across all six representations, plus the `Elements` accessors
- `Birthmark` accessors, `comparable_with`, both `Iterable` impls, and `TryFrom<Path>` success / IO-error / JSON-error paths
- `Metadata::parse` error paths (wrong field count, empty line, bad datetime and duration)

### `src/compare.rs` — 76.55% → **98.41%** lines

- `Algorithm` `Display` for all eight variants
- Each comparator against every `Data` representation it claims to support, and the `0.0` fallback for unsupported pairings
- Empty-operand and mismatched-type paths of `compare_birthmarks`
- `top_n_selection` for both `Size::Num` and `Size::All`
- `Comparison::store` success and IO-error paths
- `Aggregator` parse errors, and agreement between `PairingStrategy::pairs` and `compare_count`
- Agreement between the rolling-row and full-memory LCS / Levenshtein implementations

Also moves `compare.rs`'s test module to the end of the file, silencing the `items after a test module` warning that `cargo clippy --all-targets` reported.

## Result

| | Before | After |
|---|---|---|
| `src/birthmarks.rs` | 46.44% | **99.76%** |
| `src/compare.rs` | 76.55% | **98.41%** |
| **Total (llvm-cov lines)** | 72.48% | **85.81%** |

## Verification

- `cargo test`: 77 passed (62 lib + 6 pcode + 6 E2E + 3 integration)
- `cargo clippy --all-targets`: 0 warnings

## Note for reviewers

While covering `Comparison::store`, I found that the stored `left` record is the **second** birthmark and `right` the first: `Comparison::new` takes `(columns, rows)`, `compare_birthmarks` passes `(b1, b2)`, and `store` writes the `left` line from `rows`. Since `read_result_file` maps `left`→`path1` and `right`→`path2`, a `--skip` rerun records the pair in the opposite order from a fresh run. The similarity score is unaffected (the metrics are symmetric), so I did **not** change the output format here — the test documents the current behaviour. Worth deciding separately whether to fix the ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)