### PR TITLE
ci: take release notes from a file kept in the repository

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,6 +16,47 @@ jobs:
     permissions:
       contents: write
 
+  # Prepends the hand-written upgrade note for this version to the draft that
+  # release-start opened. The note lives in the repository so that whoever
+  # makes a breaking change writes it while they still have the context,
+  # rather than someone reconstructing it at release time (#31).
+  #
+  # A missing file is a hard failure on purpose: release-start has already
+  # tagged and drafted by this point, so a silent skip is exactly the
+  # "nobody remembered" outcome this is meant to prevent.
+  release-notes:
+    runs-on: ubuntu-latest
+    needs: start
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Prepend the upgrade note to the draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.start.outputs.tag }}
+          VERSION: ${{ needs.start.outputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          notes="docs/release-notes/v${VERSION}.md"
+          if [ ! -f "$notes" ]; then
+            echo "::error::$notes not found. Every release needs an upgrade note; add the file and re-run this job."
+            exit 1
+          fi
+
+          # release-start already drafted the release with --generate-notes, so
+          # the body holds the generated pull request list. Put the hand-written
+          # note above it rather than regenerating, so what ships is exactly
+          # what was reviewed.
+          gh release view "$TAG" --repo "$REPO" --json body --jq '.body' > generated.md
+          { cat "$notes"; echo; cat generated.md; } > notes.md
+          gh release edit "$TAG" --repo "$REPO" --notes-file notes.md
+          echo "release notes for $TAG taken from $notes" >> "$GITHUB_STEP_SUMMARY"
+
   publish:
     runs-on: ${{ matrix.os }}
     needs: start
@@ -117,7 +158,7 @@ jobs:
   # APP_PRIVATE_KEY, carried by `secrets: inherit`) is what makes the
   # `release: published` event fire, so notify-publish actually runs.
   finish:
-    needs: [start, container]
+    needs: [start, container, release-notes]
     uses: tamada/.github/.github/workflows/release-finish.yaml@v1
     with:
       tag: ${{ needs.start.outputs.tag }}

--- a/docs/release-notes/v0.4.0.md
+++ b/docs/release-notes/v0.4.0.md
@@ -1,0 +1,39 @@
+## Upgrading from v0.3.0
+
+Two changes in this release alter files that oinkie generates. Neither affects
+similarity scores, but both matter if you keep a working directory between runs.
+
+**Birthmark file names have changed again.** `oinkie extract` derives the output
+name as `{file_stem}_{hash}.json`, and the hash prefix widened from 8 to 16 hex
+characters (#30) so that the disambiguator carries 64 bits instead of 32. At 32
+bits a collision became likely at roughly 77,000 files, and a collision was
+silent — one binary's birthmark simply overwrote another's.
+
+Names from v0.3.0 therefore do not match those from v0.4.0. On the first run
+with `--skip`, every input is re-extracted. That is expected, not an error.
+Older files remain valid inputs to `compare` and `reaggregate`; the only cost of
+keeping them is that the same binary ends up present under two names.
+
+**Similarity CSVs record the pair in the correct order.** The `left` record used
+to hold the *second* birthmark and `right` the first (#29), so a `--skip` rerun
+read the pair back in the opposite order from a fresh run. The score was never
+affected — the metrics are symmetric — but `results.csv` could not be relied on
+to say which file was on which side.
+
+Only the writer changed. Similarity CSVs written by v0.3.0 or earlier still
+carry the old ordering and will keep being read reversed, and mixing old and new
+files in one directory means the interpretation varies per file. Regenerate the
+directory to get consistent results.
+
+**Shell completions moved.** They are now generated under `assets/completions`,
+one directory per shell, with conventional file names (`oinkie`, `oinkie.elv`,
+`oinkie.fish`, `oinkie.ps1`, `_oinkie`). Packaging scripts that referenced the
+old `completions` directory need updating.
+
+## Highlights
+
+- **#30** — widened the birthmark hash prefix to 64 bits, removing a silent
+  overwrite that was reachable at corpus scale
+- **#29** — fixed the `left`/`right` inversion in similarity CSVs
+- The crate is now formatted with `cargo fmt`, and CI enforces it with
+  `cargo fmt --all -- --check`


### PR DESCRIPTION
Implements the second option from #31.

## The problem

Release notes are produced by `--generate-notes` alone, which yields a list of merged pull requests. That list cannot say *"this release renames every birthmark file"* — and this project keeps producing exactly that kind of break:

- **v0.3.0** — #12 corrected the `get_hash` seek bug, changing the digest for every input
- **v0.4.0** — #30 widens the hash prefix from 8 to 16 hex characters

Both times the upgrade note was written by hand after the release was already out. This moves it into the repository so it stops depending on someone remembering.

## The change

A `release-notes` job that prepends `docs/release-notes/v{version}.md` to the draft that `release-start` opened.

```
start ──┬── release-notes ──┐
        └── publish ── container ──┴── finish
```

Three decisions worth reviewing:

**A missing file fails the job.** `release-start` has already tagged and drafted by this point, so skipping quietly would be precisely the "nobody remembered" outcome this is meant to prevent. The error names the expected path.

**`finish` waits on it.** `finish` is what takes the draft off, so a release can never be published without its note.

**The generated list is read back, not regenerated.** `release-start` already drafted with `--generate-notes`, so the body holds the pull request list; the job reads that and puts the hand-written note above it. Calling `generate-notes` a second time could produce something subtly different from what the draft was reviewed with.

## Also included

`docs/release-notes/v0.4.0.md`, covering what is already on `main` for the next release:

- the file-name change from #30, and what `--skip` does on the first run afterwards
- the `left`/`right` ordering fix from #29, including that CSVs written earlier still read reversed
- the move of generated completions to `assets/completions`, which affects packaging scripts

## Verification

The YAML parses and the job graph wires up as shown above. I dry-ran the composition step against the live v0.3.0 release — reading the draft body, concatenating, and checking the boundary — without writing anything back: 39 hand-written lines land above the 38 generated ones, 78 total.

The job itself cannot be exercised until a release actually runs, so the first real test is cutting v0.4.0.

## Scope

Deliberately kept inside this repository rather than added to `tamada/.github`. `release-start.yaml` is shared with `tamada/sibling` and `tamada/gixor`, and changing it would mean cutting a release there to move the `v1` tag. If this proves useful it can be promoted into the reusable workflow later as an optional `notes-file` input, without the other two projects having to care in the meantime.