### PR TITLE
fix: widen the birthmark file name hash to 64 bits

### DIFF
--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -6,6 +6,11 @@ use crate::birthmarks::{Birthmark, BirthmarkType, Data, Elements, Kgram, Metadat
 use crate::program::{Function, Program};
 use crate::{Error, Iterable, Result};
 
+/// Number of hex characters kept from the SHA-256 digest. 16 characters
+/// is 64 bits, which puts the birthday bound around 5 billion files;
+/// 8 characters (32 bits) collided at roughly 77,000.
+const HASH_PREFIX_LEN: usize = 16;
+
 /// Generates the file name for the extracted birthmark JSON file.
 /// The format of resultant file name is `{original_file_stem}_{hash}.json`,
 /// where `original_file_stem` is the stem of the input source file and
@@ -59,7 +64,7 @@ fn get_hash(path: &Path) -> Result<String> {
         hasher.update(&tail);
     }
     let hash = hasher.finalize();
-    Ok(format!("{:x}", hash)[..8].to_string())
+    Ok(format!("{:x}", hash)[..HASH_PREFIX_LEN].to_string())
 }
 
 pub struct Extractor {
@@ -259,5 +264,27 @@ mod tests {
         let result = extractor.extract(empty_args);
         assert!(result.is_ok());
         assert!(result.unwrap().is_empty());
+    }
+
+    /// Pins the generated file-name layout: `{stem}_{hash}.json` with the
+    /// digest truncated to a fixed width. The strip_prefix/strip_suffix pair
+    /// fails if the layout changes, and the length is checked against a
+    /// literal rather than HASH_PREFIX_LEN so that widening the prefix trips
+    /// this test — changing it renames every birthmark file and breaks
+    /// `--skip` against existing directories, which should never happen
+    /// silently.
+    #[test]
+    fn test_dest_file_name_hash_length() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("sample.bin");
+        std::fs::write(&file_path, b"contents").unwrap();
+
+        let name = dest_file_name(&file_path).unwrap();
+        let hash = name
+            .strip_prefix("sample_")
+            .and_then(|s| s.strip_suffix(".json"))
+            .expect("unexpected file name layout");
+        assert_eq!(hash.len(), 16);
+        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
     }
 }


### PR DESCRIPTION
Fixes #27.

## The problem

`get_hash` truncated the SHA-256 to 8 hex characters, so the disambiguator in `{file_stem}_{hash}.json` carried only **32 bits**:

```rust
Ok(format!("{:x}", hash)[..8].to_string())
```

By the birthday bound a collision becomes more likely than not at roughly **77,000 files**, and reaches about 1% at 9,300. That is reachable for a tool whose purpose is comparing large corpora, and `--skip` actively encourages a birthmark directory to accumulate across runs.

A collision is silent. Two binaries sharing a file stem produce the same output name and the second extraction overwrites the first — and since `extract` runs in parallel across the whole input list, nothing serialises that write either. The visible result is a comparison run that analyses one binary twice and reports it as two.

## The change

| | Before | After |
|---|---|---|
| Hex characters kept | 8 | **16** |
| Bits | 32 | **64** |
| Birthday bound | ~77,000 files | **~5 billion** |

The width now lives in a named constant carrying the reasoning, rather than sitting in the code as a bare slice index:

```rust
/// Number of hex characters kept from the SHA-256 digest. 16 characters
/// is 64 bits, which puts the birthday bound around 5 billion files;
/// 8 characters (32 bits) collided at roughly 77,000.
const HASH_PREFIX_LEN: usize = 16;
```

Slicing stays safe: `format!("{:x}", …)` of a SHA-256 is always 64 ASCII characters, so `[..16]` is within bounds and on a character boundary.

## The new test

`test_dest_file_name_hash_length` pins the file-name layout (`{stem}_{hash}.json`) and the fact that the digest is truncated at all.

It deliberately checks the length against a **literal `16` rather than `HASH_PREFIX_LEN`**. Comparing against the constant would be circular — the same constant produces the value being measured, so the assertion could never fail. With a literal, changing the width trips this test, which is the point: widening the prefix renames every birthmark file, and that should never happen without someone acknowledging it.

## Verification

- `cargo test` — the extractor suite passes (7 tests), full suite unaffected
- `cargo fmt --all -- --check` — passes
- `cargo clippy -- -D warnings` — passes

I also checked that nothing parses the generated name back apart from producing it: the only `file_stem` use elsewhere is in `cli/reaggregator.rs`, which handles `NNNNN.csv` and is unrelated. The two existing `dest_file_name` tests assert only the prefix, so they are unaffected by the width.

## Compatibility

**This changes generated file names**, exactly as the `get_hash` fix in #12 did. Existing birthmark files will not be recognised by `--skip`, and every input is re-extracted on the first run after upgrading. Previously generated files remain valid inputs to `compare` and `reaggregate`; mixing them with new ones in a single directory is safe but leaves the same binary present under two names.

The release that ships this needs an upgrade note, tracked separately.

## Suggested release grouping

Since this breaks file-name compatibility, it is worth shipping alongside any other user-visible break rather than spending a second migration on it later — #26 (removing the dead `BinaryType` and its `-B` flag) is the obvious candidate if it lands soon.