### PR TITLE
refactor: build completions from a separate gencomp binary

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+# Run `cargo gencomp` to regenerate the shell completion scripts under
+# assets/completions.
+[alias]
+gencomp = "run --features gencomp --bin gencomp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,13 @@ version = "0.3.0"
 description = "Birthmarking toolkit for Ghidra P-Code"
 edition = "2024"
 
+[features]
+gencomp = [ "dep:clap_complete" ]
+
 [dependencies]
 chrono = { version = "0.4.44", features = [ "serde" ] }
 clap = { version = "4.6.1", features = [ "derive" ] }
-clap_complete = "4.6.5"
+clap_complete = { version = "4.6.5", optional = true }
 csv = "1.4.0"
 env_logger = "0.11.10"
 indicatif = "0.18.4"
@@ -29,10 +32,11 @@ tempfile = "3.10.1"
 name = "oinkie"
 path = "cli/main.rs"
 
-[[bin]]
-name = "gencomp"
-path = "cli/gencomp.rs"
-
 [dev-dependencies]
 assert_cmd = "2.2.2"
 predicates = "3.1.4"
+
+[[bin]]
+name = "gencomp"
+path = "cli/gencomp.rs"
+required-features = [ "gencomp" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,10 @@ tempfile = "3.10.1"
 name = "oinkie"
 path = "cli/main.rs"
 
+[[bin]]
+name = "gencomp"
+path = "cli/gencomp.rs"
+
 [dev-dependencies]
 assert_cmd = "2.2.2"
 predicates = "3.1.4"

--- a/assets/completions/bash/oinkie
+++ b/assets/completions/bash/oinkie
@@ -22,9 +22,6 @@ _oinkie() {
             oinkie,extract)
                 cmd="oinkie__subcmd__extract"
                 ;;
-            oinkie,gencomp)
-                cmd="oinkie__subcmd__gencomp"
-                ;;
             oinkie,help)
                 cmd="oinkie__subcmd__help"
                 ;;
@@ -45,9 +42,6 @@ _oinkie() {
                 ;;
             oinkie__subcmd__help,extract)
                 cmd="oinkie__subcmd__help__subcmd__extract"
-                ;;
-            oinkie__subcmd__help,gencomp)
-                cmd="oinkie__subcmd__help__subcmd__gencomp"
                 ;;
             oinkie__subcmd__help,help)
                 cmd="oinkie__subcmd__help__subcmd__help"
@@ -71,12 +65,20 @@ _oinkie() {
 
     case "${cmd}" in
         oinkie)
-            opts="-h --help info lift extract compare reaggregate run gencomp help"
+            opts="-l -h -V --level --help --version info lift extract compare reaggregate run help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 1 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
+                --level)
+                    COMPREPLY=($(compgen -W "error warn info debug trace off" -- "${cur}"))
+                    return 0
+                    ;;
+                -l)
+                    COMPREPLY=($(compgen -W "error warn info debug trace off" -- "${cur}"))
+                    return 0
+                    ;;
                 *)
                     COMPREPLY=()
                     ;;
@@ -160,22 +162,8 @@ _oinkie() {
             COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
             return 0
             ;;
-        oinkie__subcmd__gencomp)
-            opts="-h --help"
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
         oinkie__subcmd__help)
-            opts="info lift extract compare reaggregate run gencomp help"
+            opts="info lift extract compare reaggregate run help"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -203,20 +191,6 @@ _oinkie() {
             return 0
             ;;
         oinkie__subcmd__help__subcmd__extract)
-            opts=""
-            if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
-                COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-                return 0
-            fi
-            case "${prev}" in
-                *)
-                    COMPREPLY=()
-                    ;;
-            esac
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
-            return 0
-            ;;
-        oinkie__subcmd__help__subcmd__gencomp)
             opts=""
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 3 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )

--- a/assets/completions/elvish/oinkie.elv
+++ b/assets/completions/elvish/oinkie.elv
@@ -18,15 +18,18 @@ set edit:completion:arg-completer[oinkie] = {|@words|
     }
     var completions = [
         &'oinkie'= {
+            cand -l 'Log level for the application'
+            cand --level 'Log level for the application'
             cand -h 'Print help'
             cand --help 'Print help'
+            cand -V 'Print version'
+            cand --version 'Print version'
             cand info 'Display information about the application'
             cand lift 'Lift binary files to P-code JSON files using a specified lifter'
             cand extract 'Extract birthmarks from a lifted binary file (JSON format)'
             cand compare 'Compare birthmarks and output the similarity score'
             cand reaggregate 'Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score'
             cand run 'Extract birthmarks and compare them in one command'
-            cand gencomp 'Generate completions'
             cand help 'Print this message or the help of the given subcommand(s)'
         }
         &'oinkie;info'= {
@@ -94,10 +97,6 @@ set edit:completion:arg-completer[oinkie] = {|@words|
             cand -h 'Print help (see more with ''--help'')'
             cand --help 'Print help (see more with ''--help'')'
         }
-        &'oinkie;gencomp'= {
-            cand -h 'Print help'
-            cand --help 'Print help'
-        }
         &'oinkie;help'= {
             cand info 'Display information about the application'
             cand lift 'Lift binary files to P-code JSON files using a specified lifter'
@@ -105,7 +104,6 @@ set edit:completion:arg-completer[oinkie] = {|@words|
             cand compare 'Compare birthmarks and output the similarity score'
             cand reaggregate 'Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score'
             cand run 'Extract birthmarks and compare them in one command'
-            cand gencomp 'Generate completions'
             cand help 'Print this message or the help of the given subcommand(s)'
         }
         &'oinkie;help;info'= {
@@ -119,8 +117,6 @@ set edit:completion:arg-completer[oinkie] = {|@words|
         &'oinkie;help;reaggregate'= {
         }
         &'oinkie;help;run'= {
-        }
-        &'oinkie;help;gencomp'= {
         }
         &'oinkie;help;help'= {
         }

--- a/assets/completions/fish/oinkie.fish
+++ b/assets/completions/fish/oinkie.fish
@@ -1,6 +1,6 @@
 # Print an optspec for argparse to handle cmd's options that are independent of any subcommand.
 function __fish_oinkie_global_optspecs
-	string join \n h/help
+	string join \n l/level= h/help V/version
 end
 
 function __fish_oinkie_needs_command
@@ -24,14 +24,20 @@ function __fish_oinkie_using_subcommand
 	contains -- $cmd[1] $argv
 end
 
+complete -c oinkie -n "__fish_oinkie_needs_command" -s l -l level -d 'Log level for the application' -r -f -a "error\t''
+warn\t''
+info\t''
+debug\t''
+trace\t''
+off\t''"
 complete -c oinkie -n "__fish_oinkie_needs_command" -s h -l help -d 'Print help'
+complete -c oinkie -n "__fish_oinkie_needs_command" -s V -l version -d 'Print version'
 complete -c oinkie -n "__fish_oinkie_needs_command" -f -a "info" -d 'Display information about the application'
 complete -c oinkie -n "__fish_oinkie_needs_command" -f -a "lift" -d 'Lift binary files to P-code JSON files using a specified lifter'
 complete -c oinkie -n "__fish_oinkie_needs_command" -f -a "extract" -d 'Extract birthmarks from a lifted binary file (JSON format)'
 complete -c oinkie -n "__fish_oinkie_needs_command" -f -a "compare" -d 'Compare birthmarks and output the similarity score'
 complete -c oinkie -n "__fish_oinkie_needs_command" -f -a "reaggregate" -d 'Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score'
 complete -c oinkie -n "__fish_oinkie_needs_command" -f -a "run" -d 'Extract birthmarks and compare them in one command'
-complete -c oinkie -n "__fish_oinkie_needs_command" -f -a "gencomp" -d 'Generate completions'
 complete -c oinkie -n "__fish_oinkie_needs_command" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
 complete -c oinkie -n "__fish_oinkie_using_subcommand info" -s h -l help -d 'Print help'
 complete -c oinkie -n "__fish_oinkie_using_subcommand lift" -s d -l dest -d 'Specify the directory for putting the resultant JSON files for the lifted P-code (default: \'./pcodes\' directory)' -r -F
@@ -172,12 +178,10 @@ complete -c oinkie -n "__fish_oinkie_using_subcommand run" -s d -l dest -d 'Dest
 complete -c oinkie -n "__fish_oinkie_using_subcommand run" -s A -l aggregator -d 'Specify the aggregator for combining element-wise similarity scores into a birthmark-wise similarity score. Available: - hungarian  Use the Hungarian algorithm to find the optimal matching between elements of two birthmarks,              maximizing the total similarity score. - topn:N     For each element in the first birthmark, consider only the top N most similar elements in the              second birthmark when calculating the overall similarity score. This can reduce noise from less              relevant matches and focus on the most significant similarities. available topn:N or topn:all (same as topn).' -r
 complete -c oinkie -n "__fish_oinkie_using_subcommand run" -s S -l skip -d 'Skip if the similarity file already exists for the pair of birthmarks'
 complete -c oinkie -n "__fish_oinkie_using_subcommand run" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c oinkie -n "__fish_oinkie_using_subcommand gencomp" -s h -l help -d 'Print help'
-complete -c oinkie -n "__fish_oinkie_using_subcommand help; and not __fish_seen_subcommand_from info lift extract compare reaggregate run gencomp help" -f -a "info" -d 'Display information about the application'
-complete -c oinkie -n "__fish_oinkie_using_subcommand help; and not __fish_seen_subcommand_from info lift extract compare reaggregate run gencomp help" -f -a "lift" -d 'Lift binary files to P-code JSON files using a specified lifter'
-complete -c oinkie -n "__fish_oinkie_using_subcommand help; and not __fish_seen_subcommand_from info lift extract compare reaggregate run gencomp help" -f -a "extract" -d 'Extract birthmarks from a lifted binary file (JSON format)'
-complete -c oinkie -n "__fish_oinkie_using_subcommand help; and not __fish_seen_subcommand_from info lift extract compare reaggregate run gencomp help" -f -a "compare" -d 'Compare birthmarks and output the similarity score'
-complete -c oinkie -n "__fish_oinkie_using_subcommand help; and not __fish_seen_subcommand_from info lift extract compare reaggregate run gencomp help" -f -a "reaggregate" -d 'Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score'
-complete -c oinkie -n "__fish_oinkie_using_subcommand help; and not __fish_seen_subcommand_from info lift extract compare reaggregate run gencomp help" -f -a "run" -d 'Extract birthmarks and compare them in one command'
-complete -c oinkie -n "__fish_oinkie_using_subcommand help; and not __fish_seen_subcommand_from info lift extract compare reaggregate run gencomp help" -f -a "gencomp" -d 'Generate completions'
-complete -c oinkie -n "__fish_oinkie_using_subcommand help; and not __fish_seen_subcommand_from info lift extract compare reaggregate run gencomp help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
+complete -c oinkie -n "__fish_oinkie_using_subcommand help; and not __fish_seen_subcommand_from info lift extract compare reaggregate run help" -f -a "info" -d 'Display information about the application'
+complete -c oinkie -n "__fish_oinkie_using_subcommand help; and not __fish_seen_subcommand_from info lift extract compare reaggregate run help" -f -a "lift" -d 'Lift binary files to P-code JSON files using a specified lifter'
+complete -c oinkie -n "__fish_oinkie_using_subcommand help; and not __fish_seen_subcommand_from info lift extract compare reaggregate run help" -f -a "extract" -d 'Extract birthmarks from a lifted binary file (JSON format)'
+complete -c oinkie -n "__fish_oinkie_using_subcommand help; and not __fish_seen_subcommand_from info lift extract compare reaggregate run help" -f -a "compare" -d 'Compare birthmarks and output the similarity score'
+complete -c oinkie -n "__fish_oinkie_using_subcommand help; and not __fish_seen_subcommand_from info lift extract compare reaggregate run help" -f -a "reaggregate" -d 'Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score'
+complete -c oinkie -n "__fish_oinkie_using_subcommand help; and not __fish_seen_subcommand_from info lift extract compare reaggregate run help" -f -a "run" -d 'Extract birthmarks and compare them in one command'
+complete -c oinkie -n "__fish_oinkie_using_subcommand help; and not __fish_seen_subcommand_from info lift extract compare reaggregate run help" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'

--- a/assets/completions/powershell/oinkie.ps1
+++ b/assets/completions/powershell/oinkie.ps1
@@ -21,15 +21,18 @@ Register-ArgumentCompleter -Native -CommandName 'oinkie' -ScriptBlock {
 
     $completions = @(switch ($command) {
         'oinkie' {
+            [CompletionResult]::new('-l', '-l', [CompletionResultType]::ParameterName, 'Log level for the application')
+            [CompletionResult]::new('--level', '--level', [CompletionResultType]::ParameterName, 'Log level for the application')
             [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
             [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
+            [CompletionResult]::new('-V', '-V ', [CompletionResultType]::ParameterName, 'Print version')
+            [CompletionResult]::new('--version', '--version', [CompletionResultType]::ParameterName, 'Print version')
             [CompletionResult]::new('info', 'info', [CompletionResultType]::ParameterValue, 'Display information about the application')
             [CompletionResult]::new('lift', 'lift', [CompletionResultType]::ParameterValue, 'Lift binary files to P-code JSON files using a specified lifter')
             [CompletionResult]::new('extract', 'extract', [CompletionResultType]::ParameterValue, 'Extract birthmarks from a lifted binary file (JSON format)')
             [CompletionResult]::new('compare', 'compare', [CompletionResultType]::ParameterValue, 'Compare birthmarks and output the similarity score')
             [CompletionResult]::new('reaggregate', 'reaggregate', [CompletionResultType]::ParameterValue, 'Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score')
             [CompletionResult]::new('run', 'run', [CompletionResultType]::ParameterValue, 'Extract birthmarks and compare them in one command')
-            [CompletionResult]::new('gencomp', 'gencomp', [CompletionResultType]::ParameterValue, 'Generate completions')
             [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
             break
         }
@@ -104,11 +107,6 @@ Register-ArgumentCompleter -Native -CommandName 'oinkie' -ScriptBlock {
             [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help (see more with ''--help'')')
             break
         }
-        'oinkie;gencomp' {
-            [CompletionResult]::new('-h', '-h', [CompletionResultType]::ParameterName, 'Print help')
-            [CompletionResult]::new('--help', '--help', [CompletionResultType]::ParameterName, 'Print help')
-            break
-        }
         'oinkie;help' {
             [CompletionResult]::new('info', 'info', [CompletionResultType]::ParameterValue, 'Display information about the application')
             [CompletionResult]::new('lift', 'lift', [CompletionResultType]::ParameterValue, 'Lift binary files to P-code JSON files using a specified lifter')
@@ -116,7 +114,6 @@ Register-ArgumentCompleter -Native -CommandName 'oinkie' -ScriptBlock {
             [CompletionResult]::new('compare', 'compare', [CompletionResultType]::ParameterValue, 'Compare birthmarks and output the similarity score')
             [CompletionResult]::new('reaggregate', 'reaggregate', [CompletionResultType]::ParameterValue, 'Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score')
             [CompletionResult]::new('run', 'run', [CompletionResultType]::ParameterValue, 'Extract birthmarks and compare them in one command')
-            [CompletionResult]::new('gencomp', 'gencomp', [CompletionResultType]::ParameterValue, 'Generate completions')
             [CompletionResult]::new('help', 'help', [CompletionResultType]::ParameterValue, 'Print this message or the help of the given subcommand(s)')
             break
         }
@@ -136,9 +133,6 @@ Register-ArgumentCompleter -Native -CommandName 'oinkie' -ScriptBlock {
             break
         }
         'oinkie;help;run' {
-            break
-        }
-        'oinkie;help;gencomp' {
             break
         }
         'oinkie;help;help' {

--- a/assets/completions/zsh/_oinkie
+++ b/assets/completions/zsh/_oinkie
@@ -15,8 +15,12 @@ _oinkie() {
 
     local context curcontext="$curcontext" state line
     _arguments "${_arguments_options[@]}" : \
+'-l+[Log level for the application]:LEVEL:(error warn info debug trace off)' \
+'--level=[Log level for the application]:LEVEL:(error warn info debug trace off)' \
 '-h[Print help]' \
 '--help[Print help]' \
+'-V[Print version]' \
+'--version[Print version]' \
 ":: :_oinkie_commands" \
 "*::: :->oinkie" \
 && ret=0
@@ -200,12 +204,6 @@ last-vs-others\:"Compares a specific reference file against all other files (\$n
 '*::files -- Path to the JSON files:_files' \
 && ret=0
 ;;
-(gencomp)
-_arguments "${_arguments_options[@]}" : \
-'-h[Print help]' \
-'--help[Print help]' \
-&& ret=0
-;;
 (help)
 _arguments "${_arguments_options[@]}" : \
 ":: :_oinkie__subcmd__help_commands" \
@@ -242,10 +240,6 @@ _arguments "${_arguments_options[@]}" : \
 _arguments "${_arguments_options[@]}" : \
 && ret=0
 ;;
-(gencomp)
-_arguments "${_arguments_options[@]}" : \
-&& ret=0
-;;
 (help)
 _arguments "${_arguments_options[@]}" : \
 && ret=0
@@ -268,7 +262,6 @@ _oinkie_commands() {
 'compare:Compare birthmarks and output the similarity score' \
 'reaggregate:Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score' \
 'run:Extract birthmarks and compare them in one command' \
-'gencomp:Generate completions' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'oinkie commands' commands "$@"
@@ -283,11 +276,6 @@ _oinkie__subcmd__extract_commands() {
     local commands; commands=()
     _describe -t commands 'oinkie extract commands' commands "$@"
 }
-(( $+functions[_oinkie__subcmd__gencomp_commands] )) ||
-_oinkie__subcmd__gencomp_commands() {
-    local commands; commands=()
-    _describe -t commands 'oinkie gencomp commands' commands "$@"
-}
 (( $+functions[_oinkie__subcmd__help_commands] )) ||
 _oinkie__subcmd__help_commands() {
     local commands; commands=(
@@ -297,7 +285,6 @@ _oinkie__subcmd__help_commands() {
 'compare:Compare birthmarks and output the similarity score' \
 'reaggregate:Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score' \
 'run:Extract birthmarks and compare them in one command' \
-'gencomp:Generate completions' \
 'help:Print this message or the help of the given subcommand(s)' \
     )
     _describe -t commands 'oinkie help commands' commands "$@"
@@ -311,11 +298,6 @@ _oinkie__subcmd__help__subcmd__compare_commands() {
 _oinkie__subcmd__help__subcmd__extract_commands() {
     local commands; commands=()
     _describe -t commands 'oinkie help extract commands' commands "$@"
-}
-(( $+functions[_oinkie__subcmd__help__subcmd__gencomp_commands] )) ||
-_oinkie__subcmd__help__subcmd__gencomp_commands() {
-    local commands; commands=()
-    _describe -t commands 'oinkie help gencomp commands' commands "$@"
 }
 (( $+functions[_oinkie__subcmd__help__subcmd__help_commands] )) ||
 _oinkie__subcmd__help__subcmd__help_commands() {

--- a/cli/cli.rs
+++ b/cli/cli.rs
@@ -73,10 +73,6 @@ pub enum OinkieCommand {
         about = "Extract birthmarks and compare them in one command"
     )]
     Run(RunOpts),
-
-    #[cfg(debug_assertions)]
-    #[command(name = "gencomp", about = "Generate completions")]
-    GenComp,
 }
 
 #[derive(Debug, clap::Parser)]

--- a/cli/gencomp.rs
+++ b/cli/gencomp.rs
@@ -1,37 +1,38 @@
+// cli.rs is compiled into this binary as well as into oinkie, but only its
+// clap derives are used here; the accessors are exercised by the oinkie
+// binary, which still lints them.
+#![allow(dead_code)]
+
+mod cli;
+mod info;
+
+use clap::{Command, CommandFactory};
+use clap_complete::Shell;
+use std::fs::File;
 use std::path::Path;
 
-#[cfg(debug_assertions)]
-mod completions {
-    use clap::{Command, CommandFactory};
-    use clap_complete::Shell;
-    use std::fs::File;
-    use std::path::Path;
-
-    fn generate_impl(s: Shell, app: &mut Command, outdir: &Path, file: String) {
-        let destfile = outdir.join(format!("{s}")).join(file);
-        std::fs::create_dir_all(destfile.parent().unwrap()).unwrap();
-        let bin_name = app.get_name().to_string();
-        if let Ok(mut dest) = File::create(destfile) {
-            clap_complete::generate(s, app, bin_name, &mut dest);
-        }
-    }
-
-    pub(super) fn generate(appname: &str, outdir: &Path) {
-        use Shell::{Bash, Elvish, Fish, PowerShell, Zsh};
-
-        let mut app = crate::cli::OinkieCommand::command();
-        app.set_bin_name(appname);
-
-        generate_impl(Bash, &mut app, outdir, appname.to_string());
-        generate_impl(Elvish, &mut app, outdir, format!("{appname}.elv"));
-        generate_impl(Fish, &mut app, outdir, format!("{appname}.fish"));
-        generate_impl(PowerShell, &mut app, outdir, format!("{appname}.ps1"));
-        generate_impl(Zsh, &mut app, outdir, format!("_{appname}"));
+fn generate_impl(s: Shell, app: &mut Command, outdir: &Path, file: String) {
+    let destfile = outdir.join(format!("{s}")).join(file);
+    std::fs::create_dir_all(destfile.parent().unwrap()).unwrap();
+    let bin_name = app.get_name().to_string();
+    if let Ok(mut dest) = File::create(destfile) {
+        clap_complete::generate(s, app, bin_name, &mut dest);
     }
 }
 
-#[allow(dead_code, unused_variables)]
-pub(crate) fn generate(appname: &str, outdir: &Path) {
-    #[cfg(debug_assertions)]
-    completions::generate(appname, outdir);
+pub fn generate(appname: &str, outdir: &Path) {
+    use Shell::{Bash, Elvish, Fish, PowerShell, Zsh};
+
+    let mut app = crate::cli::OinkieOpts::command();
+    app.set_bin_name(appname);
+
+    generate_impl(Bash, &mut app, outdir, appname.to_string());
+    generate_impl(Elvish, &mut app, outdir, format!("{appname}.elv"));
+    generate_impl(Fish, &mut app, outdir, format!("{appname}.fish"));
+    generate_impl(PowerShell, &mut app, outdir, format!("{appname}.ps1"));
+    generate_impl(Zsh, &mut app, outdir, format!("_{appname}"));
+}
+
+fn main() {
+    generate("oinkie", Path::new("assets/completions"))
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1,9 +1,6 @@
 mod cli;
 mod info;
 
-#[cfg(debug_assertions)]
-mod gencomp;
-
 use clap::{Parser, ValueEnum};
 use indicatif::ProgressBar;
 use oinkie::ghidra::Op;
@@ -381,12 +378,6 @@ fn perform(opts: cli::OinkieOpts) -> Result<Vec<Duration>> {
         Reaggregate(opts) => reaggregator::perform(opts),
         Lift(opts) => perform_lift(opts),
         Info => perform_info(),
-        #[cfg(debug_assertions)]
-        GenComp => {
-            let now = Instant::now();
-            gencomp::generate("oinkie", Path::new("assets/completions"));
-            Ok(vec![now.elapsed()])
-        }
     }
 }
 


### PR DESCRIPTION
Fixes #33.

## Why the generator had to move

Completions were produced by a `gencomp` subcommand of oinkie itself, gated on `debug_assertions`. That put the generator inside the CLI it was generating for, and the consequences could not be worked around from the outside:

- Every generated file offered a `gencomp` command that **no release binary accepts** — the subcommand only exists in debug builds, but so does the generator, so it was always present at generation time.
- Editing the files by hand does not hold; the next run puts it back.
- `#[command(hide = true)]` has **no effect** — `clap_complete` emits hidden subcommands. Verified: occurrence counts were unchanged.
- clap 4.6 has **no subcommand-removal API**; `mut_subcommand` / `mut_subcommands` only transform.

Moving the generator to its own bin target lets `GenComp` leave `OinkieCommand` entirely, so there is nothing to filter back out.

## Second defect fixed along the way

`gencomp` built its command from `OinkieCommand::command()` — the *subcommand* enum — while the real CLI is `OinkieOpts`. The top-level `-l/--level` therefore never appeared in any completion file. Now built from `OinkieOpts::command()`.

| | `gencomp` present | `-l/--level` present |
|---|---|---|
| Before | all 5 files | **none** |
| After | **none** | all 5 files |

## A note on the module layout

Each `[[bin]]` target is its own crate root, so `crate::cli` does not reach across from `cli/main.rs`. `cli/gencomp.rs` declares `mod cli` and `mod info` for itself (no `#[path]` needed — submodules resolve against the crate root's directory).

That means `cli.rs` is compiled into both binaries, and in the gencomp one every accessor is unused. Hence the crate-level `#![allow(dead_code)]`: without it, six warnings fail CI's `cargo clippy -- -D warnings`. The suppression is scoped to that binary — genuinely dead code in `cli.rs` is still caught when the `oinkie` binary is linted.

## Second commit: keeping it out of ordinary builds

The new bin target initially had no gating, so `cargo build --release` produced it and compiled `clap_complete` to do so. Neither is shipped — the release tarball (`publish.yaml:111`) and the container image both copy only the `oinkie` binary — so that was wasted work, four times over on a release that cross-compiles four targets.

`09c045f` puts the target behind a `gencomp` feature with `clap_complete` as an optional dependency, referenced as `dep:clap_complete` so no implicit feature of the same name appears.

| | default | `--features gencomp` |
|---|---|---|
| `clap_complete` in the dependency graph | **absent** | present |
| binaries built | `oinkie` only | `oinkie` + `gencomp` |

Regenerating now needs the flag, so `.cargo/config.toml` carries an alias shortening it to `cargo gencomp`. The alias has to live there — Cargo rejects the key in `Cargo.toml` with `unused manifest key: alias`, and the aliased command simply does not exist.

## Verification

- `cargo test` — 78 passed (63 lib, 6 pcode, 6 E2E against a real Ghidra install, 3 integration)
- `cargo fmt --all -- --check` and `cargo clippy -- -D warnings` — both pass
- `cargo clippy --all-targets --features gencomp` — 0 warnings, so the gated code is clean too
- `--features clap_complete` is rejected, confirming `dep:` suppressed the implicit feature
- `cargo gencomp` in a scratch copy reproduces the committed completion files **byte for byte**

## One consequence worth deciding on

CI runs `cargo clippy -- -D warnings` without the feature, so `cli/gencomp.rs` is no longer linted there. Adding a second line would cover it:

```yaml
cargo clippy --all-targets --features gencomp -- -D warnings
```

Left out of this PR since it widens what CI enforces; happy to add it here if you would rather not carry the gap.