### PR TITLE
fix: resolve the -i path before handing it to Ghidra

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -41,5 +41,7 @@ old `completions` directory need updating.
 - **#30** — widened the birthmark hash prefix to 64 bits, removing a silent
   overwrite that was reachable at corpus scale
 - **#29** — fixed the `left`/`right` inversion in similarity CSVs
+- **#36** — `lift -i` with a relative path no longer resolves it twice into
+  `irs/irs`, and the directory is created rather than having to exist
 - The crate is now formatted with `cargo fmt`, and CI enforces it with
   `cargo fmt --all -- --check`

--- a/src/ghidra/lifter.rs
+++ b/src/ghidra/lifter.rs
@@ -51,7 +51,13 @@ impl Lifter for GhidraLifter {
             .ok_or_else(|| Error::Parse(format!("Invalid script path: {:?}", script_path)))?;
 
         let (proj_dir, _temp_proj_dir) = if let Some(i) = &self.intermediate_dir {
-            (i.to_path_buf(), None)
+            // Created because every other destination directory in the CLI is,
+            // and canonicalized because this path is passed to Ghidra as an
+            // argument while also being its working directory — left relative,
+            // Ghidra would resolve it a second time against itself.
+            std::fs::create_dir_all(i).map_err(|e| Error::Io(i.clone(), e))?;
+            let i = std::fs::canonicalize(i).map_err(|e| Error::Io(i.clone(), e))?;
+            (i, None)
         } else {
             let temp_proj = tempfile::Builder::new()
                 .prefix("oinkie_proj")

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -191,3 +191,67 @@ fn test_reaggregate_command() {
 
     assert!(dest_file.exists());
 }
+
+/// The path given to `-i` is handed to Ghidra as its project location and is
+/// also used as the working directory of the Ghidra process. A relative path
+/// must therefore be resolved before the process starts, or Ghidra resolves it
+/// a second time against itself and looks for `irs/irs`.
+#[test]
+fn test_lift_command_with_relative_intermediate_dir() {
+    // Ghidra rejects any path element starting with '.', and tempdir() names
+    // its directories ".tmpXXXX", so the project location needs a plain prefix.
+    let temp_dir = tempfile::Builder::new()
+        .prefix("oinkie_test")
+        .tempdir()
+        .unwrap();
+    let input = fs::canonicalize("testdata/hello_world/bin/hello_clang").unwrap();
+    let dest = temp_dir.path().join("lifted");
+    fs::create_dir(temp_dir.path().join("irs")).unwrap();
+
+    Command::cargo_bin("oinkie")
+        .unwrap()
+        .current_dir(temp_dir.path())
+        .arg("lift")
+        .arg("-i")
+        .arg("irs")
+        .arg("-d")
+        .arg(&dest)
+        .arg(&input)
+        .assert()
+        .success();
+
+    assert!(
+        !temp_dir.path().join("irs").join("irs").exists(),
+        "the -i path was resolved twice"
+    );
+    assert!(dest.join("hello_clang.json").exists());
+}
+
+/// Every other destination directory in the CLI is created for the user, and
+/// the temporary directory used when `-i` is omitted exists by construction.
+/// A path passed to `-i` should be no different.
+#[test]
+fn test_lift_command_creates_the_intermediate_dir() {
+    // See the note above: the project location must not sit under a dot-directory.
+    let temp_dir = tempfile::Builder::new()
+        .prefix("oinkie_test")
+        .tempdir()
+        .unwrap();
+    let input = fs::canonicalize("testdata/hello_world/bin/hello_clang").unwrap();
+    let dest = temp_dir.path().join("lifted");
+    let intermediate = temp_dir.path().join("does/not/exist/yet");
+
+    Command::cargo_bin("oinkie")
+        .unwrap()
+        .arg("lift")
+        .arg("-i")
+        .arg(&intermediate)
+        .arg("-d")
+        .arg(&dest)
+        .arg(&input)
+        .assert()
+        .success();
+
+    assert!(intermediate.is_dir(), "the -i directory was not created");
+    assert!(dest.join("hello_clang.json").exists());
+}


### PR DESCRIPTION
Fixes #36.

## The bug

```
$ mkdir irs
$ oinkie lift -i irs -d out testdata/hello_world/bin/hello_clang
INFO  Creating project: /path/to/cwd/irs/irs/hello_clang (HeadlessAnalyzer)
ERROR Abort due to Headless analyzer error: Directory not found: /path/to/cwd/irs/irs
```

`proj_dir` is passed to Ghidra as its project location **and** used as the working directory of the Ghidra process. Left relative, Ghidra resolves the argument against its own working directory — which is that same relative path — so `irs` becomes `irs/irs`.

This arrived with the `current_dir` call in #13. That change canonicalized `input` and `script_path` precisely because the working-directory change would break relative paths; `proj_dir` needed the same treatment and did not get it.

## Also fixed

The directory named by `-i` was never created. The temporary directory used when `-i` is omitted exists by construction, and `--dest` is created for the user in all four subcommands, so `-i` was the only path expected to exist beforehand. It also failed by blaming the wrong component — `Command::current_dir` on a missing directory surfaces as a spawn failure, mapped to an IO error against `analyzeHeadless`:

```
$ oinkie lift -i nonexistent …
Error: IO error for /opt/homebrew/opt/ghidra/libexec/support/analyzeHeadless: No such file or directory (os error 2)
```

## The change

Four lines in `src/ghidra/lifter.rs`: create the directory, then canonicalize it so the argument is absolute and immune to the working-directory change.

## Tests

Written first, and both fail without the fix — verified by reverting it and re-running:

```
test test_lift_command_creates_the_intermediate_dir ... FAILED
test test_lift_command_with_relative_intermediate_dir ... FAILED
```

`test_lift_command_with_relative_intermediate_dir` reproduces the report exactly: it runs with the working directory set to a scratch directory, passes `-i irs` relative, and asserts that `irs/irs` is never created. The other passes an `-i` path several levels deep that does not exist and asserts it gets created.

Nothing previously exercised `-i` — the existing `test_lift_command` omits it — which is why both defects went unnoticed.

### One thing worth knowing about the tests

They build their scratch directory with `tempfile::Builder::prefix("oinkie_test")` rather than plain `tempdir()`. Ghidra refuses any path element beginning with a dot:

```
java.lang.IllegalArgumentException: Path element starting with '.' is not permitted
```

and `tempdir()` names its directories `.tmpXXXXXX`. The existing tests are unaffected because Ghidra never sees their temp paths — only `--dest`, which Rust handles itself. This is a real constraint on `-i` for users too, though acting on it is out of scope here.

## Verification

- `cargo test --test cli_test lift` — 3 passed, including the pre-existing case
- `cargo fmt --all -- --check` and `cargo clippy -- -D warnings` — both pass
- The original report now succeeds: no `irs/irs`, and `out/hello_clang.json` is produced

`cargo test --lib` currently shows one unrelated failure, `test_analysis_type_try_from_named_combinations`, coming from in-progress #25 work in the working tree rather than from this branch. This branch touches only `src/ghidra/lifter.rs` and `tests/cli_test.rs`.