### PR TITLE
fix: write the left CSV record from the first birthmark, not the second

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,6 +34,7 @@ jobs:
 
       - name: build
         run: |
+          cargo fmt --all -- --check
           cargo clippy -- -D warnings
           cargo build --release
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Note that `oinkie` does not care about the binary formats; it only looks at the 
 
 Next, we should lift the binary files to the OIR format.
 The current version of `oinkie` was only tested by lifting with [Ghidra](https://www.ghidradocs.com) and generated the OIR format.
-The future version will support [LLVM IR/BC](https://llvm.org) and [Binary Ninja](https://binary.ninja).
+The future version will support [Binary Ninja](https://binary.ninja), and [IDA Pro](https://hex-rays.com/ida-pro).
 
 See also ([`lifter/README.md`](lifter/README.md)).
 

--- a/cli/cli.rs
+++ b/cli/cli.rs
@@ -41,50 +41,94 @@ pub enum LogLevel {
 
 #[derive(Debug, clap::Parser)]
 pub enum OinkieCommand {
-    #[command(name="info", about = "Display information about the application")]
+    #[command(name = "info", about = "Display information about the application")]
     Info,
 
-    #[command(name="lift", about = "Lift binary files to P-code JSON files using a specified lifter")]
+    #[command(
+        name = "lift",
+        about = "Lift binary files to P-code JSON files using a specified lifter"
+    )]
     Lift(LiftOpts),
 
-    #[command(name="extract", about = "Extract birthmarks from a lifted binary file (JSON format)")]
+    #[command(
+        name = "extract",
+        about = "Extract birthmarks from a lifted binary file (JSON format)"
+    )]
     Extract(ExtractOpts),
 
-    #[command(name="compare", about = "Compare birthmarks and output the similarity score")]
+    #[command(
+        name = "compare",
+        about = "Compare birthmarks and output the similarity score"
+    )]
     Compare(CompareOpts),
 
-    #[command(name="reaggregate", about = "Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score")]
+    #[command(
+        name = "reaggregate",
+        about = "Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score"
+    )]
     Reaggregate(ReaggregateOpts),
 
-    #[command(name="run", about = "Extract birthmarks and compare them in one command")]
+    #[command(
+        name = "run",
+        about = "Extract birthmarks and compare them in one command"
+    )]
     Run(RunOpts),
 
     #[cfg(debug_assertions)]
-    #[command(name="gencomp", about = "Generate completions")]
+    #[command(name = "gencomp", about = "Generate completions")]
     GenComp,
 }
 
 #[derive(Debug, clap::Parser)]
 pub struct LiftOpts {
-    #[clap(short, long, default_value = "pcodes", value_name = "DIRECTORY", help = "Specify the directory for putting the resultant JSON files for the lifted P-code (default: './pcodes' directory)")]
+    #[clap(
+        short,
+        long,
+        default_value = "pcodes",
+        value_name = "DIRECTORY",
+        help = "Specify the directory for putting the resultant JSON files for the lifted P-code (default: './pcodes' directory)"
+    )]
     dest: PathBuf,
 
     #[clap(short = 'l', long, value_enum, default_value_t = LifterType::Ghidra, help = "Specify the lifter type")]
     lifter_type: LifterType,
 
-    #[clap(short = 'H', long, value_name = "HOME", help = "Specify the path to the home directory of the lifter (e.g., GHIDRA_HOME for Ghidra). If not specified, the environment variable (e.g., GHIDRA_HOME) or default paths are searched.")]
+    #[clap(
+        short = 'H',
+        long,
+        value_name = "HOME",
+        help = "Specify the path to the home directory of the lifter (e.g., GHIDRA_HOME for Ghidra). If not specified, the environment variable (e.g., GHIDRA_HOME) or default paths are searched."
+    )]
     home: Option<PathBuf>,
 
-    #[clap(short = 'i', long = "intermediate", value_name = "DIRECTORY", help = "Directory to keep intermediate files like Ghidra project directories. If not specified, a temporary directory is used and deleted.")]
+    #[clap(
+        short = 'i',
+        long = "intermediate",
+        value_name = "DIRECTORY",
+        help = "Directory to keep intermediate files like Ghidra project directories. If not specified, a temporary directory is used and deleted."
+    )]
     intermediate_dir: Option<PathBuf>,
 
-    #[clap(long, value_name = "SCRIPT", help = "Path to a custom lifting script. Interpretation depends on the lifter type. For Ghidra, it's the path to a Java script.")]
+    #[clap(
+        long,
+        value_name = "SCRIPT",
+        help = "Path to a custom lifting script. Interpretation depends on the lifter type. For Ghidra, it's the path to a Java script."
+    )]
     script: Option<PathBuf>,
 
-    #[clap(short = 'S', long, default_value_t = false, help = "Skip if the resultant JSON file already exists")]
+    #[clap(
+        short = 'S',
+        long,
+        default_value_t = false,
+        help = "Skip if the resultant JSON file already exists"
+    )]
     skip: bool,
 
-    #[clap(index = 1, value_name = "FILES", help = "Path to the binary or intermediate files to lift")]
+    #[clap(
+        index = 1,
+        value_name = "FILES",
+        help = "Path to the binary or intermediate files to lift"
+    )]
     files: Vec<PathBuf>,
 }
 
@@ -132,7 +176,13 @@ pub enum BinaryType {
 
 #[derive(Debug, clap::Parser)]
 pub struct ExtractOpts {
-    #[clap(short, long, default_value = "birthmarks", value_name = "DIRECTORY", help = "Specify the directory for putting the resultant JSON files for the extracted birthmarks (default: './birthmarks' directory)")]
+    #[clap(
+        short,
+        long,
+        default_value = "birthmarks",
+        value_name = "DIRECTORY",
+        help = "Specify the directory for putting the resultant JSON files for the extracted birthmarks (default: './birthmarks' directory)"
+    )]
     dest: PathBuf,
 
     #[clap(short, long, value_enum, value_name = "BIRTHMARK_TYPE", default_value_t = BType::OpSeq, hide_possible_values = true, ignore_case = true, help = "Type of birthmark to extract.
@@ -142,13 +192,22 @@ while 'fc-freq' extracts the frequency of function calls.
 The full birthmark types cann be found by running 'oinkie info'.")]
     birthmark_type: BType,
 
-    #[clap(short = 'S', long, default_value_t = false, help = "Skip the resultant birthmark file is already exists")]
+    #[clap(
+        short = 'S',
+        long,
+        default_value_t = false,
+        help = "Skip the resultant birthmark file is already exists"
+    )]
     skip: bool,
 
     #[clap(short = 'B', long, value_enum, value_name = "BINARY_TYPE", default_value_t = BinaryType::Ghidra, ignore_case = true, help = "Type of binary. Current version only supports Ghidra JSON format")]
     binary_type: BinaryType,
 
-    #[clap(index = 1, value_name = "JSON_FILES", help = "Path to the JSON files to extract birthmarks from")]
+    #[clap(
+        index = 1,
+        value_name = "JSON_FILES",
+        help = "Path to the JSON files to extract birthmarks from"
+    )]
     files: Vec<PathBuf>,
 }
 
@@ -181,7 +240,11 @@ impl ExtractOpts {
 #[derive(Debug, clap::Parser)]
 pub struct ReaggregateOpts {
     #[clap(
-        short = 'A', long, default_value = "hungarian", value_name = "METHOD", ignore_case = true, 
+        short = 'A',
+        long,
+        default_value = "hungarian",
+        value_name = "METHOD",
+        ignore_case = true,
         help = "Specify the aggregator for combining element-wise similarity scores into a birthmark-wise similarity score.
 Available: 
 - hungarian  Use the Hungarian algorithm to find the optimal matching between elements of two birthmarks,
@@ -192,11 +255,21 @@ Available:
     )]
     aggregator: Aggregator,
 
-    #[clap(short, long, value_name = "RESULT.CSV", help = "Specify the result CSV file of the comparing results to reaggregate.
-The file contains the birthmark-wise similarity score list.", default_value = "reaggregate.csv")]
+    #[clap(
+        short,
+        long,
+        value_name = "RESULT.CSV",
+        help = "Specify the result CSV file of the comparing results to reaggregate.
+The file contains the birthmark-wise similarity score list.",
+        default_value = "reaggregate.csv"
+    )]
     dest_file: PathBuf,
 
-    #[clap(index = 1, value_name = "SCORE_DIRECTORY", help = "Path to the directory containing the element-wise similarity scores")]
+    #[clap(
+        index = 1,
+        value_name = "SCORE_DIRECTORY",
+        help = "Path to the directory containing the element-wise similarity scores"
+    )]
     score_directory: PathBuf,
 }
 
@@ -217,10 +290,14 @@ impl ReaggregateOpts {
 #[derive(Debug, clap::Parser)]
 pub struct CompareOpts {
     #[clap(short, long, value_enum, default_value_t = Algorithm::Jaccard, value_name = "ALGORITHM", ignore_case = true, help = "Specify the similarity calculation algorithm.")]
-    algorithm: Algorithm,    
+    algorithm: Algorithm,
 
     #[clap(
-        short = 'A', long, default_value = "hungarian", value_name = "METHOD", ignore_case = true, 
+        short = 'A',
+        long,
+        default_value = "hungarian",
+        value_name = "METHOD",
+        ignore_case = true,
         help = "Specify the aggregator for combining element-wise similarity scores into a birthmark-wise similarity score.
 Available: 
 - hungarian  Use the Hungarian algorithm to find the optimal matching between elements of two birthmarks,
@@ -234,13 +311,28 @@ Available:
     #[clap(short, long, value_enum, default_value_t = PairingStrategy::AllAndSelf, value_name = "STRATEGY", ignore_case = true, help = "Specify the pairing strategy for comparing files.")]
     strategy: PairingStrategy,
 
-    #[clap(short, long, value_name = "DIRECTORY", help = "Specify the destination directory for the comparing results", default_value = "similarities")]
+    #[clap(
+        short,
+        long,
+        value_name = "DIRECTORY",
+        help = "Specify the destination directory for the comparing results",
+        default_value = "similarities"
+    )]
     dest: PathBuf,
 
-    #[clap(short = 'S', long, default_value_t = false, help = "Skip if the similarity file already exists for the pair of birthmarks")]
+    #[clap(
+        short = 'S',
+        long,
+        default_value_t = false,
+        help = "Skip if the similarity file already exists for the pair of birthmarks"
+    )]
     skip: bool,
 
-    #[clap(index = 1, value_name = "JSON_FILES", help = "Path to the birthmark JSON files to compare")]
+    #[clap(
+        index = 1,
+        value_name = "JSON_FILES",
+        help = "Path to the birthmark JSON files to compare"
+    )]
     files: Vec<PathBuf>,
 }
 
@@ -258,7 +350,10 @@ impl CompareOpts {
     }
 
     pub fn aggregator(&self) -> &Aggregator {
-        log::info!("Using {:?} as the aggregator for combining element-wise similarity scores", self.aggregator);
+        log::info!(
+            "Using {:?} as the aggregator for combining element-wise similarity scores",
+            self.aggregator
+        );
         &self.aggregator
     }
 
@@ -279,11 +374,20 @@ pub struct RunOpts {
     #[clap(short, long, value_enum, default_value_t = PairingStrategy::AllAndSelf, ignore_case = true, help = "Pairing strategy for file comparisons")]
     pub strategy: PairingStrategy,
 
-    #[clap(short, long, default_value = "similarities", help = "Destination path for the output CSV file (default: 'similarities' directory")]
+    #[clap(
+        short,
+        long,
+        default_value = "similarities",
+        help = "Destination path for the output CSV file (default: 'similarities' directory"
+    )]
     pub(crate) dest: PathBuf,
 
     #[clap(
-        short = 'A', long, default_value = "hungarian", value_name = "METHOD", ignore_case = true,
+        short = 'A',
+        long,
+        default_value = "hungarian",
+        value_name = "METHOD",
+        ignore_case = true,
         help = "Specify the aggregator for combining element-wise similarity scores into a birthmark-wise similarity score.
 Available: 
 - hungarian  Use the Hungarian algorithm to find the optimal matching between elements of two birthmarks,
@@ -294,7 +398,12 @@ Available:
     )]
     aggregator: Aggregator,
 
-    #[clap(short = 'S', long, default_value_t = false, help = "Skip if the similarity file already exists for the pair of birthmarks")]
+    #[clap(
+        short = 'S',
+        long,
+        default_value_t = false,
+        help = "Skip if the similarity file already exists for the pair of birthmarks"
+    )]
     pub(crate) skip: bool,
 
     #[clap(index = 1, help = "Path to the JSON files")]
@@ -323,7 +432,10 @@ impl RunOpts {
     }
 
     pub fn aggregator(&self) -> &Aggregator {
-        log::info!("Using {:?} as the aggregator for combining element-wise similarity scores", self.aggregator);
+        log::info!(
+            "Using {:?} as the aggregator for combining element-wise similarity scores",
+            self.aggregator
+        );
         &self.aggregator
     }
 }
@@ -415,76 +527,183 @@ impl From<&Analysis> for AnalysisType {
         match value {
             Analysis::FcFreqCosine => AnalysisType::new(BirthmarkType::FcFreq, Algorithm::Cosine),
             Analysis::FcSetDice => AnalysisType::new(BirthmarkType::FcSet, Algorithm::Dice),
-            Analysis::FcFreqEuclidean => AnalysisType::new(BirthmarkType::FcFreq, Algorithm::Euclidean),
+            Analysis::FcFreqEuclidean => {
+                AnalysisType::new(BirthmarkType::FcFreq, Algorithm::Euclidean)
+            }
             Analysis::FcSetJaccard => AnalysisType::new(BirthmarkType::FcSet, Algorithm::Jaccard),
-            Analysis::FcSeqLevenshtein => AnalysisType::new(BirthmarkType::FcSeq, Algorithm::Levenshtein),
+            Analysis::FcSeqLevenshtein => {
+                AnalysisType::new(BirthmarkType::FcSeq, Algorithm::Levenshtein)
+            }
             Analysis::FcSeqLcs => AnalysisType::new(BirthmarkType::FcSeq, Algorithm::Lcs),
             Analysis::FcSetSimpson => AnalysisType::new(BirthmarkType::FcSet, Algorithm::Simpson),
-            Analysis::FcFreqWeightedjaccard => AnalysisType::new(BirthmarkType::FcFreq, Algorithm::WeightedJaccard),
+            Analysis::FcFreqWeightedjaccard => {
+                AnalysisType::new(BirthmarkType::FcFreq, Algorithm::WeightedJaccard)
+            }
 
             Analysis::OpFreqCosine => AnalysisType::new(BirthmarkType::OpFreq, Algorithm::Cosine),
             Analysis::OpSetDice => AnalysisType::new(BirthmarkType::OpSet, Algorithm::Dice),
-            Analysis::OpFreqEuclidean => AnalysisType::new(BirthmarkType::OpFreq, Algorithm::Euclidean),
+            Analysis::OpFreqEuclidean => {
+                AnalysisType::new(BirthmarkType::OpFreq, Algorithm::Euclidean)
+            }
             Analysis::OpSetJaccard => AnalysisType::new(BirthmarkType::OpSet, Algorithm::Jaccard),
-            Analysis::OpSeqLevenshtein => AnalysisType::new(BirthmarkType::OpSeq, Algorithm::Levenshtein),
+            Analysis::OpSeqLevenshtein => {
+                AnalysisType::new(BirthmarkType::OpSeq, Algorithm::Levenshtein)
+            }
             Analysis::OpSeqLcs => AnalysisType::new(BirthmarkType::OpSeq, Algorithm::Lcs),
             Analysis::OpSetSimpson => AnalysisType::new(BirthmarkType::OpSet, Algorithm::Simpson),
-            Analysis::OpFreqWeightedjaccard => AnalysisType::new(BirthmarkType::OpFreq, Algorithm::WeightedJaccard),
+            Analysis::OpFreqWeightedjaccard => {
+                AnalysisType::new(BirthmarkType::OpFreq, Algorithm::WeightedJaccard)
+            }
 
-            Analysis::Op1gramSetDice => AnalysisType::new(BirthmarkType::OpKgramSet(1), Algorithm::Dice),
-            Analysis::Op1gramSetJaccard => AnalysisType::new(BirthmarkType::OpKgramSet(1), Algorithm::Jaccard),
-            Analysis::Op1gramSetSimpson => AnalysisType::new(BirthmarkType::OpKgramSet(1), Algorithm::Simpson),
-            Analysis::Op1gramSeqLevenshtein => AnalysisType::new(BirthmarkType::OpKgramSeq(1), Algorithm::Levenshtein),
-            Analysis::Op1gramSeqLcs => AnalysisType::new(BirthmarkType::OpKgramSeq(1), Algorithm::Lcs),
-            Analysis::Op1gramFreqCosine => AnalysisType::new(BirthmarkType::OpKgramFreq(1), Algorithm::Cosine),
-            Analysis::Op1gramFreqEuclidean => AnalysisType::new(BirthmarkType::OpKgramFreq(1), Algorithm::Euclidean),
-            Analysis::Op1gramFreqWeightedjaccard => AnalysisType::new(BirthmarkType::OpKgramFreq(1), Algorithm::WeightedJaccard),
+            Analysis::Op1gramSetDice => {
+                AnalysisType::new(BirthmarkType::OpKgramSet(1), Algorithm::Dice)
+            }
+            Analysis::Op1gramSetJaccard => {
+                AnalysisType::new(BirthmarkType::OpKgramSet(1), Algorithm::Jaccard)
+            }
+            Analysis::Op1gramSetSimpson => {
+                AnalysisType::new(BirthmarkType::OpKgramSet(1), Algorithm::Simpson)
+            }
+            Analysis::Op1gramSeqLevenshtein => {
+                AnalysisType::new(BirthmarkType::OpKgramSeq(1), Algorithm::Levenshtein)
+            }
+            Analysis::Op1gramSeqLcs => {
+                AnalysisType::new(BirthmarkType::OpKgramSeq(1), Algorithm::Lcs)
+            }
+            Analysis::Op1gramFreqCosine => {
+                AnalysisType::new(BirthmarkType::OpKgramFreq(1), Algorithm::Cosine)
+            }
+            Analysis::Op1gramFreqEuclidean => {
+                AnalysisType::new(BirthmarkType::OpKgramFreq(1), Algorithm::Euclidean)
+            }
+            Analysis::Op1gramFreqWeightedjaccard => {
+                AnalysisType::new(BirthmarkType::OpKgramFreq(1), Algorithm::WeightedJaccard)
+            }
 
-            Analysis::Op2gramSetDice => AnalysisType::new(BirthmarkType::OpKgramSet(2), Algorithm::Dice),
-            Analysis::Op2gramSetJaccard => AnalysisType::new(BirthmarkType::OpKgramSet(2), Algorithm::Jaccard),
-            Analysis::Op2gramSetSimpson => AnalysisType::new(BirthmarkType::OpKgramSet(2), Algorithm::Simpson),
-            Analysis::Op2gramSeqLevenshtein => AnalysisType::new(BirthmarkType::OpKgramSeq(2), Algorithm::Levenshtein),
-            Analysis::Op2gramSeqLcs => AnalysisType::new(BirthmarkType::OpKgramSeq(2), Algorithm::Lcs),
-            Analysis::Op2gramFreqCosine => AnalysisType::new(BirthmarkType::OpKgramFreq(2), Algorithm::Cosine),
-            Analysis::Op2gramFreqEuclidean => AnalysisType::new(BirthmarkType::OpKgramFreq(2), Algorithm::Euclidean),
-            Analysis::Op2gramFreqWeightedjaccard => AnalysisType::new(BirthmarkType::OpKgramFreq(2), Algorithm::WeightedJaccard),
+            Analysis::Op2gramSetDice => {
+                AnalysisType::new(BirthmarkType::OpKgramSet(2), Algorithm::Dice)
+            }
+            Analysis::Op2gramSetJaccard => {
+                AnalysisType::new(BirthmarkType::OpKgramSet(2), Algorithm::Jaccard)
+            }
+            Analysis::Op2gramSetSimpson => {
+                AnalysisType::new(BirthmarkType::OpKgramSet(2), Algorithm::Simpson)
+            }
+            Analysis::Op2gramSeqLevenshtein => {
+                AnalysisType::new(BirthmarkType::OpKgramSeq(2), Algorithm::Levenshtein)
+            }
+            Analysis::Op2gramSeqLcs => {
+                AnalysisType::new(BirthmarkType::OpKgramSeq(2), Algorithm::Lcs)
+            }
+            Analysis::Op2gramFreqCosine => {
+                AnalysisType::new(BirthmarkType::OpKgramFreq(2), Algorithm::Cosine)
+            }
+            Analysis::Op2gramFreqEuclidean => {
+                AnalysisType::new(BirthmarkType::OpKgramFreq(2), Algorithm::Euclidean)
+            }
+            Analysis::Op2gramFreqWeightedjaccard => {
+                AnalysisType::new(BirthmarkType::OpKgramFreq(2), Algorithm::WeightedJaccard)
+            }
 
-            Analysis::Op3gramSetDice => AnalysisType::new(BirthmarkType::OpKgramSet(3), Algorithm::Dice),
-            Analysis::Op3gramSetJaccard => AnalysisType::new(BirthmarkType::OpKgramSet(3), Algorithm::Jaccard),
-            Analysis::Op3gramSetSimpson => AnalysisType::new(BirthmarkType::OpKgramSet(3), Algorithm::Simpson),
-            Analysis::Op3gramSeqLevenshtein => AnalysisType::new(BirthmarkType::OpKgramSeq(3), Algorithm::Levenshtein),
-            Analysis::Op3gramSeqLcs => AnalysisType::new(BirthmarkType::OpKgramSeq(3), Algorithm::Lcs),
-            Analysis::Op3gramFreqCosine => AnalysisType::new(BirthmarkType::OpKgramFreq(3), Algorithm::Cosine),
-            Analysis::Op3gramFreqEuclidean => AnalysisType::new(BirthmarkType::OpKgramFreq(3), Algorithm::Euclidean),
-            Analysis::Op3gramFreqWeightedjaccard => AnalysisType::new(BirthmarkType::OpKgramFreq(3), Algorithm::WeightedJaccard),
+            Analysis::Op3gramSetDice => {
+                AnalysisType::new(BirthmarkType::OpKgramSet(3), Algorithm::Dice)
+            }
+            Analysis::Op3gramSetJaccard => {
+                AnalysisType::new(BirthmarkType::OpKgramSet(3), Algorithm::Jaccard)
+            }
+            Analysis::Op3gramSetSimpson => {
+                AnalysisType::new(BirthmarkType::OpKgramSet(3), Algorithm::Simpson)
+            }
+            Analysis::Op3gramSeqLevenshtein => {
+                AnalysisType::new(BirthmarkType::OpKgramSeq(3), Algorithm::Levenshtein)
+            }
+            Analysis::Op3gramSeqLcs => {
+                AnalysisType::new(BirthmarkType::OpKgramSeq(3), Algorithm::Lcs)
+            }
+            Analysis::Op3gramFreqCosine => {
+                AnalysisType::new(BirthmarkType::OpKgramFreq(3), Algorithm::Cosine)
+            }
+            Analysis::Op3gramFreqEuclidean => {
+                AnalysisType::new(BirthmarkType::OpKgramFreq(3), Algorithm::Euclidean)
+            }
+            Analysis::Op3gramFreqWeightedjaccard => {
+                AnalysisType::new(BirthmarkType::OpKgramFreq(3), Algorithm::WeightedJaccard)
+            }
 
-            Analysis::Op4gramSetDice => AnalysisType::new(BirthmarkType::OpKgramSet(4), Algorithm::Dice),
-            Analysis::Op4gramSetJaccard => AnalysisType::new(BirthmarkType::OpKgramSet(4), Algorithm::Jaccard),
-            Analysis::Op4gramSetSimpson => AnalysisType::new(BirthmarkType::OpKgramSet(4), Algorithm::Simpson),
-            Analysis::Op4gramSeqLevenshtein => AnalysisType::new(BirthmarkType::OpKgramSeq(4), Algorithm::Levenshtein),
-            Analysis::Op4gramSeqLcs => AnalysisType::new(BirthmarkType::OpKgramSeq(4), Algorithm::Lcs),
-            Analysis::Op4gramFreqCosine => AnalysisType::new(BirthmarkType::OpKgramFreq(4), Algorithm::Cosine),
-            Analysis::Op4gramFreqEuclidean => AnalysisType::new(BirthmarkType::OpKgramFreq(4), Algorithm::Euclidean),
-            Analysis::Op4gramFreqWeightedjaccard => AnalysisType::new(BirthmarkType::OpKgramFreq(4), Algorithm::WeightedJaccard),
+            Analysis::Op4gramSetDice => {
+                AnalysisType::new(BirthmarkType::OpKgramSet(4), Algorithm::Dice)
+            }
+            Analysis::Op4gramSetJaccard => {
+                AnalysisType::new(BirthmarkType::OpKgramSet(4), Algorithm::Jaccard)
+            }
+            Analysis::Op4gramSetSimpson => {
+                AnalysisType::new(BirthmarkType::OpKgramSet(4), Algorithm::Simpson)
+            }
+            Analysis::Op4gramSeqLevenshtein => {
+                AnalysisType::new(BirthmarkType::OpKgramSeq(4), Algorithm::Levenshtein)
+            }
+            Analysis::Op4gramSeqLcs => {
+                AnalysisType::new(BirthmarkType::OpKgramSeq(4), Algorithm::Lcs)
+            }
+            Analysis::Op4gramFreqCosine => {
+                AnalysisType::new(BirthmarkType::OpKgramFreq(4), Algorithm::Cosine)
+            }
+            Analysis::Op4gramFreqEuclidean => {
+                AnalysisType::new(BirthmarkType::OpKgramFreq(4), Algorithm::Euclidean)
+            }
+            Analysis::Op4gramFreqWeightedjaccard => {
+                AnalysisType::new(BirthmarkType::OpKgramFreq(4), Algorithm::WeightedJaccard)
+            }
 
-            Analysis::Op5gramSetDice => AnalysisType::new(BirthmarkType::OpKgramSet(5), Algorithm::Dice),
-            Analysis::Op5gramSetJaccard => AnalysisType::new(BirthmarkType::OpKgramSet(5), Algorithm::Jaccard),
-            Analysis::Op5gramSetSimpson => AnalysisType::new(BirthmarkType::OpKgramSet(5), Algorithm::Simpson),
-            Analysis::Op5gramSeqLevenshtein => AnalysisType::new(BirthmarkType::OpKgramSeq(5), Algorithm::Levenshtein),
-            Analysis::Op5gramSeqLcs => AnalysisType::new(BirthmarkType::OpKgramSeq(5), Algorithm::Lcs),
-            Analysis::Op5gramFreqCosine => AnalysisType::new(BirthmarkType::OpKgramFreq(5), Algorithm::Cosine),
-            Analysis::Op5gramFreqEuclidean => AnalysisType::new(BirthmarkType::OpKgramFreq(5), Algorithm::Euclidean),
-            Analysis::Op5gramFreqWeightedjaccard => AnalysisType::new(BirthmarkType::OpKgramFreq(5), Algorithm::WeightedJaccard),
+            Analysis::Op5gramSetDice => {
+                AnalysisType::new(BirthmarkType::OpKgramSet(5), Algorithm::Dice)
+            }
+            Analysis::Op5gramSetJaccard => {
+                AnalysisType::new(BirthmarkType::OpKgramSet(5), Algorithm::Jaccard)
+            }
+            Analysis::Op5gramSetSimpson => {
+                AnalysisType::new(BirthmarkType::OpKgramSet(5), Algorithm::Simpson)
+            }
+            Analysis::Op5gramSeqLevenshtein => {
+                AnalysisType::new(BirthmarkType::OpKgramSeq(5), Algorithm::Levenshtein)
+            }
+            Analysis::Op5gramSeqLcs => {
+                AnalysisType::new(BirthmarkType::OpKgramSeq(5), Algorithm::Lcs)
+            }
+            Analysis::Op5gramFreqCosine => {
+                AnalysisType::new(BirthmarkType::OpKgramFreq(5), Algorithm::Cosine)
+            }
+            Analysis::Op5gramFreqEuclidean => {
+                AnalysisType::new(BirthmarkType::OpKgramFreq(5), Algorithm::Euclidean)
+            }
+            Analysis::Op5gramFreqWeightedjaccard => {
+                AnalysisType::new(BirthmarkType::OpKgramFreq(5), Algorithm::WeightedJaccard)
+            }
 
-            Analysis::Op6gramSetDice => AnalysisType::new(BirthmarkType::OpKgramSet(6), Algorithm::Dice),
-            Analysis::Op6gramSetJaccard => AnalysisType::new(BirthmarkType::OpKgramSet(6), Algorithm::Jaccard),
-            Analysis::Op6gramSetSimpson => AnalysisType::new(BirthmarkType::OpKgramSet(6), Algorithm::Simpson),
-            Analysis::Op6gramSeqLevenshtein => AnalysisType::new(BirthmarkType::OpKgramSeq(6), Algorithm::Levenshtein),
-            Analysis::Op6gramSeqLcs => AnalysisType::new(BirthmarkType::OpKgramSeq(6), Algorithm::Lcs),
-            Analysis::Op6gramFreqCosine => AnalysisType::new(BirthmarkType::OpKgramFreq(6), Algorithm::Cosine),
-            Analysis::Op6gramFreqEuclidean => AnalysisType::new(BirthmarkType::OpKgramFreq(6), Algorithm::Euclidean),
-            Analysis::Op6gramFreqWeightedjaccard => AnalysisType::new(BirthmarkType::OpKgramFreq(6), Algorithm::WeightedJaccard),
-
+            Analysis::Op6gramSetDice => {
+                AnalysisType::new(BirthmarkType::OpKgramSet(6), Algorithm::Dice)
+            }
+            Analysis::Op6gramSetJaccard => {
+                AnalysisType::new(BirthmarkType::OpKgramSet(6), Algorithm::Jaccard)
+            }
+            Analysis::Op6gramSetSimpson => {
+                AnalysisType::new(BirthmarkType::OpKgramSet(6), Algorithm::Simpson)
+            }
+            Analysis::Op6gramSeqLevenshtein => {
+                AnalysisType::new(BirthmarkType::OpKgramSeq(6), Algorithm::Levenshtein)
+            }
+            Analysis::Op6gramSeqLcs => {
+                AnalysisType::new(BirthmarkType::OpKgramSeq(6), Algorithm::Lcs)
+            }
+            Analysis::Op6gramFreqCosine => {
+                AnalysisType::new(BirthmarkType::OpKgramFreq(6), Algorithm::Cosine)
+            }
+            Analysis::Op6gramFreqEuclidean => {
+                AnalysisType::new(BirthmarkType::OpKgramFreq(6), Algorithm::Euclidean)
+            }
+            Analysis::Op6gramFreqWeightedjaccard => {
+                AnalysisType::new(BirthmarkType::OpKgramFreq(6), Algorithm::WeightedJaccard)
+            }
         }
     }
 }

--- a/cli/gencomp.rs
+++ b/cli/gencomp.rs
@@ -22,11 +22,11 @@ mod completions {
         let mut app = crate::cli::OinkieCommand::command();
         app.set_bin_name(appname);
 
-        generate_impl(Bash,       &mut app, outdir, format!("{appname}"));
-        generate_impl(Elvish,     &mut app, outdir, format!("{appname}.elv"));
-        generate_impl(Fish,       &mut app, outdir, format!("{appname}.fish"));
+        generate_impl(Bash, &mut app, outdir, appname.to_string());
+        generate_impl(Elvish, &mut app, outdir, format!("{appname}.elv"));
+        generate_impl(Fish, &mut app, outdir, format!("{appname}.fish"));
         generate_impl(PowerShell, &mut app, outdir, format!("{appname}.ps1"));
-        generate_impl(Zsh,        &mut app, outdir, format!("_{appname}"));
+        generate_impl(Zsh, &mut app, outdir, format!("_{appname}"));
     }
 }
 

--- a/cli/gencomp.rs
+++ b/cli/gencomp.rs
@@ -7,11 +7,12 @@ mod completions {
     use std::fs::File;
     use std::path::Path;
 
-    fn generate_impl(s: Shell, app: &mut Command, appname: &str, outdir: &Path, file: String) {
-        let destfile = outdir.join(file);
+    fn generate_impl(s: Shell, app: &mut Command, outdir: &Path, file: String) {
+        let destfile = outdir.join(format!("{s}")).join(file);
         std::fs::create_dir_all(destfile.parent().unwrap()).unwrap();
+        let bin_name = app.get_name().to_string();
         if let Ok(mut dest) = File::create(destfile) {
-            clap_complete::generate(s, app, appname, &mut dest);
+            clap_complete::generate(s, app, bin_name, &mut dest);
         }
     }
 
@@ -21,11 +22,11 @@ mod completions {
         let mut app = crate::cli::OinkieCommand::command();
         app.set_bin_name(appname);
 
-        generate_impl(Bash,       &mut app, appname, outdir, format!("bash/{appname}"));
-        generate_impl(Elvish,     &mut app, appname, outdir, format!("elvish/{appname}"));
-        generate_impl(Fish,       &mut app, appname, outdir, format!("fish/{appname}"));
-        generate_impl(PowerShell, &mut app, appname, outdir, format!("powershell/{appname}"));
-        generate_impl(Zsh, &mut app, appname, outdir, format!("zsh/_{appname}"));
+        generate_impl(Bash,       &mut app, outdir, format!("{appname}"));
+        generate_impl(Elvish,     &mut app, outdir, format!("{appname}.elv"));
+        generate_impl(Fish,       &mut app, outdir, format!("{appname}.fish"));
+        generate_impl(PowerShell, &mut app, outdir, format!("{appname}.ps1"));
+        generate_impl(Zsh,        &mut app, outdir, format!("_{appname}"));
     }
 }
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -264,7 +264,7 @@ fn perform(opts: cli::OinkieOpts) -> Result<Vec<Duration>> {
         #[cfg(debug_assertions)]
         GenComp => {
             let now = Instant::now();
-            gencomp::generate("oinkie", Path::new("completions"));
+            gencomp::generate("oinkie", Path::new("assets/completions"));
             Ok(vec![now.elapsed()])
         }
     }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -4,19 +4,19 @@ mod info;
 #[cfg(debug_assertions)]
 mod gencomp;
 
-use std::path::PathBuf;
-use std::io::Write;
-use std::time::Duration;
-use std::{path::Path, time::Instant};
 use clap::{Parser, ValueEnum};
 use indicatif::ProgressBar;
-use rayon::prelude::*;
-use oinkie::prelude::*;
 use oinkie::ghidra::Op;
+use oinkie::prelude::*;
+use rayon::prelude::*;
+use std::io::Write;
+use std::path::PathBuf;
+use std::time::Duration;
+use std::{path::Path, time::Instant};
 
-fn load<T>(path: PathBuf) -> Result<T> 
-where 
-    T: TryFrom<PathBuf, Error = Error>
+fn load<T>(path: PathBuf) -> Result<T>
+where
+    T: TryFrom<PathBuf, Error = Error>,
 {
     let s = Instant::now();
     let item: T = path.clone().try_into()?;
@@ -34,29 +34,47 @@ fn perform_run(opts: cli::RunOpts) -> Result<Vec<Duration>> {
     let aggregator = opts.aggregator();
     std::fs::create_dir_all(dest).map_err(|e| Error::Io(dest.to_path_buf(), e))?;
 
-    let results = opts.iter().enumerate().par_bridge()
-            .map(|(i, (path1, path2))| {
-        let dest_file = dest.join(format!("{i:05}.csv"));
-        if dest_file.exists() && opts.is_skip() {
-            log::info!("Similarity file for {:?} and {:?} already exists. Skipping comparison.", path1, path2);
-            pbar.inc(3);
-            read_result_file(&dest_file, i, path1, path2)
-        } else {
-            pbar.set_message(format!("Loading program from {:?}", path1.display()));
-            let mut p1: Program<Op> = load(path1.to_path_buf())?;
-            p1.set_json_path(path1.to_path_buf());
-            pbar.inc(1);
-            pbar.set_message(format!("Loading program from {:?}", path2.display()));
-            let mut p2: Program<Op> = load(path2.to_path_buf())?;
-            p2.set_json_path(path2.to_path_buf());
-            pbar.inc(1);
-            pbar.set_message(format!("Comparing two programs ({}/{})", i + 1, comparing_count));
-            let result = atype.comparator().compare_programs(&p1, &p2, aggregator)?;
-            pbar.inc(1);
-            result.store(&dest_file)?;
-            Ok(CompareResult::new(i, result.similarity(), p1.path().to_path_buf(), p2.path().to_path_buf(), result.duration()))
-        }
-    }).collect::<Vec<_>>();
+    let results = opts
+        .iter()
+        .enumerate()
+        .par_bridge()
+        .map(|(i, (path1, path2))| {
+            let dest_file = dest.join(format!("{i:05}.csv"));
+            if dest_file.exists() && opts.is_skip() {
+                log::info!(
+                    "Similarity file for {:?} and {:?} already exists. Skipping comparison.",
+                    path1,
+                    path2
+                );
+                pbar.inc(3);
+                read_result_file(&dest_file, i, path1, path2)
+            } else {
+                pbar.set_message(format!("Loading program from {:?}", path1.display()));
+                let mut p1: Program<Op> = load(path1.to_path_buf())?;
+                p1.set_json_path(path1.to_path_buf());
+                pbar.inc(1);
+                pbar.set_message(format!("Loading program from {:?}", path2.display()));
+                let mut p2: Program<Op> = load(path2.to_path_buf())?;
+                p2.set_json_path(path2.to_path_buf());
+                pbar.inc(1);
+                pbar.set_message(format!(
+                    "Comparing two programs ({}/{})",
+                    i + 1,
+                    comparing_count
+                ));
+                let result = atype.comparator().compare_programs(&p1, &p2, aggregator)?;
+                pbar.inc(1);
+                result.store(&dest_file)?;
+                Ok(CompareResult::new(
+                    i,
+                    result.similarity(),
+                    p1.path().to_path_buf(),
+                    p2.path().to_path_buf(),
+                    result.duration(),
+                ))
+            }
+        })
+        .collect::<Vec<_>>();
     pbar.finish();
     let results = Error::vec_result_to_result_vec(results)?;
     let dest_file = dest.join("results.csv");
@@ -66,9 +84,13 @@ fn perform_run(opts: cli::RunOpts) -> Result<Vec<Duration>> {
 /// Read the comparison result from the given CSV file and return a CompareResult struct.
 /// This function skips actual comparison and shorten the comparison time if the result file already exists.
 /// The CSV file is expected to have a line starting with "result," followed by the duration in nanoseconds and the similarity value, separated by commas.
-fn read_result_file(dest_path: &Path, index: usize, _path1: &Path, _path2: &Path) -> Result<CompareResult> {
-    let file = std::fs::File::open(dest_path)
-        .map_err(|e| Error::Io(dest_path.to_path_buf(), e))?;
+fn read_result_file(
+    dest_path: &Path,
+    index: usize,
+    _path1: &Path,
+    _path2: &Path,
+) -> Result<CompareResult> {
+    let file = std::fs::File::open(dest_path).map_err(|e| Error::Io(dest_path.to_path_buf(), e))?;
     let mut reader = csv::ReaderBuilder::new()
         .flexible(true)
         .has_headers(false)
@@ -84,33 +106,59 @@ fn read_result_file(dest_path: &Path, index: usize, _path1: &Path, _path2: &Path
         match record.get(0) {
             Some("result") => {
                 if record.len() < 3 {
-                    return Err(Error::Parse(format!("Invalid result line format in {}", dest_path.display())));
+                    return Err(Error::Parse(format!(
+                        "Invalid result line format in {}",
+                        dest_path.display()
+                    )));
                 }
-                duration_nanos = record[1].parse()
+                duration_nanos = record[1]
+                    .parse()
                     .map_err(|e| Error::ParseInt(record[1].to_string(), e))?;
-                similarity = record[2].parse()
-                    .map_err(|e| Error::Parse(format!("Failed to parse similarity value in {}: {}", dest_path.display(), e)))?;
-            },
-            Some("left") => if let Some(s) = record.get(3) {
-                original_path1 = PathBuf::from(s);
-            },
-            Some("right") => if let Some(s) = record.get(3) {
-                original_path2 = PathBuf::from(s);
-            },
-            _ => {},
+                similarity = record[2].parse().map_err(|e| {
+                    Error::Parse(format!(
+                        "Failed to parse similarity value in {}: {}",
+                        dest_path.display(),
+                        e
+                    ))
+                })?;
+            }
+            Some("left") => {
+                if let Some(s) = record.get(3) {
+                    original_path1 = PathBuf::from(s);
+                }
+            }
+            Some("right") => {
+                if let Some(s) = record.get(3) {
+                    original_path2 = PathBuf::from(s);
+                }
+            }
+            _ => {}
         }
     }
 
     if original_path1.as_os_str().is_empty() || original_path2.as_os_str().is_empty() {
-        return Err(Error::Parse(format!("Birthmark paths not found in {}", dest_path.display())));
+        return Err(Error::Parse(format!(
+            "Birthmark paths not found in {}",
+            dest_path.display()
+        )));
     }
 
-    Ok(CompareResult::new(index, similarity, original_path1, original_path2, Duration::from_nanos(duration_nanos)))
+    Ok(CompareResult::new(
+        index,
+        similarity,
+        original_path1,
+        original_path2,
+        Duration::from_nanos(duration_nanos),
+    ))
 }
 
 fn new_progress_bar(len: usize) -> ProgressBar {
-    ProgressBar::new(len as u64)
-        .with_style(indicatif::ProgressStyle::with_template("[{elapsed_precise}/({per_sec})] {bar:40} {pos:>7}/{len:7} {msg}").unwrap())
+    ProgressBar::new(len as u64).with_style(
+        indicatif::ProgressStyle::with_template(
+            "[{elapsed_precise}/({per_sec})] {bar:40} {pos:>7}/{len:7} {msg}",
+        )
+        .unwrap(),
+    )
 }
 
 fn perform_compare(opts: cli::CompareOpts) -> Result<Vec<Duration>> {
@@ -121,37 +169,76 @@ fn perform_compare(opts: cli::CompareOpts) -> Result<Vec<Duration>> {
     let pbar = new_progress_bar(comparing_count * 3);
     let aggregator = opts.aggregator();
     std::fs::create_dir_all(dest).map_err(|e| Error::Io(dest.to_path_buf(), e))?;
-    let r = opts.iter().enumerate().par_bridge()
-        .map(|(i, (path1, path2))| compare_impl((i, (path1, path2)), &comparator, dest, &pbar, comparing_count, opts.is_skip(), aggregator))
+    let r = opts
+        .iter()
+        .enumerate()
+        .par_bridge()
+        .map(|(i, (path1, path2))| {
+            compare_impl(
+                (i, (path1, path2)),
+                &comparator,
+                dest,
+                &pbar,
+                comparing_count,
+                opts.is_skip(),
+                aggregator,
+            )
+        })
         .collect::<Vec<_>>();
     pbar.finish();
     let result_file = dest.join("results.csv");
-    Error::vec_result_to_result_vec(r)
-        .and_then(|r| store_and_get_durations(r, &result_file, start))
-    
+    Error::vec_result_to_result_vec(r).and_then(|r| store_and_get_durations(r, &result_file, start))
 }
 
-pub(crate) fn store_and_get_durations(results: Vec<CompareResult>, destcsv: &Path, start: Instant) -> Result<Vec<Duration>> {
-    let mut file = std::fs::File::create(destcsv)
-        .map_err(|e| Error::Io(destcsv.to_path_buf(), e))?;
-    let ritems = results.into_iter().map(|r| {
-        let csv = r.to_csv();
-        match writeln!(file, "{}", csv) {
-            Ok(_) => Ok(r.duration),
-            Err(e) => Err(Error::Io(destcsv.to_path_buf(), e)),
-        }
-    }).collect::<Vec<_>>();
+pub(crate) fn store_and_get_durations(
+    results: Vec<CompareResult>,
+    destcsv: &Path,
+    start: Instant,
+) -> Result<Vec<Duration>> {
+    let mut file =
+        std::fs::File::create(destcsv).map_err(|e| Error::Io(destcsv.to_path_buf(), e))?;
+    let ritems = results
+        .into_iter()
+        .map(|r| {
+            let csv = r.to_csv();
+            match writeln!(file, "{}", csv) {
+                Ok(_) => Ok(r.duration),
+                Err(e) => Err(Error::Io(destcsv.to_path_buf(), e)),
+            }
+        })
+        .collect::<Vec<_>>();
     let duration = start.elapsed();
-    let _ = writeln!(file, "total duration,{},{}", duration.as_nanos(), format_duration(duration));
+    let _ = writeln!(
+        file,
+        "total duration,{},{}",
+        duration.as_nanos(),
+        format_duration(duration)
+    );
     Error::vec_result_to_result_vec(ritems)
 }
 
-fn compare_impl(tuple: (usize, (&Path, &Path)), comparator: &Comparator, dest: &Path, pbar: &ProgressBar, comparing_count: usize, skip: bool, aggregator: &Aggregator) -> Result<CompareResult> {
+fn compare_impl(
+    tuple: (usize, (&Path, &Path)),
+    comparator: &Comparator,
+    dest: &Path,
+    pbar: &ProgressBar,
+    comparing_count: usize,
+    skip: bool,
+    aggregator: &Aggregator,
+) -> Result<CompareResult> {
     let (i, (path1, path2)) = tuple;
     let dest_file = dest.join(format!("{i:05}.csv"));
-    log::info!("compare_impl(dest: {} (exists: {}), skip: {skip})", dest_file.display(), dest_file.exists());
+    log::info!(
+        "compare_impl(dest: {} (exists: {}), skip: {skip})",
+        dest_file.display(),
+        dest_file.exists()
+    );
     if dest_file.exists() && skip {
-        log::info!("Similarity file for {:?} and {:?} already exists. Skipping comparison.", path1, path2);
+        log::info!(
+            "Similarity file for {:?} and {:?} already exists. Skipping comparison.",
+            path1,
+            path2
+        );
         pbar.inc(3);
         read_result_file(&dest_file, i, path1, path2)
     } else {
@@ -165,35 +252,63 @@ fn compare_impl(tuple: (usize, (&Path, &Path)), comparator: &Comparator, dest: &
         let mut b2: Birthmark = load(path2.to_path_buf())?;
         b2.set_json_path(path2.to_path_buf());
         pbar.inc(1);
-        log::info!("Comparing birthmarks (len: {} x {}) progress: {}/{comparing_count}", b1.len(), b2.len(), i + 1);
-        pbar.set_message(format!("Comparing birthmarks (len: {} x {}) progress: {}/{comparing_count}", b1.len(), b2.len(), i + 1));
+        log::info!(
+            "Comparing birthmarks (len: {} x {}) progress: {}/{comparing_count}",
+            b1.len(),
+            b2.len(),
+            i + 1
+        );
+        pbar.set_message(format!(
+            "Comparing birthmarks (len: {} x {}) progress: {}/{comparing_count}",
+            b1.len(),
+            b2.len(),
+            i + 1
+        ));
         let result = comparator.compare_birthmarks(&b1, &b2, aggregator)?;
         pbar.inc(1);
         result.store(&dest_file)?;
-        Ok(CompareResult::new(i, result.similarity(), b1.path().to_path_buf(), b2.path().to_path_buf(), result.duration()))
+        Ok(CompareResult::new(
+            i,
+            result.similarity(),
+            b1.path().to_path_buf(),
+            b2.path().to_path_buf(),
+            result.duration(),
+        ))
     }
 }
 
 fn perform_extract(opts: cli::ExtractOpts) -> Result<Vec<Duration>> {
     let dest = opts.dest();
     let pb = ProgressBar::new(opts.len() as u64)
-            .with_style(indicatif::ProgressStyle::with_template("[{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg}").unwrap())
-            .with_message("Extracting birthmarks...");
-    std::fs::create_dir_all(dest)
-        .map_err(|e| Error::Io(dest.to_path_buf(), e))?;
+        .with_style(
+            indicatif::ProgressStyle::with_template(
+                "[{elapsed_precise}] {bar:40.cyan/blue} {pos:>7}/{len:7} {msg}",
+            )
+            .unwrap(),
+        )
+        .with_message("Extracting birthmarks...");
+    std::fs::create_dir_all(dest).map_err(|e| Error::Io(dest.to_path_buf(), e))?;
     let extractor = opts.extractor();
     let start = Instant::now();
-    let r = opts.iter().par_bridge().map(|path| {
-        let e1 = Instant::now();
-        let r = match extract_impl(path, dest, &extractor, opts.is_skip()) {
-            Ok(_) => Ok(e1.elapsed()),
-            Err(e) => Err(e),
-        };
-        pb.inc(1);
-        r
-    }).collect::<Result<Vec<_>>>();
+    let r = opts
+        .iter()
+        .par_bridge()
+        .map(|path| {
+            let e1 = Instant::now();
+            let r = match extract_impl(path, dest, &extractor, opts.is_skip()) {
+                Ok(_) => Ok(e1.elapsed()),
+                Err(e) => Err(e),
+            };
+            pb.inc(1);
+            r
+        })
+        .collect::<Result<Vec<_>>>();
     let duration = start.elapsed();
-    println!("Extraction completed in {} nsec ({})", duration.as_nanos(), format_duration(duration));
+    println!(
+        "Extraction completed in {} nsec ({})",
+        duration.as_nanos(),
+        format_duration(duration)
+    );
     r
 }
 
@@ -201,15 +316,17 @@ fn extract_impl(path: &Path, dest: &Path, extractor: &Extractor, skip: bool) -> 
     let file_name = oinkie::extractor::dest_file_name(path)?;
     let dest_path = dest.join(file_name);
     if dest_path.exists() && skip {
-        log::info!("Birthmark for {:?} already exists. Skipping extraction.", path);
+        log::info!(
+            "Birthmark for {:?} already exists. Skipping extraction.",
+            path
+        );
         return Ok(());
     }
     let p: Program<Op> = path.try_into()?;
     let birthmarks = extractor.extract_each(&p)?;
-    let json = serde_json::to_string_pretty(&birthmarks)
-        .map_err(|e| Error::Json(dest_path.clone(), e))?;
-    std::fs::write(&dest_path, json)
-        .map_err(|e| Error::Io(dest_path.clone(), e))?;
+    let json =
+        serde_json::to_string_pretty(&birthmarks).map_err(|e| Error::Json(dest_path.clone(), e))?;
+    std::fs::write(&dest_path, json).map_err(|e| Error::Io(dest_path.clone(), e))?;
     Ok(())
 }
 
@@ -218,16 +335,18 @@ fn format_duration(dur: Duration) -> String {
     let mm = total_ms / 60000;
     let ss = (total_ms % 60000) / 1000;
     let sss = total_ms % 1000;
-    
+
     format!("{:02}:{:02}:{:03}", mm, ss, sss)
 }
 
 fn perform_info() -> Result<Vec<Duration>> {
     let now = Instant::now();
     println!("=========== Oinkie Info ============");
-    println!("Oinkie is a tool for detecting the code theft with Ghidra P-code as birthmarks.
+    println!(
+        "Oinkie is a tool for detecting the code theft with Ghidra P-code as birthmarks.
 The birthmark is a unique characteristic of a program that can be used to identify it.
-Oinkie extracts birthmarks from given codes and compares them to calculate the similarities.");
+Oinkie extracts birthmarks from given codes and compares them to calculate the similarities."
+    );
     println!("============ Birthmarks =============");
     cli::BType::value_variants().iter().for_each(|b| {
         let pv = b.to_possible_value().unwrap();
@@ -243,7 +362,9 @@ Oinkie extracts birthmarks from given codes and compares them to calculate the s
 
 fn validate_extract_opts(opts: cli::ExtractOpts) -> Result<cli::ExtractOpts> {
     if opts.is_empty() {
-        return Err(Error::Parse("No valid files to extract birthmarks from.".to_string()));
+        return Err(Error::Parse(
+            "No valid files to extract birthmarks from.".to_string(),
+        ));
     }
     Ok(opts)
 }
@@ -256,8 +377,7 @@ fn perform(opts: cli::OinkieOpts) -> Result<Vec<Duration>> {
     match opts.command {
         Run(opts) => perform_run(opts),
         Compare(opts) => perform_compare(opts),
-        Extract(opts) => validate_extract_opts(opts)
-            .and_then(perform_extract),
+        Extract(opts) => validate_extract_opts(opts).and_then(perform_extract),
         Reaggregate(opts) => reaggregator::perform(opts),
         Lift(opts) => perform_lift(opts),
         Info => perform_info(),
@@ -273,10 +393,14 @@ fn perform(opts: cli::OinkieOpts) -> Result<Vec<Duration>> {
 fn perform_lift(opts: cli::LiftOpts) -> Result<Vec<Duration>> {
     let dest = opts.dest();
     let pb = ProgressBar::new(opts.len() as u64)
-            .with_style(indicatif::ProgressStyle::with_template("[{elapsed_precise}] {bar:40.magenta/blue} {pos:>7}/{len:7} {msg}").unwrap())
-            .with_message("Lifting binaries...");
-    std::fs::create_dir_all(dest)
-        .map_err(|e| Error::Io(dest.to_path_buf(), e))?;
+        .with_style(
+            indicatif::ProgressStyle::with_template(
+                "[{elapsed_precise}] {bar:40.magenta/blue} {pos:>7}/{len:7} {msg}",
+            )
+            .unwrap(),
+        )
+        .with_message("Lifting binaries...");
+    std::fs::create_dir_all(dest).map_err(|e| Error::Io(dest.to_path_buf(), e))?;
 
     let lifter: Box<dyn Lifter + Sync> = LifterBuilder::new(opts.lifter_type())
         .home(opts.home().map(|p| p.to_path_buf()))
@@ -285,19 +409,33 @@ fn perform_lift(opts: cli::LiftOpts) -> Result<Vec<Duration>> {
         .build()?;
 
     let start = Instant::now();
-    let r = opts.iter().par_bridge().map(|path| {
-        let e1 = Instant::now();
-        let dest_file = dest.join(format!("{}.json", path.file_name().unwrap().to_str().unwrap()));
-        if dest_file.exists() && opts.is_skip() {
-            log::info!("Lifted JSON for {:?} already exists. Skipping lifting.", path);
-            return Ok(e1.elapsed());
-        }
-        lifter.lift(path, &dest_file)?;
-        pb.inc(1);
-        Ok(e1.elapsed())
-    }).collect::<Result<Vec<_>>>();
+    let r = opts
+        .iter()
+        .par_bridge()
+        .map(|path| {
+            let e1 = Instant::now();
+            let dest_file = dest.join(format!(
+                "{}.json",
+                path.file_name().unwrap().to_str().unwrap()
+            ));
+            if dest_file.exists() && opts.is_skip() {
+                log::info!(
+                    "Lifted JSON for {:?} already exists. Skipping lifting.",
+                    path
+                );
+                return Ok(e1.elapsed());
+            }
+            lifter.lift(path, &dest_file)?;
+            pb.inc(1);
+            Ok(e1.elapsed())
+        })
+        .collect::<Result<Vec<_>>>();
     let duration = start.elapsed();
-    println!("Lifting completed in {} nsec ({})", duration.as_nanos(), format_duration(duration));
+    println!(
+        "Lifting completed in {} nsec ({})",
+        duration.as_nanos(),
+        format_duration(duration)
+    );
     r
 }
 
@@ -310,15 +448,31 @@ pub struct CompareResult {
 }
 
 impl CompareResult {
-    pub fn new(index: usize, similarity: f64, path1: PathBuf, path2: PathBuf, duration: std::time::Duration) -> Self {
-        Self { index, similarity, path1, path2, duration }
+    pub fn new(
+        index: usize,
+        similarity: f64,
+        path1: PathBuf,
+        path2: PathBuf,
+        duration: std::time::Duration,
+    ) -> Self {
+        Self {
+            index,
+            similarity,
+            path1,
+            path2,
+            duration,
+        }
     }
 
     pub fn to_csv(&self) -> String {
-        format!("{},{},{},{},{}", self.index, self.similarity,
+        format!(
+            "{},{},{},{},{}",
+            self.index,
+            self.similarity,
             escape_csv_string(&self.path1.display().to_string()),
             escape_csv_string(&self.path2.display().to_string()),
-            self.duration.as_nanos())
+            self.duration.as_nanos()
+        )
     }
 
     pub fn parse(line: &str) -> Result<Self> {
@@ -327,21 +481,40 @@ impl CompareResult {
             .has_headers(false)
             .from_reader(line.as_bytes());
         let record = match reader.records().next() {
-            Some(r) => r.map_err(|e| Error::Parse(format!("Invalid compare result line format: {e}")))?,
-            None => return Err(Error::Parse(format!("Invalid compare result line format: {}", line))),
+            Some(r) => {
+                r.map_err(|e| Error::Parse(format!("Invalid compare result line format: {e}")))?
+            }
+            None => {
+                return Err(Error::Parse(format!(
+                    "Invalid compare result line format: {}",
+                    line
+                )));
+            }
         };
         if record.len() < 5 {
-            return Err(Error::Parse(format!("Invalid compare result line format: {}", line)));
+            return Err(Error::Parse(format!(
+                "Invalid compare result line format: {}",
+                line
+            )));
         }
-        let index: usize = record[0].parse()
+        let index: usize = record[0]
+            .parse()
             .map_err(|e| Error::ParseInt(record[0].to_string(), e))?;
-        let similarity: f64 = record[1].parse()
+        let similarity: f64 = record[1]
+            .parse()
             .map_err(|e| Error::Parse(format!("Failed to parse similarity value: {}", e)))?;
         let path1 = PathBuf::from(&record[2]);
         let path2 = PathBuf::from(&record[3]);
-        let duration_nanos: u64 = record[4].parse()
+        let duration_nanos: u64 = record[4]
+            .parse()
             .map_err(|e| Error::ParseInt(record[4].to_string(), e))?;
-        Ok(Self::new(index, similarity, path1, path2, Duration::from_nanos(duration_nanos)))
+        Ok(Self::new(
+            index,
+            similarity,
+            path1,
+            path2,
+            Duration::from_nanos(duration_nanos),
+        ))
     }
 }
 
@@ -355,18 +528,20 @@ fn main() {
     let args = std::env::args().collect::<Vec<_>>();
     let status_code = match rs_main(args) {
         Err(Error::Clap(e)) => {
-            if e.kind() == clap::error::ErrorKind::DisplayHelp || e.kind() == clap::error::ErrorKind::DisplayVersion {
+            if e.kind() == clap::error::ErrorKind::DisplayHelp
+                || e.kind() == clap::error::ErrorKind::DisplayVersion
+            {
                 println!("{}", e.render().ansi());
                 0
             } else {
                 eprintln!("Error: {}", e);
                 1
             }
-        },
+        }
         Err(e) => {
             eprintln!("Error: {}", e);
             2
-        },
+        }
         Ok(_) => 0,
     };
     std::process::exit(status_code);
@@ -397,7 +572,9 @@ mod tests {
 
     #[test]
     fn test_parse_lift_opts() {
-        let args = vec!["oinkie", "lift", "--home", "/ghidra", "--dest", "out", "--skip", "bin1", "bin2"];
+        let args = vec![
+            "oinkie", "lift", "--home", "/ghidra", "--dest", "out", "--skip", "bin1", "bin2",
+        ];
         let opts = cli::OinkieOpts::try_parse_from(args).unwrap();
         if let cli::OinkieCommand::Lift(lift_opts) = opts.command {
             assert_eq!(lift_opts.home(), Some(Path::new("/ghidra")));
@@ -414,13 +591,15 @@ mod tests {
 
     #[test]
     fn test_compare_result_roundtrip_with_comma_in_path() {
-        let original = CompareResult::new(3, 0.5,
+        let original = CompareResult::new(
+            3,
+            0.5,
             PathBuf::from("dir,with,commas/a.json"),
             PathBuf::from("dir/\"quoted\"/b.json"),
-            Duration::from_nanos(123));
+            Duration::from_nanos(123),
+        );
         let line = original.to_csv();
-        let parsed = CompareResult::parse(&line)
-            .expect("Failed to parse escaped compare result");
+        let parsed = CompareResult::parse(&line).expect("Failed to parse escaped compare result");
         assert_eq!(parsed.index, original.index);
         assert_eq!(parsed.path1, original.path1);
         assert_eq!(parsed.path2, original.path2);
@@ -430,12 +609,17 @@ mod tests {
     #[test]
     fn test_parse_compare_result() {
         let line = "21,0.9920060729565723,birthmarks/experiment0/bzip2-1.0.4_a83e5e24.json,birthmarks/experiment0/bzip2-1.0.8_981e34d2.json,515602167";
-        let cr = CompareResult::parse(line)
-            .expect("Failed to parse compare result");
+        let cr = CompareResult::parse(line).expect("Failed to parse compare result");
         assert_eq!(cr.index, 21);
         assert!((cr.similarity - 0.9920060729565723).abs() < 1e-10);
-        assert_eq!(cr.path1, PathBuf::from("birthmarks/experiment0/bzip2-1.0.4_a83e5e24.json"));
-        assert_eq!(cr.path2, PathBuf::from("birthmarks/experiment0/bzip2-1.0.8_981e34d2.json"));
+        assert_eq!(
+            cr.path1,
+            PathBuf::from("birthmarks/experiment0/bzip2-1.0.4_a83e5e24.json")
+        );
+        assert_eq!(
+            cr.path2,
+            PathBuf::from("birthmarks/experiment0/bzip2-1.0.8_981e34d2.json")
+        );
         assert_eq!(cr.duration.as_nanos(), 515602167);
     }
 }

--- a/cli/reaggregator.rs
+++ b/cli/reaggregator.rs
@@ -1,6 +1,6 @@
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
-use std::io::{BufRead, BufReader};
 
 use crate::{CompareResult, cli};
 use ndarray::Array2;
@@ -11,27 +11,36 @@ pub(crate) fn perform(opts: cli::ReaggregateOpts) -> Result<Vec<Duration>> {
     let score_dir = opts.score_directory();
     let crs = load_results(score_dir)?;
     log::info!("read the previous results {:?}", start.elapsed());
-    let results = crs.iter()
+    let results = crs
+        .iter()
         .map(|cr| reaggregate(cr, score_dir, opts.aggregator()))
         .collect::<Vec<_>>();
     let results = Error::vec_result_to_result_vec(results)?;
-    let cresults = results.into_iter()
-        .map(|(cr, _)| cr).collect::<Vec<_>>();
+    let cresults = results.into_iter().map(|(cr, _)| cr).collect::<Vec<_>>();
     super::store_and_get_durations(cresults, opts.dest_file(), start)
 }
 
-fn reaggregate(cr: &CompareResult, score_dir: &Path, aggregator: &Aggregator) -> Result<(CompareResult, Duration)> {
+fn reaggregate(
+    cr: &CompareResult,
+    score_dir: &Path,
+    aggregator: &Aggregator,
+) -> Result<(CompareResult, Duration)> {
     let start = std::time::Instant::now();
     match load_comparison_file(cr.index, score_dir) {
         Ok((matrix, p1, p2, duration)) => {
             let (rows, cols) = matrix.dim();
             let size = std::cmp::max(rows, cols);
             let mut square_matrix = Array2::zeros((size, size));
-            square_matrix.slice_mut(ndarray::s![0..rows, 0..cols]).assign(&matrix);
+            square_matrix
+                .slice_mut(ndarray::s![0..rows, 0..cols])
+                .assign(&matrix);
             let similarities = aggregator.aggregate(&square_matrix)?;
             let similarity = similarities.iter().sum::<f64>() / similarities.len() as f64;
-            Ok((CompareResult::new(cr.index, similarity, p1, p2, duration), start.elapsed()))
-        },
+            Ok((
+                CompareResult::new(cr.index, similarity, p1, p2, duration),
+                start.elapsed(),
+            ))
+        }
         Err(e) => Err(e),
     }
 }
@@ -46,15 +55,23 @@ fn load_results(score_dir: &Path) -> Result<Vec<CompareResult>> {
 
 fn scan_directory_for_results(score_dir: &Path) -> Result<Vec<CompareResult>> {
     let mut results = Vec::new();
-    for entry in std::fs::read_dir(score_dir)
-                .map_err(|e| Error::Io(score_dir.to_path_buf(), e))? {
+    for entry in std::fs::read_dir(score_dir).map_err(|e| Error::Io(score_dir.to_path_buf(), e))? {
         let entry = entry.map_err(|e| Error::Io(score_dir.to_path_buf(), e))?;
         let path = entry.path();
         if path.extension().and_then(|s| s.to_str()) == Some("csv")
-                && let Some(stem) = path.file_stem().and_then(|s| s.to_str())
-                && stem.chars().all(|c| c.is_numeric()) {
-            let index = stem.parse::<usize>().map_err(|e| Error::ParseInt(stem.to_string(), e))?;
-            let cr = CompareResult::new(index, 0.0, PathBuf::new(), PathBuf::new(), Duration::from_secs(0));
+            && let Some(stem) = path.file_stem().and_then(|s| s.to_str())
+            && stem.chars().all(|c| c.is_numeric())
+        {
+            let index = stem
+                .parse::<usize>()
+                .map_err(|e| Error::ParseInt(stem.to_string(), e))?;
+            let cr = CompareResult::new(
+                index,
+                0.0,
+                PathBuf::new(),
+                PathBuf::new(),
+                Duration::from_secs(0),
+            );
             results.push(cr);
         }
     }
@@ -63,8 +80,8 @@ fn scan_directory_for_results(score_dir: &Path) -> Result<Vec<CompareResult>> {
 
 fn load_results_impl(score_dir: &Path) -> Result<Vec<CompareResult>> {
     let result_file = score_dir.join("results.csv");
-    let mut reader = std::fs::File::open(result_file.clone())
-        .map_err(|e| Error::Io(result_file.clone(), e))?;
+    let mut reader =
+        std::fs::File::open(result_file.clone()).map_err(|e| Error::Io(result_file.clone(), e))?;
     let mut results = Vec::new();
     let bufr = BufReader::new(&mut reader);
     for line in bufr.lines().map_while(|r| r.ok()) {
@@ -79,7 +96,10 @@ fn load_results_impl(score_dir: &Path) -> Result<Vec<CompareResult>> {
     Ok(results)
 }
 
-fn load_comparison_file(index: usize, score_dir: &Path) -> Result<(Array2<f64>, PathBuf, PathBuf, Duration)> {
+fn load_comparison_file(
+    index: usize,
+    score_dir: &Path,
+) -> Result<(Array2<f64>, PathBuf, PathBuf, Duration)> {
     let file_name = format!("{index:05}.csv");
     let path = score_dir.join(file_name);
     let r = load_comparison(&path);
@@ -105,28 +125,41 @@ fn load_comparison<P: AsRef<Path>>(path: P) -> Result<(Array2<f64>, PathBuf, Pat
         let record = result.map_err(Error::Csv)?;
         let prefix = record.get(0).unwrap_or("");
         match prefix {
-            "result" => if let Some(d_str) = record.get(1) {
-                let nanos = d_str.parse::<u64>().unwrap_or(0);
-                duration = Duration::from_nanos(nanos);
-            },
-            "left" => if let Some(s) = record.get(3) {
-                path1 = PathBuf::from(s);
-            },
-            "right" => if let Some(s) = record.get(3) {
-                path2 = PathBuf::from(s);
-            },
+            "result" => {
+                if let Some(d_str) = record.get(1) {
+                    let nanos = d_str.parse::<u64>().unwrap_or(0);
+                    duration = Duration::from_nanos(nanos);
+                }
+            }
+            "left" => {
+                if let Some(s) = record.get(3) {
+                    path1 = PathBuf::from(s);
+                }
+            }
+            "right" => {
+                if let Some(s) = record.get(3) {
+                    path2 = PathBuf::from(s);
+                }
+            }
             "matrix" => col_names = record.iter().skip(2).map(|s| s.to_string()).collect(),
             _ if prefix.chars().all(|c| c.is_numeric()) && !prefix.is_empty() => {
                 rows.push(record.get(1).unwrap_or("").to_string());
                 for value in record.iter().skip(2) {
-                    items.push(value.parse::<f64>().map_err(|e| Error::ParseFloat(value.to_string(), e))?);
+                    items.push(
+                        value
+                            .parse::<f64>()
+                            .map_err(|e| Error::ParseFloat(value.to_string(), e))?,
+                    );
                 }
-            },
+            }
             _ => continue,
         }
     }
     if col_names.is_empty() || rows.is_empty() {
-        Err(Error::Parse(format!("Valid matrix data not found in {}", path.as_ref().display())))
+        Err(Error::Parse(format!(
+            "Valid matrix data not found in {}",
+            path.as_ref().display()
+        )))
     } else {
         let matrix = Array2::from_shape_vec((rows.len(), col_names.len()), items)
             .map_err(Error::ShapeError)?;
@@ -137,6 +170,5 @@ fn load_comparison<P: AsRef<Path>>(path: P) -> Result<(Array2<f64>, PathBuf, Pat
 #[cfg(test)]
 mod tests {
     #[test]
-    fn test_load_comparison() {
-    }
+    fn test_load_comparison() {}
 }

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -1,9 +1,12 @@
-use std::{fmt::Display, path::{Path, PathBuf}};
+use std::{
+    fmt::Display,
+    path::{Path, PathBuf},
+};
 
+use crate::prelude::*;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::time::Duration;
-use rustc_hash::{FxHashMap, FxHashSet};
-use crate::prelude::*;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum BirthmarkType {
@@ -55,10 +58,8 @@ impl TryFrom<PathBuf> for Birthmark {
     type Error = Error;
 
     fn try_from(path: PathBuf) -> Result<Self> {
-        let file = std::fs::File::open(&path)
-            .map_err(|e| Error::Io(path.clone(), e))?;
-        serde_json::from_reader(file)
-            .map_err(|e| Error::Json(path, e))
+        let file = std::fs::File::open(&path).map_err(|e| Error::Io(path.clone(), e))?;
+        serde_json::from_reader(file).map_err(|e| Error::Json(path, e))
     }
 }
 
@@ -78,7 +79,7 @@ pub struct Metadata {
     /// Represents the time taken to extract the birthmark, measured in nanoseconds for precision.
     #[serde(
         serialize_with = "serialize_duration_as_nanos",
-        deserialize_with = "deserialize_duration_from_nanos",
+        deserialize_with = "deserialize_duration_from_nanos"
     )]
     pub duration: std::time::Duration,
     pub birthmark_type: BirthmarkType,
@@ -86,10 +87,14 @@ pub struct Metadata {
 
 impl Metadata {
     pub fn csv_info(&self) -> String {
-        format!("birthmark,{},{},{},{},{}",
+        format!(
+            "birthmark,{},{},{},{},{}",
             crate::compare::escape_csv_string(&self.file_name),
             crate::compare::escape_csv_string(&self.path.display().to_string()),
-            self.birthmark_type, self.extracted_at.to_rfc3339(), self.duration.as_nanos())
+            self.birthmark_type,
+            self.extracted_at.to_rfc3339(),
+            self.duration.as_nanos()
+        )
     }
 
     pub fn parse(line: &str) -> Result<Self> {
@@ -101,7 +106,10 @@ impl Metadata {
             let record = result.map_err(Error::Csv)?;
             let items = record.iter().collect::<Vec<_>>();
             if items.len() != 6 {
-                return Err(Error::Parse(format!("expected 6 items in metadata, got {}", items.len())));
+                return Err(Error::Parse(format!(
+                    "expected 6 items in metadata, got {}",
+                    items.len()
+                )));
             }
             let file_name = items[1].to_string();
             let path = PathBuf::from(items[2]);
@@ -109,7 +117,8 @@ impl Metadata {
             let extracted_at = chrono::DateTime::parse_from_rfc3339(items[4])
                 .map_err(|e| Error::Parse(format!("invalid extracted_at datetime: {}", e)))?
                 .with_timezone(&chrono::Utc);
-            let duration = items[5].parse::<u64>()
+            let duration = items[5]
+                .parse::<u64>()
                 .map_err(|e| Error::Parse(format!("invalid duration: {}", e)))?;
             Ok(Self {
                 file_name,
@@ -124,7 +133,10 @@ impl Metadata {
     }
 }
 
-fn serialize_duration_as_nanos<S>(duration: &std::time::Duration, serializer: S) -> std::result::Result<S::Ok, S::Error>
+fn serialize_duration_as_nanos<S>(
+    duration: &std::time::Duration,
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -150,8 +162,16 @@ pub struct Birthmark {
 
 impl CsvInfo for Birthmark {
     fn csv_info(&self) -> String {
-        let json_path = self.json_path.as_ref().map(|p| p.display().to_string()).unwrap_or_default();
-        format!("{},{}", self.metadata.csv_info(), crate::compare::escape_csv_string(&json_path))
+        let json_path = self
+            .json_path
+            .as_ref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_default();
+        format!(
+            "{},{}",
+            self.metadata.csv_info(),
+            crate::compare::escape_csv_string(&json_path)
+        )
     }
 
     fn names(&self) -> Vec<String> {
@@ -260,9 +280,15 @@ impl Data {
             Data::Freq(freq) => Box::new(freq.keys().map(|s| s.as_str())),
             Data::Seq(seq) => Box::new(seq.iter().map(|s| s.as_str())),
             Data::Set(set) => Box::new(set.iter().map(|s| s.as_str())),
-            Data::KgramSeq(seq) => Box::new(seq.iter().flat_map(|k| k.0.iter().map(|s| s.as_str()))),
-            Data::KgramFreq(freq) => Box::new(freq.keys().flat_map(|k| k.0.iter().map(|s| s.as_str()))),
-            Data::KgramSet(set) => Box::new(set.iter().flat_map(|k| k.0.iter().map(|s| s.as_str()))),
+            Data::KgramSeq(seq) => {
+                Box::new(seq.iter().flat_map(|k| k.0.iter().map(|s| s.as_str())))
+            }
+            Data::KgramFreq(freq) => {
+                Box::new(freq.keys().flat_map(|k| k.0.iter().map(|s| s.as_str())))
+            }
+            Data::KgramSet(set) => {
+                Box::new(set.iter().flat_map(|k| k.0.iter().map(|s| s.as_str())))
+            }
         }
     }
 
@@ -314,21 +340,29 @@ impl TryFrom<String> for AnalysisType {
         } else if s == "op-set-dice" {
             Ok(AnalysisType::new(BirthmarkType::OpSet, Algorithm::Dice))
         } else if s == "op-freq-euclidean" {
-            Ok(AnalysisType::new(BirthmarkType::OpFreq, Algorithm::Euclidean))
+            Ok(AnalysisType::new(
+                BirthmarkType::OpFreq,
+                Algorithm::Euclidean,
+            ))
         } else if s == "op-set-jaccard" {
             Ok(AnalysisType::new(BirthmarkType::OpSet, Algorithm::Jaccard))
         } else if s == "op-seq-levenshtein" {
-            Ok(AnalysisType::new(BirthmarkType::OpSeq, Algorithm::Levenshtein))
+            Ok(AnalysisType::new(
+                BirthmarkType::OpSeq,
+                Algorithm::Levenshtein,
+            ))
         } else if s == "op-set-simpson" {
             Ok(AnalysisType::new(BirthmarkType::OpSet, Algorithm::Simpson))
         } else if s == "op-freq-weightedjaccard" {
-            Ok(AnalysisType::new(BirthmarkType::OpFreq, Algorithm::WeightedJaccard))
+            Ok(AnalysisType::new(
+                BirthmarkType::OpFreq,
+                Algorithm::WeightedJaccard,
+            ))
         } else if let Some((bt, c)) = parse_kgram_and_algorithm(s) {
             Ok(AnalysisType::new(bt, c))
         } else {
             Err(Error::BirthmarkType(name))
         }
-
     }
 }
 
@@ -375,8 +409,7 @@ fn parse_kgram(name: &str) -> Option<BirthmarkType> {
 }
 
 fn parse_k_value(k: &str) -> Option<usize> {
-    k.parse()
-        .ok()
+    k.parse().ok()
 }
 
 #[cfg(test)]
@@ -392,8 +425,8 @@ mod tests {
             duration: Duration::from_nanos(42),
             birthmark_type: BirthmarkType::OpSeq,
         };
-        let parsed = Metadata::parse(&metadata.csv_info())
-            .expect("failed to parse escaped metadata");
+        let parsed =
+            Metadata::parse(&metadata.csv_info()).expect("failed to parse escaped metadata");
         assert_eq!(parsed.file_name, metadata.file_name);
         assert_eq!(parsed.path, metadata.path);
         assert_eq!(parsed.birthmark_type, metadata.birthmark_type);
@@ -406,9 +439,12 @@ mod tests {
         assert_eq!(metadata.file_name, "bzip2-1.0.2");
         assert_eq!(metadata.path, PathBuf::from("${HOME}/oinkie/bzip2-1.0.2"));
         assert_eq!(metadata.birthmark_type, BirthmarkType::OpSeq);
-        assert_eq!(metadata.extracted_at, chrono::DateTime::parse_from_rfc3339("2026-04-17T04:57:55.385904+00:00")
-            .expect("failed to parse extracted_at")
-            .with_timezone(&chrono::Utc));
+        assert_eq!(
+            metadata.extracted_at,
+            chrono::DateTime::parse_from_rfc3339("2026-04-17T04:57:55.385904+00:00")
+                .expect("failed to parse extracted_at")
+                .with_timezone(&chrono::Utc)
+        );
         assert_eq!(metadata.duration, Duration::from_nanos(4462500));
     }
 
@@ -443,9 +479,16 @@ mod tests {
             ("op-5gram-freq", BirthmarkType::OpKgramFreq(5)),
         ];
         for (input, expected) in cases {
-            assert_eq!(BirthmarkType::try_from(input).unwrap(), expected, "input: {input}");
+            assert_eq!(
+                BirthmarkType::try_from(input).unwrap(),
+                expected,
+                "input: {input}"
+            );
             // parsing must be case insensitive
-            assert_eq!(BirthmarkType::try_from(input.to_uppercase().as_str()).unwrap(), expected);
+            assert_eq!(
+                BirthmarkType::try_from(input.to_uppercase().as_str()).unwrap(),
+                expected
+            );
         }
     }
 
@@ -459,26 +502,44 @@ mod tests {
     #[test]
     fn test_birthmark_type_display_roundtrips() {
         let types = [
-            BirthmarkType::FcSeq, BirthmarkType::FcSet, BirthmarkType::FcFreq,
-            BirthmarkType::OpFreq, BirthmarkType::OpSeq, BirthmarkType::OpSet,
-            BirthmarkType::OpKgramSeq(2), BirthmarkType::OpKgramFreq(3), BirthmarkType::OpKgramSet(4),
+            BirthmarkType::FcSeq,
+            BirthmarkType::FcSet,
+            BirthmarkType::FcFreq,
+            BirthmarkType::OpFreq,
+            BirthmarkType::OpSeq,
+            BirthmarkType::OpSet,
+            BirthmarkType::OpKgramSeq(2),
+            BirthmarkType::OpKgramFreq(3),
+            BirthmarkType::OpKgramSet(4),
         ];
         for bt in types {
             let rendered = bt.to_string();
-            assert_eq!(BirthmarkType::try_from(rendered.as_str()).unwrap(), bt, "rendered: {rendered}");
+            assert_eq!(
+                BirthmarkType::try_from(rendered.as_str()).unwrap(),
+                bt,
+                "rendered: {rendered}"
+            );
         }
     }
 
     #[test]
     fn test_analysis_type_try_from_named_combinations() {
         let names = [
-            "op-freq-cosine", "op-set-dice", "op-freq-euclidean", "op-set-jaccard",
-            "op-seq-levenshtein", "op-set-simpson", "op-freq-weightedjaccard",
+            "op-freq-cosine",
+            "op-set-dice",
+            "op-freq-euclidean",
+            "op-set-jaccard",
+            "op-seq-levenshtein",
+            "op-set-simpson",
+            "op-freq-weightedjaccard",
         ];
         for name in names {
             assert!(AnalysisType::try_from(name).is_ok(), "name: {name}");
             // the String and &str impls must agree
-            assert!(AnalysisType::try_from(name.to_string()).is_ok(), "name: {name}");
+            assert!(
+                AnalysisType::try_from(name.to_string()).is_ok(),
+                "name: {name}"
+            );
         }
     }
 
@@ -491,18 +552,25 @@ mod tests {
             ("op-4gram-seq-levenshtein", BirthmarkType::OpKgramSeq(4)),
             ("op-5gram-freq-cosine", BirthmarkType::OpKgramFreq(5)),
             ("op-5gram-freq-euclidean", BirthmarkType::OpKgramFreq(5)),
-            ("op-6gram-freq-weightedjaccard", BirthmarkType::OpKgramFreq(6)),
+            (
+                "op-6gram-freq-weightedjaccard",
+                BirthmarkType::OpKgramFreq(6),
+            ),
         ];
         for (name, expected) in cases {
-            let at = AnalysisType::try_from(name)
-                .unwrap_or_else(|e| panic!("{name}: {e}"));
+            let at = AnalysisType::try_from(name).unwrap_or_else(|e| panic!("{name}: {e}"));
             assert_eq!(at.birthmark, expected, "name: {name}");
         }
     }
 
     #[test]
     fn test_analysis_type_try_from_rejects_unknown() {
-        for name in ["", "unknown", "op-2gram-set-unknown", "fc-set-jaccard-extra"] {
+        for name in [
+            "",
+            "unknown",
+            "op-2gram-set-unknown",
+            "fc-set-jaccard-extra",
+        ] {
             assert!(AnalysisType::try_from(name).is_err(), "name: {name}");
         }
     }
@@ -513,13 +581,20 @@ mod tests {
         let variants = [
             Data::Seq(vec!["A".to_string(), "B".to_string()]),
             Data::Set(["A".to_string(), "B".to_string()].into_iter().collect()),
-            Data::Freq([("A".to_string(), 1), ("B".to_string(), 2)].into_iter().collect()),
+            Data::Freq(
+                [("A".to_string(), 1), ("B".to_string(), 2)]
+                    .into_iter()
+                    .collect(),
+            ),
             Data::KgramSeq(vec![kgram.clone()]),
             Data::KgramSet([kgram.clone()].into_iter().collect()),
             Data::KgramFreq([(kgram, 1)].into_iter().collect()),
         ];
         for data in variants {
-            let elements = Elements { name: "f".to_string(), data };
+            let elements = Elements {
+                name: "f".to_string(),
+                data,
+            };
             // every variant above carries two mnemonics in total
             assert_eq!(elements.ops().count(), 2);
             assert!(!elements.is_empty());
@@ -529,7 +604,10 @@ mod tests {
 
     #[test]
     fn test_elements_is_empty_on_empty_data() {
-        let elements = Elements { name: "f".to_string(), data: Data::Seq(vec![]) };
+        let elements = Elements {
+            name: "f".to_string(),
+            data: Data::Seq(vec![]),
+        };
         assert!(elements.is_empty());
         assert_eq!(elements.len(), 0);
         assert_eq!(elements.ops().count(), 0);
@@ -609,10 +687,16 @@ mod tests {
     fn test_birthmark_try_from_path_reports_errors() {
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("missing.json");
-        assert!(matches!(Birthmark::try_from(missing).unwrap_err(), Error::Io(..)));
+        assert!(matches!(
+            Birthmark::try_from(missing).unwrap_err(),
+            Error::Io(..)
+        ));
 
         let broken = dir.path().join("broken.json");
         std::fs::write(&broken, b"{ not json").unwrap();
-        assert!(matches!(Birthmark::try_from(broken).unwrap_err(), Error::Json(..)));
+        assert!(matches!(
+            Birthmark::try_from(broken).unwrap_err(),
+            Error::Json(..)
+        ));
     }
 }

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -127,8 +127,8 @@ impl<'a, S: CsvInfo> Comparison<'a, S> {
             self.similarity()
         )
         .map_err(io_err)?;
-        writeln!(out, "left,{}", self.rows.csv_info()).map_err(io_err)?;
-        writeln!(out, "right,{}", self.columns.csv_info()).map_err(io_err)?;
+        writeln!(out, "left,{}", self.columns.csv_info()).map_err(io_err)?;
+        writeln!(out, "right,{}", self.rows.csv_info()).map_err(io_err)?;
         let b1_names = self.columns.names();
         let b2_names = self.rows.names();
         write!(
@@ -1250,12 +1250,8 @@ mod tests {
 
         let content = std::fs::read_to_string(&dest).unwrap();
         assert!(content.starts_with("result,"));
-        // NOTE: Comparison::new takes (columns, rows) and compare_birthmarks
-        // passes (b1, b2), while store writes the "left" record from `rows`.
-        // The stored "left" is therefore the *second* birthmark, and "right"
-        // the first. This asserts the behaviour as it currently stands.
-        assert!(content.contains("\nleft,birthmark,right,"));
-        assert!(content.contains("\nright,birthmark,left,"));
+        assert!(content.contains("\nleft,birthmark,left,"));
+        assert!(content.contains("\nright,birthmark,right,"));
         assert!(content.contains("\nmatrix,,"));
         // one line per row element, each prefixed with its index
         assert_eq!(

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -1,9 +1,9 @@
 use crate::{Iterable, prelude::*};
-use std::{io::Write, path::Path, time::Instant};
 use clap::ValueEnum;
-use rustc_hash::{FxHashMap, FxHashSet};
 use itertools::Itertools;
 use ndarray::Array2;
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::{io::Write, path::Path, time::Instant};
 
 #[cfg_attr(doc, katexit::katexit)]
 #[derive(Debug, Clone, ValueEnum)]
@@ -39,14 +39,24 @@ impl PairingStrategy {
             PairingStrategy::All => targets.len() * targets.len().saturating_sub(1) / 2,
             PairingStrategy::SelfCoverage => targets.len(),
             PairingStrategy::Adjacent => targets.len().saturating_sub(1),
-            PairingStrategy::FirstVsOthers | PairingStrategy::LastVsOthers => targets.len().saturating_sub(1),
+            PairingStrategy::FirstVsOthers | PairingStrategy::LastVsOthers => {
+                targets.len().saturating_sub(1)
+            }
             PairingStrategy::AllAndSelf => targets.len() * (targets.len() + 1) / 2,
         }
     }
-    pub fn pairs<'a, T: std::marker::Sync>(&'a self, targets: &'a [T]) -> Box<dyn Iterator<Item = (&'a T, &'a T)> + Send + 'a> {
+    pub fn pairs<'a, T: std::marker::Sync>(
+        &'a self,
+        targets: &'a [T],
+    ) -> Box<dyn Iterator<Item = (&'a T, &'a T)> + Send + 'a> {
         match self {
-            PairingStrategy::AllAndSelf => Box::new(targets.iter().combinations(2).map(|c| (c[0], c[1]))
-                .chain(targets.iter().map(|f| (f, f)))),
+            PairingStrategy::AllAndSelf => Box::new(
+                targets
+                    .iter()
+                    .combinations(2)
+                    .map(|c| (c[0], c[1]))
+                    .chain(targets.iter().map(|f| (f, f))),
+            ),
             PairingStrategy::All => Box::new(targets.iter().combinations(2).map(|c| (c[0], c[1]))),
             PairingStrategy::SelfCoverage => Box::new(targets.iter().map(|f| (f, f))),
             PairingStrategy::Adjacent => Box::new(targets.windows(2).map(|w| (&w[0], &w[1]))),
@@ -57,7 +67,7 @@ impl PairingStrategy {
                 } else {
                     Box::new(std::iter::empty())
                 }
-            },
+            }
             PairingStrategy::LastVsOthers => {
                 let mut it = targets.iter().rev();
                 if let Some(last) = it.next() {
@@ -89,8 +99,20 @@ pub fn escape_csv_string(s: &str) -> String {
 }
 
 impl<'a, S: CsvInfo> Comparison<'a, S> {
-    pub fn new(columns: &'a S, rows: &'a S, matrix: Array2<f64>, similarities: Vec<f64>, duration: std::time::Duration) -> Comparison<'a, S> {
-        Self { columns, rows, matrix, similarities, duration }
+    pub fn new(
+        columns: &'a S,
+        rows: &'a S,
+        matrix: Array2<f64>,
+        similarities: Vec<f64>,
+        duration: std::time::Duration,
+    ) -> Comparison<'a, S> {
+        Self {
+            columns,
+            rows,
+            matrix,
+            similarities,
+            duration,
+        }
     }
 
     pub fn store<P: AsRef<Path>>(&self, dest: P) -> Result<()> {
@@ -98,13 +120,23 @@ impl<'a, S: CsvInfo> Comparison<'a, S> {
         let io_err = |e| Error::Io(dest.to_path_buf(), e);
         let mut file = std::fs::File::create(dest).map_err(io_err)?;
         let mut out = std::io::BufWriter::new(&mut file);
-        writeln!(out, "result,{},{}", self.duration.as_nanos(), self.similarity()).map_err(io_err)?;
+        writeln!(
+            out,
+            "result,{},{}",
+            self.duration.as_nanos(),
+            self.similarity()
+        )
+        .map_err(io_err)?;
         writeln!(out, "left,{}", self.rows.csv_info()).map_err(io_err)?;
         writeln!(out, "right,{}", self.columns.csv_info()).map_err(io_err)?;
         let b1_names = self.columns.names();
         let b2_names = self.rows.names();
-        write!(out, "matrix,,{}", b1_names.iter()
-            .map(|s| escape_csv_string(s)).join(",")).map_err(io_err)?;
+        write!(
+            out,
+            "matrix,,{}",
+            b1_names.iter().map(|s| escape_csv_string(s)).join(",")
+        )
+        .map_err(io_err)?;
         for (j, item) in b2_names.iter().enumerate() {
             write!(out, "\n{}, {}", j, escape_csv_string(item)).map_err(io_err)?;
             for i in 0..b1_names.len() {
@@ -154,11 +186,13 @@ impl std::str::FromStr for Aggregator {
             Ok(Aggregator::TopN(Size::All))
         } else if let Some(n) = s.strip_prefix("topn:") {
             match n.parse::<usize>() {
-                Ok(0) => Err(Error::Parse("topn requires N >= 1 (use \"topn:all\" for all elements)".to_string())),
+                Ok(0) => Err(Error::Parse(
+                    "topn requires N >= 1 (use \"topn:all\" for all elements)".to_string(),
+                )),
                 Ok(n) => {
                     log::info!("Using TopN({n}) algorithm for aggregation");
                     Ok(Aggregator::TopN(Size::Num(n)))
-                },
+                }
                 Err(e) => Err(Error::ParseInt(s, e)),
             }
         } else {
@@ -170,33 +204,49 @@ impl std::str::FromStr for Aggregator {
 impl Aggregator {
     pub fn aggregate(&self, array: &Array2<f64>) -> Result<Vec<f64>> {
         match self {
-            Aggregator::Hungarian => 
-                hungarian_algorithm(array)
-                    .map(|(sim, _matches)| sim),
-            Aggregator::TopN(n) => 
-                top_n_selection(array, n)
+            Aggregator::Hungarian => hungarian_algorithm(array).map(|(sim, _matches)| sim),
+            Aggregator::TopN(n) => top_n_selection(array, n),
         }
     }
 }
 
 trait BirthmarkComparator {
-    fn compare_birthmarks<'a>(&self, b1: &'a Birthmark, b2: &'a Birthmark, aggregator: &Aggregator) -> Result<Comparison<'a, Birthmark>> {
+    fn compare_birthmarks<'a>(
+        &self,
+        b1: &'a Birthmark,
+        b2: &'a Birthmark,
+        aggregator: &Aggregator,
+    ) -> Result<Comparison<'a, Birthmark>> {
         if !b1.comparable_with(b2) {
-            return Err(Error::Mismatch(b1.metadata.birthmark_type.clone(), b2.metadata.birthmark_type.clone()));
+            return Err(Error::Mismatch(
+                b1.metadata.birthmark_type.clone(),
+                b2.metadata.birthmark_type.clone(),
+            ));
         }
         let p1_len = b1.elements.len();
         let p2_len = b2.elements.len();
         let size = std::cmp::max(p1_len, p2_len);
         if p1_len == 0 && p2_len == 0 {
-            Ok(Comparison::new(b1, b2, Array2::<f64>::zeros((0, 0)), vec![1.0], std::time::Duration::from_millis(0)))
+            Ok(Comparison::new(
+                b1,
+                b2,
+                Array2::<f64>::zeros((0, 0)),
+                vec![1.0],
+                std::time::Duration::from_millis(0),
+            ))
         } else if p1_len == 0 || p2_len == 0 {
-            Ok(Comparison::new(b1, b2, Array2::<f64>::zeros((0, 0)), vec![0.0], std::time::Duration::from_millis(0)))
+            Ok(Comparison::new(
+                b1,
+                b2,
+                Array2::<f64>::zeros((0, 0)),
+                vec![0.0],
+                std::time::Duration::from_millis(0),
+            ))
         } else {
             let start = Instant::now();
-            let r = build_matrix(b1, b2, size, |e1, e2| {
-                self.compare_elements(e1, e2)
-            })?;
-            aggregator.aggregate(&r)
+            let r = build_matrix(b1, b2, size, |e1, e2| self.compare_elements(e1, e2))?;
+            aggregator
+                .aggregate(&r)
                 .map(|sim| Comparison::new(b1, b2, r, sim, start.elapsed()))
         }
     }
@@ -204,8 +254,13 @@ trait BirthmarkComparator {
     fn compare_elements(&self, e1: &Elements, e2: &Elements) -> f64;
 }
 
-fn build_matrix<F, T>(p1: impl Iterable<Item = T>, p2: impl Iterable<Item = T>, size: usize, compare_func: F) -> Result<Array2<f64>>
-where 
+fn build_matrix<F, T>(
+    p1: impl Iterable<Item = T>,
+    p2: impl Iterable<Item = T>,
+    size: usize,
+    compare_func: F,
+) -> Result<Array2<f64>>
+where
     F: Fn(&T, &T) -> f64,
 {
     // The matrix holds similarities; the conversion to costs for lapjv
@@ -217,22 +272,26 @@ where
             similarities[i * size + j] = compare_func(item1, item2);
         }
     }
-    Array2::from_shape_vec((size, size), similarities)
-        .map_err(Error::ShapeError)
+    Array2::from_shape_vec((size, size), similarities).map_err(Error::ShapeError)
 }
 
 fn top_n_selection(array2d: &Array2<f64>, n: &Size) -> Result<Vec<f64>> {
-    let rows = array2d.axis_iter(ndarray::Axis(0))
+    let rows = array2d
+        .axis_iter(ndarray::Axis(0))
         .map(|col| col.fold(0.0f64, |acc, &v| acc.max(v)))
         .sorted_by(|a, b| b.total_cmp(a))
         .collect::<Vec<_>>();
-    let cols = array2d.axis_iter(ndarray::Axis(1))
+    let cols = array2d
+        .axis_iter(ndarray::Axis(1))
         .map(|col| col.fold(0.0f64, |acc, &v| acc.max(v)))
         .sorted_by(|a, b| b.total_cmp(a))
         .collect::<Vec<_>>();
     match n {
-        Size::Num(k) => 
-            Ok(rows.into_iter().take(*k).chain(cols.into_iter().take(*k)).collect()),
+        Size::Num(k) => Ok(rows
+            .into_iter()
+            .take(*k)
+            .chain(cols.into_iter().take(*k))
+            .collect()),
         Size::All => Ok(rows.into_iter().chain(cols).collect()),
     }
 }
@@ -245,30 +304,46 @@ fn hungarian_algorithm(similarity_matrix: &Array2<f64>) -> Result<(Vec<f64>, Vec
             for (i, &j) in rows.iter().enumerate() {
                 if i < cost_matrix.nrows() && j < cost_matrix.ncols() {
                     // Convert cost back to similarity by using (1.0 - cost).
-                    similarities.push(1.0 - cost_matrix[(i, j)]); 
+                    similarities.push(1.0 - cost_matrix[(i, j)]);
                 }
             }
             Ok((similarities, rows))
-        },
+        }
         Err(e) => Err(Error::LapJV(e)),
     }
 }
 
 trait ProgramComparator<T: crate::Op> {
-    fn compare_programs<'a>(&self, p1: &'a Program<T>, p2: &'a Program<T>, aggregator: &Aggregator) -> Result<Comparison<'a, Program<T>>> {
+    fn compare_programs<'a>(
+        &self,
+        p1: &'a Program<T>,
+        p2: &'a Program<T>,
+        aggregator: &Aggregator,
+    ) -> Result<Comparison<'a, Program<T>>> {
         let p1_len = p1.len();
         let p2_len = p2.len();
         let size = std::cmp::max(p1_len, p2_len);
         if p1_len == 0 && p2_len == 0 {
-            Ok(Comparison::new(p1, p2, Array2::<f64>::zeros((0, 0)), vec![1.0], std::time::Duration::from_millis(0)))
+            Ok(Comparison::new(
+                p1,
+                p2,
+                Array2::<f64>::zeros((0, 0)),
+                vec![1.0],
+                std::time::Duration::from_millis(0),
+            ))
         } else if p1_len == 0 || p2_len == 0 {
-            Ok(Comparison::new(p1, p2, Array2::<f64>::zeros((0, 0)), vec![0.0], std::time::Duration::from_millis(0)))
+            Ok(Comparison::new(
+                p1,
+                p2,
+                Array2::<f64>::zeros((0, 0)),
+                vec![0.0],
+                std::time::Duration::from_millis(0),
+            ))
         } else {
             let start = Instant::now();
-            let r = build_matrix(p1, p2, size, |f1, f2| {
-                self.compare_func(f1, f2)
-            })?;
-            aggregator.aggregate(&r)
+            let r = build_matrix(p1, p2, size, |f1, f2| self.compare_func(f1, f2))?;
+            aggregator
+                .aggregate(&r)
                 .map(|sim| Comparison::new(p1, p2, r, sim, start.elapsed()))
         }
     }
@@ -319,7 +394,7 @@ impl Algorithm {
 
 /// This struct holds the specific algorithm instance and dispatches the comparison calls to it.
 pub struct Comparator {
-    inner: ComparatorImpl
+    inner: ComparatorImpl,
 }
 
 /// The implementation of Comparator, which holds the specific algorithm instance and dispatches the comparison calls to it.
@@ -338,20 +413,41 @@ enum ComparatorImpl {
 impl From<&Algorithm> for Comparator {
     fn from(algorithm: &Algorithm) -> Self {
         match algorithm {
-            Algorithm::Cosine => Comparator{ inner: ComparatorImpl::Cosine(Cosine{}) },
-            Algorithm::Dice => Comparator{ inner: ComparatorImpl::Dice(Dice{}) },
-            Algorithm::Euclidean => Comparator{ inner: ComparatorImpl::Euclidean(Euclidean{}) },
-            Algorithm::Jaccard => Comparator{ inner: ComparatorImpl::Jaccard(Jaccard{}) },
-            Algorithm::Levenshtein => Comparator{ inner: ComparatorImpl::Levenshtein(Levenshtein{}) },
-            Algorithm::Lcs => Comparator{ inner: ComparatorImpl::Lcs(Lcs{}) },
-            Algorithm::Simpson => Comparator{ inner: ComparatorImpl::Simpson(Simpson{}) },
-            Algorithm::WeightedJaccard => Comparator{ inner: ComparatorImpl::WeightedJaccard(WeightedJaccard{}) },
+            Algorithm::Cosine => Comparator {
+                inner: ComparatorImpl::Cosine(Cosine {}),
+            },
+            Algorithm::Dice => Comparator {
+                inner: ComparatorImpl::Dice(Dice {}),
+            },
+            Algorithm::Euclidean => Comparator {
+                inner: ComparatorImpl::Euclidean(Euclidean {}),
+            },
+            Algorithm::Jaccard => Comparator {
+                inner: ComparatorImpl::Jaccard(Jaccard {}),
+            },
+            Algorithm::Levenshtein => Comparator {
+                inner: ComparatorImpl::Levenshtein(Levenshtein {}),
+            },
+            Algorithm::Lcs => Comparator {
+                inner: ComparatorImpl::Lcs(Lcs {}),
+            },
+            Algorithm::Simpson => Comparator {
+                inner: ComparatorImpl::Simpson(Simpson {}),
+            },
+            Algorithm::WeightedJaccard => Comparator {
+                inner: ComparatorImpl::WeightedJaccard(WeightedJaccard {}),
+            },
         }
     }
 }
 
 impl Comparator {
-    pub fn compare_programs<'a, T: crate::Op>(&self, p1: &'a Program<T>, p2: &'a Program<T>, aggregator: &Aggregator) -> Result<Comparison<'a, Program<T>>> {
+    pub fn compare_programs<'a, T: crate::Op>(
+        &self,
+        p1: &'a Program<T>,
+        p2: &'a Program<T>,
+        aggregator: &Aggregator,
+    ) -> Result<Comparison<'a, Program<T>>> {
         match &self.inner {
             ComparatorImpl::Cosine(c) => c.compare_programs(p1, p2, aggregator),
             ComparatorImpl::Dice(d) => d.compare_programs(p1, p2, aggregator),
@@ -364,7 +460,12 @@ impl Comparator {
         }
     }
 
-    pub fn compare_birthmarks<'a>(&self, b1: &'a Birthmark, b2: &'a Birthmark, aggregator: &Aggregator) -> Result<Comparison<'a, Birthmark>> {
+    pub fn compare_birthmarks<'a>(
+        &self,
+        b1: &'a Birthmark,
+        b2: &'a Birthmark,
+        aggregator: &Aggregator,
+    ) -> Result<Comparison<'a, Birthmark>> {
         match &self.inner {
             ComparatorImpl::Cosine(c) => c.compare_birthmarks(b1, b2, aggregator),
             ComparatorImpl::Dice(d) => d.compare_birthmarks(b1, b2, aggregator),
@@ -610,7 +711,10 @@ where
     freq
 }
 
-fn jaccard_index<T: std::fmt::Debug + std::cmp::Eq + std::hash::Hash>(s1: &FxHashSet<T>, s2: &FxHashSet<T>) -> f64 {
+fn jaccard_index<T: std::fmt::Debug + std::cmp::Eq + std::hash::Hash>(
+    s1: &FxHashSet<T>,
+    s2: &FxHashSet<T>,
+) -> f64 {
     if s1.is_empty() && s2.is_empty() {
         1.0
     } else if s1.is_empty() || s2.is_empty() {
@@ -620,7 +724,10 @@ fn jaccard_index<T: std::fmt::Debug + std::cmp::Eq + std::hash::Hash>(s1: &FxHas
     }
 }
 
-fn dice_index<T: std::fmt::Debug + std::cmp::Eq + std::hash::Hash>(s1: &FxHashSet<T>, s2: &FxHashSet<T>) -> f64 {
+fn dice_index<T: std::fmt::Debug + std::cmp::Eq + std::hash::Hash>(
+    s1: &FxHashSet<T>,
+    s2: &FxHashSet<T>,
+) -> f64 {
     if s1.is_empty() && s2.is_empty() {
         1.0
     } else if s1.is_empty() || s2.is_empty() {
@@ -630,7 +737,10 @@ fn dice_index<T: std::fmt::Debug + std::cmp::Eq + std::hash::Hash>(s1: &FxHashSe
     }
 }
 
-fn simpson_index<T: std::fmt::Debug + std::cmp::Eq + std::hash::Hash>(s1: &FxHashSet<T>, s2: &FxHashSet<T>) -> f64 {
+fn simpson_index<T: std::fmt::Debug + std::cmp::Eq + std::hash::Hash>(
+    s1: &FxHashSet<T>,
+    s2: &FxHashSet<T>,
+) -> f64 {
     if s1.is_empty() && s2.is_empty() {
         1.0
     } else if s1.is_empty() || s2.is_empty() {
@@ -644,8 +754,12 @@ fn levenshtein_distance<T: PartialEq>(s1: &[T], s2: &[T]) -> f64 {
     let n = s1.len();
     let m = s2.len();
 
-    if n == 0 && m == 0 { return 1.0; }
-    if n == 0 || m == 0 { return 0.0; }
+    if n == 0 && m == 0 {
+        return 1.0;
+    }
+    if n == 0 || m == 0 {
+        return 0.0;
+    }
     let max_len = n.max(m);
 
     // shorter sequence is s2, longer sequence is s1 for minimizing memory usage.
@@ -660,7 +774,7 @@ fn levenshtein_distance<T: PartialEq>(s1: &[T], s2: &[T]) -> f64 {
         curr[0] = i;
         for j in 1..=m {
             let cost = if s1[i - 1] == s2[j - 1] { 0 } else { 1 };
-            
+
             // 3つの操作の最小値をとる
             let substitution = prev[j - 1] + cost;
             let insertion = curr[j - 1] + 1;
@@ -699,13 +813,19 @@ fn levenshtein_distance_full_memory<T: PartialEq>(s1: &[T], s2: &[T]) -> f64 {
     1.0 - (dp[[s1.len(), s2.len()]] as f64 / (s1.len().max(s2.len()) as f64))
 }
 
-fn cosine_similarity<T: std::cmp::Eq + std::hash::Hash>(f1: &FxHashMap<T, usize>, f2: &FxHashMap<T, usize>) -> f64 {
+fn cosine_similarity<T: std::cmp::Eq + std::hash::Hash>(
+    f1: &FxHashMap<T, usize>,
+    f2: &FxHashMap<T, usize>,
+) -> f64 {
     let keys = f1.keys().chain(f2.keys()).collect::<FxHashSet<_>>();
-    let dot_product = keys.iter().map(|k| {
-        let v1 = *f1.get(*k).unwrap_or(&0) as f64;
-        let v2 = *f2.get(*k).unwrap_or(&0) as f64;
-        v1 * v2
-    }).sum::<f64>();
+    let dot_product = keys
+        .iter()
+        .map(|k| {
+            let v1 = *f1.get(*k).unwrap_or(&0) as f64;
+            let v2 = *f2.get(*k).unwrap_or(&0) as f64;
+            v1 * v2
+        })
+        .sum::<f64>();
     let magnitude1 = f1.values().map(|v| (*v as f64).powi(2)).sum::<f64>().sqrt();
     let magnitude2 = f2.values().map(|v| (*v as f64).powi(2)).sum::<f64>().sqrt();
     if magnitude1 > 0.0 && magnitude2 > 0.0 {
@@ -715,28 +835,45 @@ fn cosine_similarity<T: std::cmp::Eq + std::hash::Hash>(f1: &FxHashMap<T, usize>
     }
 }
 
-fn euclidean_distance<T: std::cmp::Eq + std::hash::Hash>(f1: &FxHashMap<T, usize>, f2: &FxHashMap<T, usize>) -> f64 {
+fn euclidean_distance<T: std::cmp::Eq + std::hash::Hash>(
+    f1: &FxHashMap<T, usize>,
+    f2: &FxHashMap<T, usize>,
+) -> f64 {
     let keys = f1.keys().chain(f2.keys()).collect::<FxHashSet<_>>();
-    let sum_of_squares = keys.iter().map(|k| {
-        let v1 = *f1.get(*k).unwrap_or(&0) as f64;
-        let v2 = *f2.get(*k).unwrap_or(&0) as f64;
-        (v1 - v2).powi(2)
-    }).sum::<f64>();
-    1.0 - (sum_of_squares.sqrt() / (f1.values().map(|v| (*v as f64).powi(2)).sum::<f64>().sqrt() + f2.values().map(|v| (*v as f64).powi(2)).sum::<f64>().sqrt()))
+    let sum_of_squares = keys
+        .iter()
+        .map(|k| {
+            let v1 = *f1.get(*k).unwrap_or(&0) as f64;
+            let v2 = *f2.get(*k).unwrap_or(&0) as f64;
+            (v1 - v2).powi(2)
+        })
+        .sum::<f64>();
+    1.0 - (sum_of_squares.sqrt()
+        / (f1.values().map(|v| (*v as f64).powi(2)).sum::<f64>().sqrt()
+            + f2.values().map(|v| (*v as f64).powi(2)).sum::<f64>().sqrt()))
 }
 
-fn weighted_jaccard<T: std::cmp::Eq + std::hash::Hash>(f1: &FxHashMap<T, usize>, f2: &FxHashMap<T, usize>) -> f64 {
+fn weighted_jaccard<T: std::cmp::Eq + std::hash::Hash>(
+    f1: &FxHashMap<T, usize>,
+    f2: &FxHashMap<T, usize>,
+) -> f64 {
     let keys = f1.keys().chain(f2.keys()).collect::<FxHashSet<_>>();
-    let min_sum = keys.iter().map(|k| {
-        let v1 = *f1.get(*k).unwrap_or(&0) as f64;
-        let v2 = *f2.get(*k).unwrap_or(&0) as f64;
-        v1.min(v2)
-    }).sum::<f64>();
-    let max_sum = keys.iter().map(|k| {
-        let v1 = *f1.get(*k).unwrap_or(&0) as f64;
-        let v2 = *f2.get(*k).unwrap_or(&0) as f64;
-        v1.max(v2)
-    }).sum::<f64>();
+    let min_sum = keys
+        .iter()
+        .map(|k| {
+            let v1 = *f1.get(*k).unwrap_or(&0) as f64;
+            let v2 = *f2.get(*k).unwrap_or(&0) as f64;
+            v1.min(v2)
+        })
+        .sum::<f64>();
+    let max_sum = keys
+        .iter()
+        .map(|k| {
+            let v1 = *f1.get(*k).unwrap_or(&0) as f64;
+            let v2 = *f2.get(*k).unwrap_or(&0) as f64;
+            v1.max(v2)
+        })
+        .sum::<f64>();
     if max_sum > 0.0 {
         min_sum / max_sum
     } else {
@@ -747,7 +884,9 @@ fn weighted_jaccard<T: std::cmp::Eq + std::hash::Hash>(f1: &FxHashMap<T, usize>,
 fn longest_common_subsequence<T: PartialEq>(s1: &[T], s2: &[T]) -> f64 {
     let n = s1.len();
     let m = s2.len();
-    if n == 0 || m == 0 { return 0.0; }
+    if n == 0 || m == 0 {
+        return 0.0;
+    }
 
     // shorter sequence is s2, longer sequence is s1 for minimizing memory usage.
     let (s1, s2) = if n < m { (s2, s1) } else { (s1, s2) };
@@ -771,7 +910,7 @@ fn longest_common_subsequence<T: PartialEq>(s1: &[T], s2: &[T]) -> f64 {
     }
 
     // the previous row contains the final results since the last swap
-    let lcs_length = prev[m]; 
+    let lcs_length = prev[m];
     2.0 * lcs_length as f64 / (n + m) as f64
 }
 
@@ -811,27 +950,53 @@ mod tests {
     #[test]
     fn aggregator_rejects_topn_zero() {
         assert!("topn:0".parse::<Aggregator>().is_err());
-        assert!(matches!("topn:3".parse::<Aggregator>(), Ok(Aggregator::TopN(Size::Num(3)))));
-        assert!(matches!("topn".parse::<Aggregator>(), Ok(Aggregator::TopN(Size::All))));
-        assert!(matches!("hungarian".parse::<Aggregator>(), Ok(Aggregator::Hungarian)));
+        assert!(matches!(
+            "topn:3".parse::<Aggregator>(),
+            Ok(Aggregator::TopN(Size::Num(3)))
+        ));
+        assert!(matches!(
+            "topn".parse::<Aggregator>(),
+            Ok(Aggregator::TopN(Size::All))
+        ));
+        assert!(matches!(
+            "hungarian".parse::<Aggregator>(),
+            Ok(Aggregator::Hungarian)
+        ));
     }
 
     #[test]
     fn aggregator_rejects_malformed_input() {
         // a non-numeric N and an entirely unknown name take separate error paths
-        assert!(matches!("topn:abc".parse::<Aggregator>(), Err(Error::ParseInt(..))));
-        assert!(matches!("nonsense".parse::<Aggregator>(), Err(Error::Parse(_))));
+        assert!(matches!(
+            "topn:abc".parse::<Aggregator>(),
+            Err(Error::ParseInt(..))
+        ));
+        assert!(matches!(
+            "nonsense".parse::<Aggregator>(),
+            Err(Error::Parse(_))
+        ));
         // parsing is case insensitive
-        assert!(matches!("HUNGARIAN".parse::<Aggregator>(), Ok(Aggregator::Hungarian)));
-        assert!(matches!("TopN:All".parse::<Aggregator>(), Ok(Aggregator::TopN(Size::All))));
+        assert!(matches!(
+            "HUNGARIAN".parse::<Aggregator>(),
+            Ok(Aggregator::Hungarian)
+        ));
+        assert!(matches!(
+            "TopN:All".parse::<Aggregator>(),
+            Ok(Aggregator::TopN(Size::All))
+        ));
     }
 
     #[test]
     fn pairs_on_empty_targets_yield_nothing() {
         let empty: Vec<i32> = vec![];
-        for strategy in [PairingStrategy::FirstVsOthers, PairingStrategy::LastVsOthers,
-                         PairingStrategy::All, PairingStrategy::AllAndSelf,
-                         PairingStrategy::Adjacent, PairingStrategy::SelfCoverage] {
+        for strategy in [
+            PairingStrategy::FirstVsOthers,
+            PairingStrategy::LastVsOthers,
+            PairingStrategy::All,
+            PairingStrategy::AllAndSelf,
+            PairingStrategy::Adjacent,
+            PairingStrategy::SelfCoverage,
+        ] {
             assert_eq!(strategy.pairs(&empty).count(), 0, "strategy: {strategy:?}");
         }
     }
@@ -839,11 +1004,19 @@ mod tests {
     #[test]
     fn pairs_match_compare_count() {
         let targets = vec![1, 2, 3, 4];
-        for strategy in [PairingStrategy::All, PairingStrategy::AllAndSelf,
-                         PairingStrategy::Adjacent, PairingStrategy::SelfCoverage,
-                         PairingStrategy::FirstVsOthers, PairingStrategy::LastVsOthers] {
-            assert_eq!(strategy.pairs(&targets).count(), strategy.compare_count(&targets),
-                "strategy: {strategy:?}");
+        for strategy in [
+            PairingStrategy::All,
+            PairingStrategy::AllAndSelf,
+            PairingStrategy::Adjacent,
+            PairingStrategy::SelfCoverage,
+            PairingStrategy::FirstVsOthers,
+            PairingStrategy::LastVsOthers,
+        ] {
+            assert_eq!(
+                strategy.pairs(&targets).count(),
+                strategy.compare_count(&targets),
+                "strategy: {strategy:?}"
+            );
         }
     }
 
@@ -865,7 +1038,10 @@ mod tests {
     }
 
     fn elements(name: &str, data: Data) -> Elements {
-        Elements { name: name.to_string(), data }
+        Elements {
+            name: name.to_string(),
+            data,
+        }
     }
 
     fn seq(items: &[&str]) -> Data {
@@ -877,19 +1053,36 @@ mod tests {
     }
 
     fn freq(items: &[&str]) -> Data {
-        Data::Freq(seq2freq(&items.iter().map(|s| s.to_string()).collect::<Vec<_>>()))
+        Data::Freq(seq2freq(
+            &items.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+        ))
     }
 
     fn kgram_seq(items: &[&str]) -> Data {
-        Data::KgramSeq(items.iter().map(|s| Kgram::new(vec![s.to_string()])).collect())
+        Data::KgramSeq(
+            items
+                .iter()
+                .map(|s| Kgram::new(vec![s.to_string()]))
+                .collect(),
+        )
     }
 
     fn kgram_set(items: &[&str]) -> Data {
-        Data::KgramSet(items.iter().map(|s| Kgram::new(vec![s.to_string()])).collect())
+        Data::KgramSet(
+            items
+                .iter()
+                .map(|s| Kgram::new(vec![s.to_string()]))
+                .collect(),
+        )
     }
 
     fn kgram_freq(items: &[&str]) -> Data {
-        Data::KgramFreq(seq2freq(&items.iter().map(|s| Kgram::new(vec![s.to_string()])).collect::<Vec<_>>()))
+        Data::KgramFreq(seq2freq(
+            &items
+                .iter()
+                .map(|s| Kgram::new(vec![s.to_string()]))
+                .collect::<Vec<_>>(),
+        ))
     }
 
     /// Every set-like comparator must report 1.0 for identical inputs across
@@ -967,7 +1160,7 @@ mod tests {
         let mut b2 = birthmark("b", &[("main", &["A"])]);
         b2.metadata.birthmark_type = BirthmarkType::OpSet;
         match Jaccard.compare_birthmarks(&b1, &b2, &Aggregator::Hungarian) {
-            Err(Error::Mismatch(..)) => {},
+            Err(Error::Mismatch(..)) => {}
             Err(e) => panic!("unexpected error: {e}"),
             Ok(_) => panic!("expected a mismatch error"),
         }
@@ -979,32 +1172,43 @@ mod tests {
         let filled = birthmark("filled", &[("main", &["A"])]);
 
         // both empty means identical
-        let both = Jaccard.compare_birthmarks(&empty, &empty, &Aggregator::Hungarian).unwrap();
+        let both = Jaccard
+            .compare_birthmarks(&empty, &empty, &Aggregator::Hungarian)
+            .unwrap();
         assert_eq!(both.similarity(), 1.0);
 
         // exactly one empty means nothing in common
-        let one = Jaccard.compare_birthmarks(&empty, &filled, &Aggregator::Hungarian).unwrap();
+        let one = Jaccard
+            .compare_birthmarks(&empty, &filled, &Aggregator::Hungarian)
+            .unwrap();
         assert_eq!(one.similarity(), 0.0);
-        let other = Jaccard.compare_birthmarks(&filled, &empty, &Aggregator::Hungarian).unwrap();
+        let other = Jaccard
+            .compare_birthmarks(&filled, &empty, &Aggregator::Hungarian)
+            .unwrap();
         assert_eq!(other.similarity(), 0.0);
     }
 
     #[test]
     fn compare_birthmarks_of_identical_inputs_scores_one() {
         let b = birthmark("a", &[("f", &["A", "B"]), ("g", &["C"])]);
-        for aggregator in [Aggregator::Hungarian, Aggregator::TopN(Size::All), Aggregator::TopN(Size::Num(1))] {
+        for aggregator in [
+            Aggregator::Hungarian,
+            Aggregator::TopN(Size::All),
+            Aggregator::TopN(Size::Num(1)),
+        ] {
             let c = Jaccard.compare_birthmarks(&b, &b, &aggregator).unwrap();
-            assert!((c.similarity() - 1.0).abs() < 1e-9, "aggregator: {aggregator:?}");
+            assert!(
+                (c.similarity() - 1.0).abs() < 1e-9,
+                "aggregator: {aggregator:?}"
+            );
         }
     }
 
     #[test]
     fn top_n_selection_limits_the_number_of_scores() {
-        let matrix = Array2::from_shape_vec((3, 3), vec![
-            1.0, 0.0, 0.0,
-            0.0, 1.0, 0.0,
-            0.0, 0.0, 1.0,
-        ]).unwrap();
+        let matrix =
+            Array2::from_shape_vec((3, 3), vec![1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0])
+                .unwrap();
         // Size::Num(k) keeps k row maxima plus k column maxima
         let picked = top_n_selection(&matrix, &Size::Num(2)).unwrap();
         assert_eq!(picked.len(), 4);
@@ -1017,8 +1221,18 @@ mod tests {
     #[test]
     fn comparison_similarity_is_zero_when_no_scores_were_aggregated() {
         let b = birthmark("a", &[("f", &["A"])]);
-        let c = Comparison::new(&b, &b, Array2::zeros((0, 0)), vec![], std::time::Duration::from_nanos(0));
-        assert_eq!(c.similarity(), 0.0, "an empty aggregation must not produce NaN");
+        let c = Comparison::new(
+            &b,
+            &b,
+            Array2::zeros((0, 0)),
+            vec![],
+            std::time::Duration::from_nanos(0),
+        );
+        assert_eq!(
+            c.similarity(),
+            0.0,
+            "an empty aggregation must not produce NaN"
+        );
         assert_eq!(c.duration(), std::time::Duration::from_nanos(0));
     }
 
@@ -1026,7 +1240,9 @@ mod tests {
     fn comparison_store_writes_a_parsable_matrix() {
         let b1 = birthmark("left", &[("f", &["A", "B"]), ("g", &["B"])]);
         let b2 = birthmark("right", &[("h", &["A"]), ("i", &["B"])]);
-        let c = Jaccard.compare_birthmarks(&b1, &b2, &Aggregator::Hungarian).unwrap();
+        let c = Jaccard
+            .compare_birthmarks(&b1, &b2, &Aggregator::Hungarian)
+            .unwrap();
 
         let dir = tempfile::tempdir().unwrap();
         let dest = dir.path().join("00000.csv");
@@ -1042,13 +1258,21 @@ mod tests {
         assert!(content.contains("\nright,birthmark,left,"));
         assert!(content.contains("\nmatrix,,"));
         // one line per row element, each prefixed with its index
-        assert_eq!(content.lines().filter(|l| l.starts_with('0') || l.starts_with('1')).count(), 2);
+        assert_eq!(
+            content
+                .lines()
+                .filter(|l| l.starts_with('0') || l.starts_with('1'))
+                .count(),
+            2
+        );
     }
 
     #[test]
     fn comparison_store_reports_io_errors() {
         let b = birthmark("a", &[("f", &["A"])]);
-        let c = Jaccard.compare_birthmarks(&b, &b, &Aggregator::Hungarian).unwrap();
+        let c = Jaccard
+            .compare_birthmarks(&b, &b, &Aggregator::Hungarian)
+            .unwrap();
         // a directory that does not exist cannot receive the result file
         let err = c.store("no/such/directory/out.csv").unwrap_err();
         assert!(matches!(err, Error::Io(..)));
@@ -1057,13 +1281,24 @@ mod tests {
     #[test]
     fn comparator_dispatches_every_algorithm() {
         let b = birthmark("a", &[("f", &["A", "B"])]);
-        for algorithm in [Algorithm::Cosine, Algorithm::Dice, Algorithm::Euclidean,
-                          Algorithm::Jaccard, Algorithm::Levenshtein, Algorithm::Lcs,
-                          Algorithm::Simpson, Algorithm::WeightedJaccard] {
+        for algorithm in [
+            Algorithm::Cosine,
+            Algorithm::Dice,
+            Algorithm::Euclidean,
+            Algorithm::Jaccard,
+            Algorithm::Levenshtein,
+            Algorithm::Lcs,
+            Algorithm::Simpson,
+            Algorithm::WeightedJaccard,
+        ] {
             let comparator = algorithm.comparator();
-            let c = comparator.compare_birthmarks(&b, &b, &Aggregator::Hungarian)
+            let c = comparator
+                .compare_birthmarks(&b, &b, &Aggregator::Hungarian)
                 .unwrap_or_else(|e| panic!("{algorithm}: {e}"));
-            assert!((c.similarity() - 1.0).abs() < 1e-9, "algorithm: {algorithm}");
+            assert!(
+                (c.similarity() - 1.0).abs() < 1e-9,
+                "algorithm: {algorithm}"
+            );
         }
     }
 
@@ -1071,11 +1306,20 @@ mod tests {
     fn similarity_functions_agree_with_their_full_memory_variants() {
         let a = ["A", "B", "C", "D"];
         let b = ["A", "C", "D", "E"];
-        assert!((longest_common_subsequence(&a, &b) - longest_common_subsequence_full_memory(&a, &b)).abs() < 1e-9);
-        assert!((levenshtein_distance(&a, &b) - levenshtein_distance_full_memory(&a, &b)).abs() < 1e-9);
+        assert!(
+            (longest_common_subsequence(&a, &b) - longest_common_subsequence_full_memory(&a, &b))
+                .abs()
+                < 1e-9
+        );
+        assert!(
+            (levenshtein_distance(&a, &b) - levenshtein_distance_full_memory(&a, &b)).abs() < 1e-9
+        );
         // the row/column swap for the shorter sequence must not change the score
         let short = ["A", "B"];
-        assert!((longest_common_subsequence(&a, &short) - longest_common_subsequence(&short, &a)).abs() < 1e-9);
+        assert!(
+            (longest_common_subsequence(&a, &short) - longest_common_subsequence(&short, &a)).abs()
+                < 1e-9
+        );
         assert!((levenshtein_distance(&a, &short) - levenshtein_distance(&short, &a)).abs() < 1e-9);
     }
 

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -2,18 +2,24 @@ use std::path::Path;
 
 use rustc_hash::FxHashMap;
 
-use crate::{Result, Error, Iterable};
-use crate::birthmarks::{Birthmark, BirthmarkType, Data, Elements, Metadata, Kgram};
-use crate::program::{Program, Function};
+use crate::birthmarks::{Birthmark, BirthmarkType, Data, Elements, Kgram, Metadata};
+use crate::program::{Function, Program};
+use crate::{Error, Iterable, Result};
 
 /// Generates the file name for the extracted birthmark JSON file.
-/// The format of resultant file name is `{original_file_stem}_{hash}.json`, 
+/// The format of resultant file name is `{original_file_stem}_{hash}.json`,
 /// where `original_file_stem` is the stem of the input source file and
 /// `hash` is a hash value generated from the content of the source file
 /// to ensure uniqueness and avoid overwriting files with the same name.
 pub fn dest_file_name(program_path: &Path) -> Result<String> {
-    let file_name = program_path.file_stem()
-        .ok_or_else(|| Error::Parse(format!("{}: cannot determine the file stem", program_path.display())))?
+    let file_name = program_path
+        .file_stem()
+        .ok_or_else(|| {
+            Error::Parse(format!(
+                "{}: cannot determine the file stem",
+                program_path.display()
+            ))
+        })?
         .to_string_lossy();
     let hash = get_hash(program_path);
     let new_filename = format!("{file_name}_{}.json", hash?);
@@ -21,12 +27,15 @@ pub fn dest_file_name(program_path: &Path) -> Result<String> {
 }
 
 fn get_hash(path: &Path) -> Result<String> {
-    use std::io::{Read, Seek};
     use sha2::Digest;
+    use std::io::{Read, Seek};
     let pbuf = path.to_path_buf();
 
     let mut file = std::fs::File::open(path).map_err(|e| Error::Io(pbuf.clone(), e))?;
-    let len = file.metadata().map_err(|e| Error::Io(pbuf.clone(), e))?.len();
+    let len = file
+        .metadata()
+        .map_err(|e| Error::Io(pbuf.clone(), e))?
+        .len();
 
     let mut hasher = sha2::Sha256::new();
     // the file length participates in the hash so that same-prefix/suffix
@@ -35,15 +44,18 @@ fn get_hash(path: &Path) -> Result<String> {
 
     // Read the first 4KB of the file for hashing
     let mut head = vec![0; 4096.min(len as usize)];
-    file.read_exact(&mut head).map_err(|e| Error::Io(pbuf.clone(), e))?;
+    file.read_exact(&mut head)
+        .map_err(|e| Error::Io(pbuf.clone(), e))?;
     hasher.update(&head);
 
     if len > 4096 {
         // Read the last (up to) 4KB of the file, without overlapping the head
         let tail_len = 4096.min(len as usize - 4096);
         let mut tail = vec![0; tail_len];
-        file.seek(std::io::SeekFrom::End(-(tail_len as i64))).map_err(|e| Error::Io(pbuf.clone(), e))?;
-        file.read_exact(&mut tail).map_err(|e| Error::Io(pbuf.clone(), e))?;
+        file.seek(std::io::SeekFrom::End(-(tail_len as i64)))
+            .map_err(|e| Error::Io(pbuf.clone(), e))?;
+        file.read_exact(&mut tail)
+            .map_err(|e| Error::Io(pbuf.clone(), e))?;
         hasher.update(&tail);
     }
     let hash = hasher.finalize();
@@ -60,7 +72,8 @@ impl Extractor {
     }
 
     pub fn extract<T: crate::Op>(&self, args: Vec<&Program<T>>) -> Result<Vec<Birthmark>> {
-        let result = args.iter()
+        let result = args
+            .iter()
             .map(|p| extract_birthmark_op(p, &self.bt))
             .collect::<Vec<_>>();
         Error::vec_result_to_result_vec(result)
@@ -73,22 +86,28 @@ impl Extractor {
 
 fn extract_birthmark_op<T: crate::Op>(p: &Program<T>, bt: &BirthmarkType) -> Result<Birthmark> {
     let now = std::time::Instant::now();
-    let elements = p.iter().map(|f| {
-        let name = f.name().to_string();
-        let data = match bt {
-            BirthmarkType::FcFreq => Data::Freq(extract_function_calls_freq(f, p)),
-            BirthmarkType::FcSet => Data::Set(extract_function_calls_freq(f, p).into_keys().collect()),
-            BirthmarkType::FcSeq => Data::Seq(extract_function_calls(f, p)),
-            BirthmarkType::OpFreq => Data::Freq(f.ops_freq()),
-            BirthmarkType::OpSet => Data::Set(f.ops_freq().into_keys().collect()),
-            BirthmarkType::OpSeq => Data::Seq(f.ops().map(|s| s.into()).collect()),
-            BirthmarkType::OpKgramSeq(k) => Data::KgramSeq(extract_op_kgram_seq(f, *k)),
-            BirthmarkType::OpKgramFreq(k) => Data::KgramFreq(extract_op_kgram_freq(f, *k)),
-            BirthmarkType::OpKgramSet(k) => Data::KgramSet(extract_op_kgram_seq(f, *k)
-                .into_iter().collect()),
-        };
-        Elements { name, data }
-    }).collect::<Vec<_>>();
+    let elements = p
+        .iter()
+        .map(|f| {
+            let name = f.name().to_string();
+            let data = match bt {
+                BirthmarkType::FcFreq => Data::Freq(extract_function_calls_freq(f, p)),
+                BirthmarkType::FcSet => {
+                    Data::Set(extract_function_calls_freq(f, p).into_keys().collect())
+                }
+                BirthmarkType::FcSeq => Data::Seq(extract_function_calls(f, p)),
+                BirthmarkType::OpFreq => Data::Freq(f.ops_freq()),
+                BirthmarkType::OpSet => Data::Set(f.ops_freq().into_keys().collect()),
+                BirthmarkType::OpSeq => Data::Seq(f.ops().map(|s| s.into()).collect()),
+                BirthmarkType::OpKgramSeq(k) => Data::KgramSeq(extract_op_kgram_seq(f, *k)),
+                BirthmarkType::OpKgramFreq(k) => Data::KgramFreq(extract_op_kgram_freq(f, *k)),
+                BirthmarkType::OpKgramSet(k) => {
+                    Data::KgramSet(extract_op_kgram_seq(f, *k).into_iter().collect())
+                }
+            };
+            Elements { name, data }
+        })
+        .collect::<Vec<_>>();
     let metadata = build_metadata(p, bt.clone(), now);
     Ok(Birthmark {
         metadata,
@@ -97,11 +116,19 @@ fn extract_birthmark_op<T: crate::Op>(p: &Program<T>, bt: &BirthmarkType) -> Res
     })
 }
 
-fn build_metadata<T>(p: &Program<T>, bt: BirthmarkType, start_time: std::time::Instant) -> Metadata {
+fn build_metadata<T>(
+    p: &Program<T>,
+    bt: BirthmarkType,
+    start_time: std::time::Instant,
+) -> Metadata {
     let extracted_at = chrono::Utc::now();
     let duration = start_time.elapsed();
     let path = p.path().to_path_buf();
-    let name = path.file_name().unwrap_or_default().to_string_lossy().to_string();
+    let name = path
+        .file_name()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_string();
     Metadata {
         file_name: name,
         path,
@@ -112,7 +139,9 @@ fn build_metadata<T>(p: &Program<T>, bt: BirthmarkType, start_time: std::time::I
 }
 
 fn extract_op_kgram_seq<T: crate::Op>(f: &Function<T>, k: usize) -> Vec<Kgram> {
-    f.ops().map(|s| s.into()).collect::<Vec<_>>()
+    f.ops()
+        .map(|s| s.into())
+        .collect::<Vec<_>>()
         .windows(k)
         .map(|w| Kgram::new(w.to_vec()))
         .collect()
@@ -126,22 +155,26 @@ pub(crate) fn seq_to_freq<T>(seq: impl Iterator<Item = T>) -> FxHashMap<T, usize
 where
     T: std::hash::Hash + Eq,
 {
-    seq.into_iter()
-        .fold(FxHashMap::default(), |mut acc, item| {
-            *acc.entry(item).or_insert(0) += 1;
-            acc
-        })
+    seq.into_iter().fold(FxHashMap::default(), |mut acc, item| {
+        *acc.entry(item).or_insert(0) += 1;
+        acc
+    })
 }
 
 fn extract_function_calls<T: crate::Op>(f: &Function<T>, p: &Program<T>) -> Vec<String> {
-    f.iter().filter(|op| op.mnemonic() == "CALL")
+    f.iter()
+        .filter(|op| op.mnemonic() == "CALL")
         .filter_map(|op| op.inputs().first().and_then(|addr| p.symbol(addr)))
         .map(|s| s.to_string())
         .collect()
 }
 
-fn extract_function_calls_freq<T: crate::Op>(f: &Function<T>, p: &Program<T>) -> FxHashMap<String, usize> {
-    extract_function_calls(f, p).into_iter()
+fn extract_function_calls_freq<T: crate::Op>(
+    f: &Function<T>,
+    p: &Program<T>,
+) -> FxHashMap<String, usize> {
+    extract_function_calls(f, p)
+        .into_iter()
         .fold(FxHashMap::default(), |mut acc, call| {
             *acc.entry(call).or_insert(0) += 1;
             acc
@@ -171,7 +204,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let file_path = dir.path().join("large_test.txt");
         let mut file = std::fs::File::create(&file_path).unwrap();
-        
+
         // Write 10KB of data
         let data = vec![0u8; 10240];
         file.write_all(&data).unwrap();
@@ -228,4 +261,3 @@ mod tests {
         assert!(result.unwrap().is_empty());
     }
 }
-

--- a/src/ghidra.rs
+++ b/src/ghidra.rs
@@ -1,30 +1,32 @@
-use std::{path::{Path, PathBuf}, str::FromStr};
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
-use serde::{Deserialize, Serialize, Serializer, de::DeserializeOwned};
-use crate::{Result, Error};
 use crate::ghidra::pcode::PcodeOp;
 use crate::program::Program;
+use crate::{Error, Result};
+use serde::{Deserialize, Serialize, Serializer, de::DeserializeOwned};
 
-pub mod pcode;
 pub(crate) mod lifter;
+pub mod pcode;
 
-impl<T> TryFrom<PathBuf> for Program<T> 
+impl<T> TryFrom<PathBuf> for Program<T>
 where
-    T: DeserializeOwned + crate::Op
+    T: DeserializeOwned + crate::Op,
 {
     type Error = Error;
 
     fn try_from(path: PathBuf) -> Result<Self> {
         std::fs::File::open(&path)
             .map_err(|e| Error::Io(path.clone(), e))
-            .and_then(|f| serde_json::from_reader(f)
-                .map_err(|e| Error::Json(path, e)))
+            .and_then(|f| serde_json::from_reader(f).map_err(|e| Error::Json(path, e)))
     }
 }
 
 impl<T> TryFrom<&Path> for Program<T>
 where
-    T: DeserializeOwned + crate::Op
+    T: DeserializeOwned + crate::Op,
 {
     type Error = Error;
 
@@ -116,18 +118,25 @@ impl FromStr for Value {
             u64::from_str_radix(&parts[1][2..], 16)
         } else {
             parts[1].parse()
-        }.map_err(|e| Error::ParseInt(parts[1].to_string(), e))?;
+        }
+        .map_err(|e| Error::ParseInt(parts[1].to_string(), e))?;
 
-        let size = parts[2].parse()
+        let size = parts[2]
+            .parse()
             .map_err(|e| Error::ParseInt(parts[2].to_string(), e))?;
 
-        Ok(Value { storage, address, size })
+        Ok(Value {
+            storage,
+            address,
+            size,
+        })
     }
 }
 
 impl<'de> Deserialize<'de> for Value {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-            where D: serde::Deserializer<'de> 
+    where
+        D: serde::Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
         FromStr::from_str(&s).map_err(serde::de::Error::custom)
@@ -147,15 +156,14 @@ impl Serialize for Value {
 #[cfg(test)]
 mod tests {
     use crate::program::Program;
-    use crate::{Op, Iterable};
+    use crate::{Iterable, Op};
 
     use super::*;
 
     #[test]
     fn parse_pcode_value() {
         let s = "(ram, 0x1000497b0, 8)";
-        let value: Value = s.parse()
-            .expect("Failed to parse PCodeValue");
+        let value: Value = s.parse().expect("Failed to parse PCodeValue");
         assert_eq!(value.storage, StorageType::Ram);
         assert_eq!(value.address, 0x1000497b0);
         assert_eq!(value.size, 8);
@@ -176,10 +184,12 @@ mod tests {
     fn parse_pcode_json() {
         let file = std::fs::File::open("testdata/hello_world/pcodes/hello_clang.json")
             .expect("Failed to open JSON file");
-        let r: Program<super::Op> = serde_json::from_reader(file)
-            .expect("Failed to parse JSON");
+        let r: Program<super::Op> = serde_json::from_reader(file).expect("Failed to parse JSON");
         assert_eq!(r.name(), "hello_clang");
-        assert_eq!(r.path(), std::path::Path::new("testdata/hello_world/bin/hello_clang"));
+        assert_eq!(
+            r.path(),
+            std::path::Path::new("testdata/hello_world/bin/hello_clang")
+        );
         assert_eq!(r.len(), 1);
 
         let f1 = r.iter().next().unwrap();
@@ -195,12 +205,10 @@ mod tests {
         assert_eq!(op2.ret(), Some("(unique, 0x10000009, 8)"));
     }
 
-
     #[test]
     fn parse_pcode_json2() {
         let file = std::fs::File::open("testdata/hello_world/pcodes/hello_gcc.json")
             .expect("Failed to open JSON file");
-        let _r: Program<super::Op> = serde_json::from_reader(file)
-            .expect("Failed to parse JSON");
+        let _r: Program<super::Op> = serde_json::from_reader(file).expect("Failed to parse JSON");
     }
 }

--- a/src/ghidra/lifter.rs
+++ b/src/ghidra/lifter.rs
@@ -1,6 +1,6 @@
-use std::path::{Path, PathBuf};
-use crate::{Result, Error};
 use crate::lift::Lifter;
+use crate::{Error, Result};
+use std::path::{Path, PathBuf};
 
 pub const DEFAULT_GHIDRA_SCRIPT: &str = include_str!("../../lifter/scripts/HighPCodeLifter.java");
 
@@ -12,7 +12,11 @@ pub struct GhidraLifter {
 
 impl GhidraLifter {
     pub fn new(home: PathBuf, script: Option<PathBuf>, intermediate_dir: Option<PathBuf>) -> Self {
-        Self { home, script, intermediate_dir }
+        Self {
+            home,
+            script,
+            intermediate_dir,
+        }
     }
 }
 
@@ -20,32 +24,44 @@ impl Lifter for GhidraLifter {
     fn lift(&self, input: &Path, output: &Path) -> Result<()> {
         let analyze_headless = self.home.join("support/analyzeHeadless");
         if !analyze_headless.exists() {
-            return Err(Error::Parse(format!("Ghidra headless analyzer not found at {:?}", analyze_headless)));
+            return Err(Error::Parse(format!(
+                "Ghidra headless analyzer not found at {:?}",
+                analyze_headless
+            )));
         }
 
         let (script_path, _temp_dir) = if let Some(s) = &self.script {
             let s = std::fs::canonicalize(s).map_err(|e| Error::Io(s.clone(), e))?;
             (s, None)
         } else {
-            let temp_dir = tempfile::Builder::new().prefix("oinkie_script").tempdir().map_err(|e| Error::Io(PathBuf::from("temp"), e))?;
+            let temp_dir = tempfile::Builder::new()
+                .prefix("oinkie_script")
+                .tempdir()
+                .map_err(|e| Error::Io(PathBuf::from("temp"), e))?;
             let script_file = temp_dir.path().join("HighPCodeLifter.java");
             std::fs::write(&script_file, DEFAULT_GHIDRA_SCRIPT)
                 .map_err(|e| Error::Io(script_file.clone(), e))?;
             (script_file, Some(temp_dir))
         };
-        let script_dir = script_path.parent()
+        let script_dir = script_path
+            .parent()
             .ok_or_else(|| Error::Parse(format!("Invalid script path: {:?}", script_path)))?;
-        let script_name = script_path.file_name()
+        let script_name = script_path
+            .file_name()
             .ok_or_else(|| Error::Parse(format!("Invalid script path: {:?}", script_path)))?;
 
         let (proj_dir, _temp_proj_dir) = if let Some(i) = &self.intermediate_dir {
             (i.to_path_buf(), None)
         } else {
-            let temp_proj = tempfile::Builder::new().prefix("oinkie_proj").tempdir().map_err(|e| Error::Io(PathBuf::from("temp"), e))?;
+            let temp_proj = tempfile::Builder::new()
+                .prefix("oinkie_proj")
+                .tempdir()
+                .map_err(|e| Error::Io(PathBuf::from("temp"), e))?;
             (temp_proj.path().to_path_buf(), Some(temp_proj))
         };
 
-        let proj_name = input.file_name()
+        let proj_name = input
+            .file_name()
             .and_then(|n| n.to_str())
             .ok_or_else(|| Error::Parse(format!("Invalid input path: {:?}", input)))?;
         // the working directory of the Ghidra process is the project directory,
@@ -53,23 +69,32 @@ impl Lifter for GhidraLifter {
         let input = std::fs::canonicalize(input).map_err(|e| Error::Io(input.to_path_buf(), e))?;
 
         let mut command = std::process::Command::new(&analyze_headless);
-        command.arg(&proj_dir)
-               .arg(proj_name)
-               .arg("-import").arg(&input)
-               .arg("-scriptPath").arg(script_dir)
-               .arg("-postScript").arg(script_name)
-               // The lifter script writes "{program name}.json" into the working
-               // directory of the Ghidra process. Run it inside the project
-               // directory so that concurrent lifts of same-named binaries do not
-               // race on a single path in the user's current directory.
-               .current_dir(&proj_dir);
+        command
+            .arg(&proj_dir)
+            .arg(proj_name)
+            .arg("-import")
+            .arg(&input)
+            .arg("-scriptPath")
+            .arg(script_dir)
+            .arg("-postScript")
+            .arg(script_name)
+            // The lifter script writes "{program name}.json" into the working
+            // directory of the Ghidra process. Run it inside the project
+            // directory so that concurrent lifts of same-named binaries do not
+            // race on a single path in the user's current directory.
+            .current_dir(&proj_dir);
 
         log::info!("Executing Ghidra: {:?}", command);
-        let output_res = command.output().map_err(|e| Error::Io(analyze_headless, e))?;
+        let output_res = command
+            .output()
+            .map_err(|e| Error::Io(analyze_headless, e))?;
         if !output_res.status.success() {
             let stderr = String::from_utf8_lossy(&output_res.stderr);
             let stdout = String::from_utf8_lossy(&output_res.stdout);
-            return Err(Error::Parse(format!("Ghidra failed with status {}.\nSTDOUT: {}\nSTDERR: {}", output_res.status, stdout, stderr)));
+            return Err(Error::Parse(format!(
+                "Ghidra failed with status {}.\nSTDOUT: {}\nSTDERR: {}",
+                output_res.status, stdout, stderr
+            )));
         }
 
         // Move the generated JSON to the destination
@@ -83,7 +108,10 @@ impl Lifter for GhidraLifter {
                 let _ = std::fs::remove_file(&generated_json);
             }
         } else {
-            return Err(Error::Parse(format!("Expected Ghidra to generate {:?}, but it was not found.", generated_json)));
+            return Err(Error::Parse(format!(
+                "Expected Ghidra to generate {:?}, but it was not found.",
+                generated_json
+            )));
         }
 
         Ok(())
@@ -130,7 +158,9 @@ mod tests {
     fn test_find_ghidra_home_with_env() {
         // Backup the env
         let old_env = env::var("GHIDRA_HOME").ok();
-        unsafe { env::set_var("GHIDRA_HOME", "/env/ghidra/home"); }
+        unsafe {
+            env::set_var("GHIDRA_HOME", "/env/ghidra/home");
+        }
 
         let result = find_ghidra_home(None);
         assert!(result.is_ok());
@@ -138,9 +168,13 @@ mod tests {
 
         // Restore env
         if let Some(val) = old_env {
-            unsafe { env::set_var("GHIDRA_HOME", val); }
+            unsafe {
+                env::set_var("GHIDRA_HOME", val);
+            }
         } else {
-            unsafe { env::remove_var("GHIDRA_HOME"); }
+            unsafe {
+                env::remove_var("GHIDRA_HOME");
+            }
         }
     }
 
@@ -148,7 +182,9 @@ mod tests {
     fn test_find_ghidra_home_not_found() {
         // Backup the env
         let old_env = env::var("GHIDRA_HOME").ok();
-        unsafe { env::remove_var("GHIDRA_HOME"); }
+        unsafe {
+            env::remove_var("GHIDRA_HOME");
+        }
 
         let result = find_ghidra_home(None);
         // It might find it in standard paths on some systems, so we can't definitively assert error
@@ -157,7 +193,9 @@ mod tests {
 
         // Restore env
         if let Some(val) = old_env {
-            unsafe { env::set_var("GHIDRA_HOME", val); }
+            unsafe {
+                env::set_var("GHIDRA_HOME", val);
+            }
         }
     }
 
@@ -187,7 +225,7 @@ mod tests {
         match result {
             Err(Error::Parse(msg)) => {
                 assert!(msg.contains("Ghidra headless analyzer not found at"));
-            },
+            }
             _ => panic!("Expected Error::Parse"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,12 @@ use ndarray::ShapeError;
 
 use crate::prelude::BirthmarkType;
 
-pub mod lift;
-pub mod ghidra;
-pub mod prelude;
-pub mod extractor;
-mod compare;
 mod birthmarks;
+mod compare;
+pub mod extractor;
+pub mod ghidra;
+pub mod lift;
+pub mod prelude;
 mod program;
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -42,7 +42,7 @@ impl std::fmt::Display for Error {
                     write!(f, "\n  {}. {}", i + 1, err)?;
                 }
                 Ok(())
-            },
+            }
             Error::BirthmarkType(t) => write!(f, "{t}: unknown birthmark type"),
             Error::Csv(e) => write!(f, "CSV error: {}", e),
             Error::InvalidPcode(code) => write!(f, "invalid pcode: {code}"),

--- a/src/lift.rs
+++ b/src/lift.rs
@@ -1,7 +1,7 @@
-use std::path::{Path, PathBuf};
-use serde::{Deserialize, Serialize};
-use clap::ValueEnum;
 use crate::Result;
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
 
 pub trait Lifter {
     fn lift(&self, input: &Path, output: &Path) -> Result<()>;
@@ -11,7 +11,8 @@ pub trait Lifter {
 #[clap(rename_all = "kebab-case")]
 pub enum LifterType {
     Ghidra,
-    Llvm,
+    Angr,
+    IDAPro,
     BinaryNinja,
 }
 
@@ -57,8 +58,15 @@ impl LifterBuilder {
                     self.intermediate_dir,
                 )))
             }
-            LifterType::Llvm => Err(crate::Error::Parse("LLVM lifter is not yet implemented.".to_string())),
-            LifterType::BinaryNinja => Err(crate::Error::Parse("Binary Ninja lifter is not yet implemented.".to_string())),
+            LifterType::Angr => Err(crate::Error::Parse(
+                "angr lifter is not yet implemented.".to_string(),
+            )),
+            LifterType::IDAPro => Err(crate::Error::Parse(
+                "IDA Pro lifter is not yet implemented.".to_string(),
+            )),
+            LifterType::BinaryNinja => Err(crate::Error::Parse(
+                "Binary Ninja lifter is not yet implemented.".to_string(),
+            )),
         }
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,13 +1,14 @@
-pub use crate::{Error, Result, Op, Iterable};
-pub use crate::lift::{Lifter, LifterType, LifterBuilder};
-pub use crate::compare::{Aggregator, Algorithm, Comparator, Comparison, PairingStrategy, escape_csv_string};
-pub use crate::birthmarks::{BirthmarkType, AnalysisType, Data, Kgram, Metadata};
-pub use crate::program::{Program, Function};
+pub use crate::birthmarks::{AnalysisType, BirthmarkType, Data, Kgram, Metadata};
 pub use crate::birthmarks::{Birthmark, Elements};
+pub use crate::compare::{
+    Aggregator, Algorithm, Comparator, Comparison, PairingStrategy, escape_csv_string,
+};
 pub use crate::extractor::Extractor;
+pub use crate::lift::{Lifter, LifterBuilder, LifterType};
+pub use crate::program::{Function, Program};
+pub use crate::{Error, Iterable, Op, Result};
 
 pub trait CsvInfo {
     fn csv_info(&self) -> String;
     fn names(&self) -> Vec<String>;
 }
-

--- a/src/program.rs
+++ b/src/program.rs
@@ -18,14 +18,21 @@ pub struct Program<T> {
 
 impl<T> crate::prelude::CsvInfo for Program<T> {
     fn csv_info(&self) -> String {
-        let json_path = self.json_path.as_ref().map(|p| p.display().to_string()).unwrap_or_default();
-        format!("program,{},{},{},{},{}",
+        let json_path = self
+            .json_path
+            .as_ref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_default();
+        format!(
+            "program,{},{},{},{},{}",
             crate::compare::escape_csv_string(&self.name),
             crate::compare::escape_csv_string(&self.path.display().to_string()),
-            self.symbols.len(), self.functions.len(),
-            crate::compare::escape_csv_string(&json_path))
+            self.symbols.len(),
+            self.functions.len(),
+            crate::compare::escape_csv_string(&json_path)
+        )
     }
-    
+
     fn names(&self) -> Vec<String> {
         self.functions.iter().map(|f| f.name.clone()).collect()
     }
@@ -36,8 +43,19 @@ impl<T> Program<T> {
         self.json_path = Some(path);
     }
 
-    pub fn new(name: String, path: PathBuf, symbols: FxHashMap<String, String>, functions: Vec<Function<T>>) -> Self {
-        Self { name, path, symbols, functions, json_path: None }
+    pub fn new(
+        name: String,
+        path: PathBuf,
+        symbols: FxHashMap<String, String>,
+        functions: Vec<Function<T>>,
+    ) -> Self {
+        Self {
+            name,
+            path,
+            symbols,
+            functions,
+            json_path: None,
+        }
     }
 
     pub fn name(&self) -> &str {
@@ -82,7 +100,7 @@ impl<T> Iterable for Program<T> {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Function<T> {
     name: String,
-    ops: Vec<T>
+    ops: Vec<T>,
 }
 
 impl<T: crate::Op> Function<T> {

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -14,14 +14,14 @@ fn test_info_command() {
         .stdout(predicate::str::contains("Compare Algorithms"));
 }
 
-
 #[test]
 fn test_lift_command() {
     let temp_dir = tempdir().unwrap();
     let dest = temp_dir.path().join("lifted");
 
     let mut cmd = Command::cargo_bin("oinkie").unwrap();
-    let result = cmd.arg("lift")
+    let result = cmd
+        .arg("lift")
         .arg("-d")
         .arg(&dest)
         .arg("-l")
@@ -38,7 +38,7 @@ fn test_lift_command() {
 fn test_extract_command() {
     let temp_dir = tempdir().unwrap();
     let dest = temp_dir.path().join("birthmarks");
-    
+
     let mut cmd = Command::cargo_bin("oinkie").unwrap();
     cmd.arg("extract")
         .arg("-d")
@@ -51,8 +51,15 @@ fn test_extract_command() {
         .success();
 
     // Verify the output files were created
-    let entries: Vec<_> = fs::read_dir(&dest).unwrap().map(|e| e.unwrap().path()).collect();
-    assert_eq!(entries.len(), 2, "Expected 2 birthmark files to be generated");
+    let entries: Vec<_> = fs::read_dir(&dest)
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .collect();
+    assert_eq!(
+        entries.len(),
+        2,
+        "Expected 2 birthmark files to be generated"
+    );
 }
 
 #[test]
@@ -60,7 +67,7 @@ fn test_compare_command() {
     let temp_dir = tempdir().unwrap();
     let birthmarks_dir = temp_dir.path().join("birthmarks");
     let similarities_dir = temp_dir.path().join("similarities");
-    
+
     // First, extract
     Command::cargo_bin("oinkie")
         .unwrap()
@@ -74,8 +81,11 @@ fn test_compare_command() {
         .assert()
         .success();
 
-    let entries: Vec<_> = fs::read_dir(&birthmarks_dir).unwrap().map(|e| e.unwrap().path()).collect();
-    
+    let entries: Vec<_> = fs::read_dir(&birthmarks_dir)
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .collect();
+
     // Now, compare
     let mut cmd = Command::cargo_bin("oinkie").unwrap();
     cmd.arg("compare")
@@ -91,8 +101,14 @@ fn test_compare_command() {
         .assert()
         .success();
 
-    let sim_entries: Vec<_> = fs::read_dir(&similarities_dir).unwrap().map(|e| e.unwrap().path()).collect();
-    assert!(!sim_entries.is_empty(), "Expected similarity files to be generated");
+    let sim_entries: Vec<_> = fs::read_dir(&similarities_dir)
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .collect();
+    assert!(
+        !sim_entries.is_empty(),
+        "Expected similarity files to be generated"
+    );
 }
 
 #[test]
@@ -103,7 +119,7 @@ fn test_run_command() {
     let mut cmd = Command::cargo_bin("oinkie").unwrap();
     cmd.arg("run")
         .arg("-a")
-        .arg("op-set-jaccard") 
+        .arg("op-set-jaccard")
         .arg("-s")
         .arg("all")
         .arg("-d")
@@ -112,9 +128,15 @@ fn test_run_command() {
         .arg("testdata/hello_world/pcodes/hello_gcc.json")
         .assert()
         .success();
-        
-    let sim_entries: Vec<_> = fs::read_dir(&similarities_dir).unwrap().map(|e| e.unwrap().path()).collect();
-    assert!(!sim_entries.is_empty(), "Expected similarity files to be generated");
+
+    let sim_entries: Vec<_> = fs::read_dir(&similarities_dir)
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .collect();
+    assert!(
+        !sim_entries.is_empty(),
+        "Expected similarity files to be generated"
+    );
 }
 
 #[test]
@@ -122,7 +144,7 @@ fn test_reaggregate_command() {
     let temp_dir = tempdir().unwrap();
     let birthmarks_dir = temp_dir.path().join("birthmarks");
     let similarities_dir = temp_dir.path().join("similarities");
-    
+
     // First, extract
     Command::cargo_bin("oinkie")
         .unwrap()
@@ -136,7 +158,10 @@ fn test_reaggregate_command() {
         .assert()
         .success();
 
-    let entries: Vec<_> = fs::read_dir(&birthmarks_dir).unwrap().map(|e| e.unwrap().path()).collect();
+    let entries: Vec<_> = fs::read_dir(&birthmarks_dir)
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .collect();
 
     // Compare
     Command::cargo_bin("oinkie")

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -1,5 +1,5 @@
-use oinkie::prelude::*;
 use oinkie::ghidra::Op;
+use oinkie::prelude::*;
 use std::path::PathBuf;
 
 fn load_program(path: &str) -> Program<Op> {
@@ -37,22 +37,38 @@ fn test_extractor_and_comparator() {
 
         let extracted = extractor.extract(vec![&p1, &p2]).unwrap();
         assert_eq!(extracted.len(), 2);
-    
+
         let comparator = algo.comparator();
-        
+
         // Test with Hungarian aggregator
-        let result_hungarian = comparator.compare_birthmarks(&b1, &b2, &Aggregator::Hungarian).unwrap();
-        assert!(result_hungarian.similarity() >= -0.01 && result_hungarian.similarity() <= 1.01, 
-            "Similarity out of bounds for {:?} and {:?} with Hungarian: {}", bt, algo, result_hungarian.similarity());
+        let result_hungarian = comparator
+            .compare_birthmarks(&b1, &b2, &Aggregator::Hungarian)
+            .unwrap();
+        assert!(
+            result_hungarian.similarity() >= -0.01 && result_hungarian.similarity() <= 1.01,
+            "Similarity out of bounds for {:?} and {:?} with Hungarian: {}",
+            bt,
+            algo,
+            result_hungarian.similarity()
+        );
 
         // Test with TopN aggregator
         use std::str::FromStr;
-        let result_topn = comparator.compare_birthmarks(&b1, &b2, &Aggregator::from_str("topn:all").unwrap()).unwrap();
-        assert!(result_topn.similarity() >= -0.01 && result_topn.similarity() <= 1.01,
-            "Similarity out of bounds for {:?} and {:?} with TopN: {}", bt, algo, result_topn.similarity());
-            
+        let result_topn = comparator
+            .compare_birthmarks(&b1, &b2, &Aggregator::from_str("topn:all").unwrap())
+            .unwrap();
+        assert!(
+            result_topn.similarity() >= -0.01 && result_topn.similarity() <= 1.01,
+            "Similarity out of bounds for {:?} and {:?} with TopN: {}",
+            bt,
+            algo,
+            result_topn.similarity()
+        );
+
         // Test comparing programs directly
-        let result_prog = comparator.compare_programs(&p1, &p2, &Aggregator::Hungarian).unwrap();
+        let result_prog = comparator
+            .compare_programs(&p1, &p2, &Aggregator::Hungarian)
+            .unwrap();
         assert!(result_prog.similarity() >= -0.01 && result_prog.similarity() <= 1.01);
     }
 }
@@ -90,7 +106,7 @@ fn test_empty_comparisons() {
     let p1 = load_program("testdata/hello_world/pcodes/hello_clang.json");
     let ext1 = Extractor::new(BirthmarkType::OpSeq);
     let ext2 = Extractor::new(BirthmarkType::FcSeq);
-    
+
     let b1 = ext1.extract_each(&p1).unwrap();
     let b2 = ext2.extract_each(&p1).unwrap();
 


### PR DESCRIPTION
Fixes #23.

## The bug

`Comparison::new` takes its operands as `(columns, rows)`, and every caller passes `(b1, b2)` — so `columns` is the **first** birthmark. But `store` wrote the records the other way round:

```rust
writeln!(out, "left,{}",  self.rows.csv_info())?;     // b2
writeln!(out, "right,{}", self.columns.csv_info())?;  // b1
```

`read_result_file` maps `left` → `path1` and `right` → `path2`, so the same comparison was recorded differently depending on how it was produced:

| | `path1` | `path2` |
|---|---|---|
| Fresh comparison (`cli/main.rs`) | b1 | b2 |
| `--skip` rerun (reads the CSV) | **b2** | **b1** |

The similarity score is unaffected — every metric here is symmetric — so this never produced a wrong number. What it did produce is a `results.csv` whose pair ordering depends on whether the run recomputed or reused a cached file, which makes the recorded paths unreliable and carries the same inconsistency into `reaggregate`.

## The fix

Two lines in `store`, so that `left` is the first birthmark and `right` the second, matching what `read_result_file` expects and what a fresh run records.

The store test previously asserted the swapped layout — it was written in #21 to pin down the behaviour as it stood, with a `NOTE` comment explaining the inversion. Both the comment and the assertions are now updated to the intended ordering.

## Commits

The PR is three commits, and they are worth reading separately:

| Commit | What |
|---|---|
| `2e5525e` | Move generated completions to `assets/completions`, add file extensions, and refresh the list of planned lifter backends in the README |
| `27f122a` | `cargo fmt` across the crate, plus `cargo fmt --all -- --check` in CI |
| `abd7e17` | The actual fix — 1 file, +4/−8 |

The formatting commit is large (15 files, +1486/−584) but purely mechanical. It is separated deliberately: the tree had never been formatted consistently, so an editor with format-on-save turned a two-line edit into a whole-file diff. Formatting everything once removes the cause, and the `--check` step in CI keeps it from coming back. Reviewing `abd7e17` alone gives the whole behavioural change.

## Verification

On the branch head:

- `cargo test` — 77 passed (62 lib, 6 pcode, 6 E2E against a real Ghidra install, 3 integration)
- `cargo fmt --all -- --check` — passes, so the new CI step is green
- `cargo clippy -- -D warnings` — passes; `27f122a` also cleared a `useless_format` in `cli/gencomp.rs` that the newer clippy flags

## Note for existing users

Only the writer changed. Similarity CSVs generated before this commit still carry the old ordering, and `read_result_file` will keep reading those reversed. A `--skip` run against an existing `similarities/` directory therefore still yields swapped paths, and mixing old and new files in one directory means the interpretation varies per file.

Regenerating the directory is the clean way out. If that is too expensive for a large corpus, the alternative is to make the reader tolerant of both layouts — the `left`/`right` records carry the birthmark paths, so they can be matched against the `path1`/`path2` the caller already has instead of trusting the label. That is out of scope here.