### PR TITLE
refactor: delegate the birthmark half, and reject pairings that cannot mean what they say

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -36,10 +36,46 @@ one directory per shell, with conventional file names (`oinkie`, `oinkie.elv`,
 `oinkie.fish`, `oinkie.ps1`, `_oinkie`). Packaging scripts that referenced the
 old `completions` directory need updating.
 
+## Library API
+
+These affect code using oinkie as a crate. The command-line interface is
+unchanged by them.
+
+**`AnalysisType::new` now returns `Result`.** It validates that the algorithm
+operates on the birthmark's shape, which `try_from` already did and `new` did
+not — so the check could be walked around by constructing the pair directly.
+Callers add a `?` or handle `Error::IncompatibleAnalysis`, a new variant.
+
+**Analysis names that pair an algorithm with the wrong shape are rejected.**
+Each algorithm computes over one representation and converts anything else
+first, so `op-seq-euclidean` returned exactly what `op-freq-euclidean` returns
+while its name promised a comparison over sequences, and `op-set-levenshtein`
+scored 0.0 because no conversion exists. The error names the pairing that was
+meant:
+
+```
+op-seq-euclidean: euclidean operates on frequency vectors; use op-freq-euclidean
+```
+
+In practice this only changes k-gram names: `op-3gram-set-levenshtein` and its
+kind used to parse and now do not. Every pairing the CLI offers is canonical, so
+nothing reachable through `--analysis` is affected.
+
+**More names parse than before.** `AnalysisType::try_from` reads the algorithm
+and hands the rest to `BirthmarkType::try_from` (#38), so the eight `fc-*`
+combinations and the seven `*-lcs` ones now work, as does any `k` — previously
+fifteen of the sixty-four combinations the CLI offers could not be parsed at all.
+
+**New public items** for asking whether a pairing is valid before building one:
+`Shape`, `BirthmarkType::shape`, `BirthmarkType::with_shape`,
+`BirthmarkType::pairs_with` and `Algorithm::shape`.
+
 ## Highlights
 
 - **#30** — widened the birthmark hash prefix to 64 bits, removing a silent
   overwrite that was reachable at corpus scale
 - **#29** — fixed the `left`/`right` inversion in similarity CSVs
+- **#38** — analysis names are parsed in one place, and a pairing that cannot
+  mean what it says is rejected with the canonical form named
 - The crate is now formatted with `cargo fmt`, and CI enforces it with
   `cargo fmt --all -- --check`

--- a/cli/cli.rs
+++ b/cli/cli.rs
@@ -400,8 +400,8 @@ impl RunOpts {
         &self.dest
     }
 
-    pub fn analysis_type(&self) -> AnalysisType {
-        (&self.analysis).into()
+    pub fn analysis_type(&self) -> Result<AnalysisType> {
+        (&self.analysis).try_into()
     }
 
     pub fn iter(&self) -> Box<dyn Iterator<Item = (&PathBuf, &PathBuf)> + Send + '_> {
@@ -501,14 +501,21 @@ pub(crate) enum Analysis {
     Op6gramFreqWeightedjaccard,
 }
 
-impl From<Analysis> for AnalysisType {
-    fn from(v: Analysis) -> Self {
-        AnalysisType::from(&v)
+impl TryFrom<Analysis> for AnalysisType {
+    type Error = Error;
+
+    fn try_from(v: Analysis) -> Result<Self> {
+        AnalysisType::try_from(&v)
     }
 }
 
-impl From<&Analysis> for AnalysisType {
-    fn from(value: &Analysis) -> Self {
+// Every pairing listed here is the canonical one for its algorithm, so none of
+// these can fail; the Result comes from AnalysisType::new, which validates so
+// that the pairing cannot be built wrongly from anywhere.
+impl TryFrom<&Analysis> for AnalysisType {
+    type Error = Error;
+
+    fn try_from(value: &Analysis) -> Result<Self> {
         match value {
             Analysis::FcFreqCosine => AnalysisType::new(BirthmarkType::FcFreq, Algorithm::Cosine),
             Analysis::FcSetDice => AnalysisType::new(BirthmarkType::FcSet, Algorithm::Dice),

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -24,7 +24,7 @@ where
 
 fn perform_run(opts: cli::RunOpts) -> Result<Vec<Duration>> {
     let start = Instant::now();
-    let atype = opts.analysis_type();
+    let atype = opts.analysis_type()?;
     let dest = opts.dest();
     let comparing_count = opts.compare_count();
     let pbar = new_progress_bar(comparing_count * 3);

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -39,7 +39,7 @@ impl TryFrom<&str> for BirthmarkType {
 }
 
 impl BirthmarkType {
-    pub(crate) fn shape(&self) -> Shape {
+    pub fn shape(&self) -> Shape {
         match self {
             BirthmarkType::FcSeq | BirthmarkType::OpSeq | BirthmarkType::OpKgramSeq(_) => {
                 Shape::Seq
@@ -53,9 +53,17 @@ impl BirthmarkType {
         }
     }
 
+    /// Whether this birthmark's shape is the one the algorithm computes over.
+    /// Anything else is converted by the comparator first, so a pairing that
+    /// does not match either reproduces another pairing's numbers under a
+    /// misleading name or scores nothing at all.
+    pub fn pairs_with(&self, algorithm: &Algorithm) -> bool {
+        self.shape() == algorithm.shape()
+    }
+
     /// The same birthmark family in another shape, used to name the pairing a
     /// rejected analysis should have used.
-    pub(crate) fn with_shape(&self, shape: Shape) -> BirthmarkType {
+    pub fn with_shape(&self, shape: Shape) -> BirthmarkType {
         match (self, shape) {
             (BirthmarkType::FcSeq | BirthmarkType::FcSet | BirthmarkType::FcFreq, s) => match s {
                 Shape::Seq => BirthmarkType::FcSeq,
@@ -353,11 +361,17 @@ pub struct AnalysisType {
 }
 
 impl AnalysisType {
-    pub fn new(bt: BirthmarkType, algorithm: Algorithm) -> Self {
-        Self {
+    /// Fails when the algorithm does not operate on the birthmark's shape.
+    /// Validating here rather than only in `try_from` means the check cannot
+    /// be walked around by constructing the pair directly.
+    pub fn new(bt: BirthmarkType, algorithm: Algorithm) -> Result<Self> {
+        if !bt.pairs_with(&algorithm) {
+            return Err(Error::IncompatibleAnalysis(bt, algorithm));
+        }
+        Ok(Self {
             birthmark: bt,
             comparator: algorithm.comparator(),
-        }
+        })
     }
 
     pub fn comparator(&self) -> &Comparator {
@@ -390,13 +404,7 @@ impl TryFrom<String> for AnalysisType {
         let birthmark = BirthmarkType::try_from(birthmark)?;
         let algorithm =
             parse_algorithm(algorithm).ok_or_else(|| Error::BirthmarkType(name.clone()))?;
-        // Anything but the canonical shape is converted by the comparator
-        // before it computes, so it would quietly return the canonical
-        // pairing's numbers under a name that promises something else.
-        if birthmark.shape() != algorithm_spec(&algorithm).1 {
-            return Err(Error::IncompatibleAnalysis(birthmark, algorithm));
-        }
-        Ok(AnalysisType::new(birthmark, algorithm))
+        AnalysisType::new(birthmark, algorithm)
     }
 }
 
@@ -405,14 +413,14 @@ impl TryFrom<String> for AnalysisType {
 /// an algorithm with a different shape silently produces the same numbers as
 /// the canonical pairing, or none at all.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum Shape {
+pub enum Shape {
     Seq,
     Set,
     Freq,
 }
 
 impl Shape {
-    pub(crate) fn description(&self) -> &'static str {
+    pub fn description(&self) -> &'static str {
         match self {
             Shape::Seq => "sequences",
             Shape::Set => "sets",
@@ -421,29 +429,11 @@ impl Shape {
     }
 }
 
-/// The CLI spelling of an algorithm and the shape it operates on, in one
-/// table so that the parser, the validation and the error message cannot
-/// drift apart. Written out rather than derived from `ValueEnum`, whose
-/// kebab-case would render `WeightedJaccard` as `weighted-jaccard` and put a
-/// hyphen inside a name that has to be split off by its last one.
-pub(crate) fn algorithm_spec(algorithm: &Algorithm) -> (&'static str, Shape) {
-    match algorithm {
-        Algorithm::Cosine => ("cosine", Shape::Freq),
-        Algorithm::Dice => ("dice", Shape::Set),
-        Algorithm::Euclidean => ("euclidean", Shape::Freq),
-        Algorithm::Jaccard => ("jaccard", Shape::Set),
-        Algorithm::Lcs => ("lcs", Shape::Seq),
-        Algorithm::Levenshtein => ("levenshtein", Shape::Seq),
-        Algorithm::Simpson => ("simpson", Shape::Set),
-        Algorithm::WeightedJaccard => ("weightedjaccard", Shape::Freq),
-    }
-}
-
 fn parse_algorithm(name: &str) -> Option<Algorithm> {
     use clap::ValueEnum;
     Algorithm::value_variants()
         .iter()
-        .find(|a| algorithm_spec(a).0 == name)
+        .find(|a| a.cli_name() == name)
         .cloned()
 }
 
@@ -718,7 +708,7 @@ mod tests {
         use clap::ValueEnum;
         for prefix in ["op", "fc", "op-4gram"] {
             for algorithm in Algorithm::value_variants() {
-                let (algorithm_name, shape) = algorithm_spec(algorithm);
+                let (algorithm_name, shape) = (algorithm.cli_name(), algorithm.shape());
                 let shape_name = match shape {
                     Shape::Seq => "seq",
                     Shape::Set => "set",
@@ -726,6 +716,47 @@ mod tests {
                 };
                 let name = format!("{prefix}-{shape_name}-{algorithm_name}");
                 assert!(AnalysisType::try_from(name.clone()).is_ok(), "name: {name}");
+            }
+        }
+    }
+
+    /// pairs_with is the check new and try_from share, so it must agree with
+    /// both: the shapes that match are exactly the pairings they accept.
+    #[test]
+    fn test_pairs_with_agrees_with_construction() {
+        use clap::ValueEnum;
+        let birthmarks = [
+            BirthmarkType::OpSeq,
+            BirthmarkType::OpSet,
+            BirthmarkType::OpFreq,
+            BirthmarkType::FcSeq,
+            BirthmarkType::FcSet,
+            BirthmarkType::FcFreq,
+            BirthmarkType::OpKgramSeq(3),
+            BirthmarkType::OpKgramSet(3),
+            BirthmarkType::OpKgramFreq(3),
+        ];
+        for birthmark in birthmarks {
+            for algorithm in Algorithm::value_variants() {
+                let paired = birthmark.pairs_with(algorithm);
+                assert_eq!(
+                    paired,
+                    birthmark.shape() == algorithm.shape(),
+                    "{birthmark}/{}",
+                    algorithm.cli_name()
+                );
+                assert_eq!(
+                    AnalysisType::new(birthmark.clone(), algorithm.clone()).is_ok(),
+                    paired,
+                    "new disagrees with pairs_with for {birthmark}/{}",
+                    algorithm.cli_name()
+                );
+                let name = format!("{birthmark}-{}", algorithm.cli_name());
+                assert_eq!(
+                    AnalysisType::try_from(name.clone()).is_ok(),
+                    paired,
+                    "try_from disagrees with pairs_with for {name}"
+                );
             }
         }
     }

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -38,6 +38,49 @@ impl TryFrom<&str> for BirthmarkType {
     }
 }
 
+impl BirthmarkType {
+    pub(crate) fn shape(&self) -> Shape {
+        match self {
+            BirthmarkType::FcSeq | BirthmarkType::OpSeq | BirthmarkType::OpKgramSeq(_) => {
+                Shape::Seq
+            }
+            BirthmarkType::FcSet | BirthmarkType::OpSet | BirthmarkType::OpKgramSet(_) => {
+                Shape::Set
+            }
+            BirthmarkType::FcFreq | BirthmarkType::OpFreq | BirthmarkType::OpKgramFreq(_) => {
+                Shape::Freq
+            }
+        }
+    }
+
+    /// The same birthmark family in another shape, used to name the pairing a
+    /// rejected analysis should have used.
+    pub(crate) fn with_shape(&self, shape: Shape) -> BirthmarkType {
+        match (self, shape) {
+            (BirthmarkType::FcSeq | BirthmarkType::FcSet | BirthmarkType::FcFreq, s) => match s {
+                Shape::Seq => BirthmarkType::FcSeq,
+                Shape::Set => BirthmarkType::FcSet,
+                Shape::Freq => BirthmarkType::FcFreq,
+            },
+            (
+                BirthmarkType::OpKgramSeq(k)
+                | BirthmarkType::OpKgramSet(k)
+                | BirthmarkType::OpKgramFreq(k),
+                s,
+            ) => match s {
+                Shape::Seq => BirthmarkType::OpKgramSeq(*k),
+                Shape::Set => BirthmarkType::OpKgramSet(*k),
+                Shape::Freq => BirthmarkType::OpKgramFreq(*k),
+            },
+            (_, s) => match s {
+                Shape::Seq => BirthmarkType::OpSeq,
+                Shape::Set => BirthmarkType::OpSet,
+                Shape::Freq => BirthmarkType::OpFreq,
+            },
+        }
+    }
+}
+
 impl Display for BirthmarkType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -347,26 +390,61 @@ impl TryFrom<String> for AnalysisType {
         let birthmark = BirthmarkType::try_from(birthmark)?;
         let algorithm =
             parse_algorithm(algorithm).ok_or_else(|| Error::BirthmarkType(name.clone()))?;
+        // Anything but the canonical shape is converted by the comparator
+        // before it computes, so it would quietly return the canonical
+        // pairing's numbers under a name that promises something else.
+        if birthmark.shape() != algorithm_spec(&algorithm).1 {
+            return Err(Error::IncompatibleAnalysis(birthmark, algorithm));
+        }
         Ok(AnalysisType::new(birthmark, algorithm))
     }
 }
 
-/// The algorithm half of an analysis name. Kept as an explicit table rather
-/// than derived from `ValueEnum`, whose kebab-case would render
-/// `WeightedJaccard` as `weighted-jaccard` and break the split on the last
-/// hyphen.
-fn parse_algorithm(name: &str) -> Option<Algorithm> {
-    match name {
-        "cosine" => Some(Algorithm::Cosine),
-        "dice" => Some(Algorithm::Dice),
-        "euclidean" => Some(Algorithm::Euclidean),
-        "jaccard" => Some(Algorithm::Jaccard),
-        "lcs" => Some(Algorithm::Lcs),
-        "levenshtein" => Some(Algorithm::Levenshtein),
-        "simpson" => Some(Algorithm::Simpson),
-        "weightedjaccard" => Some(Algorithm::WeightedJaccard),
-        _ => None,
+/// The representation a birthmark takes. Every algorithm operates on exactly
+/// one of these, converting anything else it is handed — which is why pairing
+/// an algorithm with a different shape silently produces the same numbers as
+/// the canonical pairing, or none at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Shape {
+    Seq,
+    Set,
+    Freq,
+}
+
+impl Shape {
+    pub(crate) fn description(&self) -> &'static str {
+        match self {
+            Shape::Seq => "sequences",
+            Shape::Set => "sets",
+            Shape::Freq => "frequency vectors",
+        }
     }
+}
+
+/// The CLI spelling of an algorithm and the shape it operates on, in one
+/// table so that the parser, the validation and the error message cannot
+/// drift apart. Written out rather than derived from `ValueEnum`, whose
+/// kebab-case would render `WeightedJaccard` as `weighted-jaccard` and put a
+/// hyphen inside a name that has to be split off by its last one.
+pub(crate) fn algorithm_spec(algorithm: &Algorithm) -> (&'static str, Shape) {
+    match algorithm {
+        Algorithm::Cosine => ("cosine", Shape::Freq),
+        Algorithm::Dice => ("dice", Shape::Set),
+        Algorithm::Euclidean => ("euclidean", Shape::Freq),
+        Algorithm::Jaccard => ("jaccard", Shape::Set),
+        Algorithm::Lcs => ("lcs", Shape::Seq),
+        Algorithm::Levenshtein => ("levenshtein", Shape::Seq),
+        Algorithm::Simpson => ("simpson", Shape::Set),
+        Algorithm::WeightedJaccard => ("weightedjaccard", Shape::Freq),
+    }
+}
+
+fn parse_algorithm(name: &str) -> Option<Algorithm> {
+    use clap::ValueEnum;
+    Algorithm::value_variants()
+        .iter()
+        .find(|a| algorithm_spec(a).0 == name)
+        .cloned()
 }
 
 fn parse_kgram(name: &str) -> Option<BirthmarkType> {
@@ -572,18 +650,20 @@ mod tests {
     /// it on its own.
     #[test]
     fn test_analysis_type_delegates_the_birthmark_half() {
-        for birthmark in [
-            "op-seq",
-            "op-set",
-            "op-freq",
-            "fc-seq",
-            "fc-set",
-            "fc-freq",
-            "op-4gram-seq",
+        // each birthmark is paired with an algorithm of its own shape, so that
+        // this test observes the delegation rather than the validation
+        for (birthmark, algorithm) in [
+            ("op-seq", "lcs"),
+            ("op-set", "jaccard"),
+            ("op-freq", "cosine"),
+            ("fc-seq", "levenshtein"),
+            ("fc-set", "dice"),
+            ("fc-freq", "euclidean"),
+            ("op-4gram-seq", "lcs"),
         ] {
             let expected =
                 BirthmarkType::try_from(birthmark).unwrap_or_else(|e| panic!("{birthmark}: {e}"));
-            let name = format!("{birthmark}-jaccard");
+            let name = format!("{birthmark}-{algorithm}");
             let at = AnalysisType::try_from(name.clone()).unwrap_or_else(|e| panic!("{name}: {e}"));
             assert_eq!(at.birthmark, expected, "name: {name}");
         }
@@ -599,6 +679,54 @@ mod tests {
             "op-0.5gram-set-dice",
         ] {
             assert!(AnalysisType::try_from(name).is_err(), "name: {name}");
+        }
+    }
+
+    /// Each algorithm converts whatever shape it is handed into the one it
+    /// operates on, so a non-canonical pairing either reproduces the canonical
+    /// one's numbers under a misleading name or scores nothing at all. Both
+    /// are rejected, and the message names the pairing that was meant.
+    #[test]
+    fn test_analysis_type_rejects_non_canonical_pairings() {
+        let cases = [
+            ("op-seq-euclidean", "use op-freq-euclidean"),
+            ("op-set-levenshtein", "use op-seq-levenshtein"),
+            ("op-freq-lcs", "use op-seq-lcs"),
+            ("fc-seq-jaccard", "use fc-set-jaccard"),
+            // the suggestion keeps the k of the birthmark it was given
+            ("op-3gram-seq-euclidean", "use op-3gram-freq-euclidean"),
+        ];
+        for (name, expected) in cases {
+            match AnalysisType::try_from(name) {
+                Err(e @ Error::IncompatibleAnalysis(..)) => {
+                    let rendered = e.to_string();
+                    assert!(
+                        rendered.contains(expected),
+                        "name: {name}, rendered: {rendered}"
+                    );
+                }
+                Err(e) => panic!("{name}: unexpected error: {e}"),
+                Ok(_) => panic!("{name}: expected the pairing to be rejected"),
+            }
+        }
+    }
+
+    /// The canonical pairing of every algorithm must survive validation, in
+    /// each birthmark family.
+    #[test]
+    fn test_analysis_type_accepts_every_canonical_pairing() {
+        use clap::ValueEnum;
+        for prefix in ["op", "fc", "op-4gram"] {
+            for algorithm in Algorithm::value_variants() {
+                let (algorithm_name, shape) = algorithm_spec(algorithm);
+                let shape_name = match shape {
+                    Shape::Seq => "seq",
+                    Shape::Set => "set",
+                    Shape::Freq => "freq",
+                };
+                let name = format!("{prefix}-{shape_name}-{algorithm_name}");
+                assert!(AnalysisType::try_from(name.clone()).is_ok(), "name: {name}");
+            }
         }
     }
 

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -333,61 +333,39 @@ impl TryFrom<&str> for AnalysisType {
 impl TryFrom<String> for AnalysisType {
     type Error = Error;
 
+    /// Parses `{birthmark}-{algorithm}`, for example `op-3gram-set-dice`.
+    ///
+    /// Only the algorithm name is read here; everything before it is handed to
+    /// [`BirthmarkType::try_from`], which is the parser that owns that half.
+    /// Splitting on the last hyphen is safe because no algorithm name contains
+    /// one — `weightedjaccard` is deliberately a single word.
     fn try_from(name: String) -> Result<Self> {
-        let s = name.to_lowercase();
-        if s == "op-freq-cosine" {
-            Ok(AnalysisType::new(BirthmarkType::OpFreq, Algorithm::Cosine))
-        } else if s == "op-set-dice" {
-            Ok(AnalysisType::new(BirthmarkType::OpSet, Algorithm::Dice))
-        } else if s == "op-freq-euclidean" {
-            Ok(AnalysisType::new(
-                BirthmarkType::OpFreq,
-                Algorithm::Euclidean,
-            ))
-        } else if s == "op-set-jaccard" {
-            Ok(AnalysisType::new(BirthmarkType::OpSet, Algorithm::Jaccard))
-        } else if s == "op-seq-levenshtein" {
-            Ok(AnalysisType::new(
-                BirthmarkType::OpSeq,
-                Algorithm::Levenshtein,
-            ))
-        } else if s == "op-set-simpson" {
-            Ok(AnalysisType::new(BirthmarkType::OpSet, Algorithm::Simpson))
-        } else if s == "op-freq-weightedjaccard" {
-            Ok(AnalysisType::new(
-                BirthmarkType::OpFreq,
-                Algorithm::WeightedJaccard,
-            ))
-        } else if let Some((bt, c)) = parse_kgram_and_algorithm(s) {
-            Ok(AnalysisType::new(bt, c))
-        } else {
-            Err(Error::BirthmarkType(name))
-        }
+        let lowered = name.to_lowercase();
+        let (birthmark, algorithm) = lowered
+            .rsplit_once('-')
+            .ok_or_else(|| Error::BirthmarkType(name.clone()))?;
+        let birthmark = BirthmarkType::try_from(birthmark)?;
+        let algorithm =
+            parse_algorithm(algorithm).ok_or_else(|| Error::BirthmarkType(name.clone()))?;
+        Ok(AnalysisType::new(birthmark, algorithm))
     }
 }
 
-fn parse_kgram_and_algorithm(name: String) -> Option<(BirthmarkType, Algorithm)> {
-    if let Some(s) = name.strip_prefix("op-") {
-        let s = s.to_string();
-        if let Some(s) = s.strip_suffix("-cosine") {
-            parse_kgram(s).map(|bt| (bt, Algorithm::Cosine))
-        } else if let Some(s) = s.strip_suffix("-dice") {
-            parse_kgram(s).map(|bt| (bt, Algorithm::Dice))
-        } else if let Some(s) = s.strip_suffix("-euclidean") {
-            parse_kgram(s).map(|bt| (bt, Algorithm::Euclidean))
-        } else if let Some(s) = s.strip_suffix("-jaccard") {
-            parse_kgram(s).map(|bt| (bt, Algorithm::Jaccard))
-        } else if let Some(s) = s.strip_suffix("-levenshtein") {
-            parse_kgram(s).map(|bt| (bt, Algorithm::Levenshtein))
-        } else if let Some(s) = s.strip_suffix("-simpson") {
-            parse_kgram(s).map(|bt| (bt, Algorithm::Simpson))
-        } else if let Some(s) = s.strip_suffix("-weightedjaccard") {
-            parse_kgram(s).map(|bt| (bt, Algorithm::WeightedJaccard))
-        } else {
-            None
-        }
-    } else {
-        None
+/// The algorithm half of an analysis name. Kept as an explicit table rather
+/// than derived from `ValueEnum`, whose kebab-case would render
+/// `WeightedJaccard` as `weighted-jaccard` and break the split on the last
+/// hyphen.
+fn parse_algorithm(name: &str) -> Option<Algorithm> {
+    match name {
+        "cosine" => Some(Algorithm::Cosine),
+        "dice" => Some(Algorithm::Dice),
+        "euclidean" => Some(Algorithm::Euclidean),
+        "jaccard" => Some(Algorithm::Jaccard),
+        "lcs" => Some(Algorithm::Lcs),
+        "levenshtein" => Some(Algorithm::Levenshtein),
+        "simpson" => Some(Algorithm::Simpson),
+        "weightedjaccard" => Some(Algorithm::WeightedJaccard),
+        _ => None,
     }
 }
 
@@ -530,8 +508,18 @@ mod tests {
             "op-freq-euclidean",
             "op-set-jaccard",
             "op-seq-levenshtein",
+            "op-seq-lcs",
             "op-set-simpson",
             "op-freq-weightedjaccard",
+            // the fc- family reaches BirthmarkType::try_from by the same route
+            "fc-freq-cosine",
+            "fc-set-dice",
+            "fc-freq-euclidean",
+            "fc-set-jaccard",
+            "fc-seq-levenshtein",
+            "fc-seq-lcs",
+            "fc-set-simpson",
+            "fc-freq-weightedjaccard",
         ];
         for name in names {
             assert!(AnalysisType::try_from(name).is_ok(), "name: {name}");
@@ -556,6 +544,10 @@ mod tests {
                 "op-6gram-freq-weightedjaccard",
                 BirthmarkType::OpKgramFreq(6),
             ),
+            ("op-3gram-seq-lcs", BirthmarkType::OpKgramSeq(3)),
+            // delegation removes the k <= 6 ceiling the CLI enum imposes
+            ("op-9gram-freq-cosine", BirthmarkType::OpKgramFreq(9)),
+            ("op-12gram-set-jaccard", BirthmarkType::OpKgramSet(12)),
         ];
         for (name, expected) in cases {
             let at = AnalysisType::try_from(name).unwrap_or_else(|e| panic!("{name}: {e}"));
@@ -570,6 +562,41 @@ mod tests {
             "unknown",
             "op-2gram-set-unknown",
             "fc-set-jaccard-extra",
+        ] {
+            assert!(AnalysisType::try_from(name).is_err(), "name: {name}");
+        }
+    }
+
+    /// The algorithm name is the only part read here; everything before the
+    /// last hyphen must come back exactly as BirthmarkType::try_from resolves
+    /// it on its own.
+    #[test]
+    fn test_analysis_type_delegates_the_birthmark_half() {
+        for birthmark in [
+            "op-seq",
+            "op-set",
+            "op-freq",
+            "fc-seq",
+            "fc-set",
+            "fc-freq",
+            "op-4gram-seq",
+        ] {
+            let expected =
+                BirthmarkType::try_from(birthmark).unwrap_or_else(|e| panic!("{birthmark}: {e}"));
+            let name = format!("{birthmark}-jaccard");
+            let at = AnalysisType::try_from(name.clone()).unwrap_or_else(|e| panic!("{name}: {e}"));
+            assert_eq!(at.birthmark, expected, "name: {name}");
+        }
+    }
+
+    /// A birthmark half that BirthmarkType rejects must fail the whole parse,
+    /// rather than being reported as an unknown analysis name.
+    #[test]
+    fn test_analysis_type_reports_a_bad_birthmark_half() {
+        for name in [
+            "op-nonsense-jaccard",
+            "xx-set-jaccard",
+            "op-0.5gram-set-dice",
         ] {
             assert!(AnalysisType::try_from(name).is_err(), "name: {name}");
         }

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -387,6 +387,35 @@ impl std::fmt::Display for Algorithm {
 }
 
 impl Algorithm {
+    /// The CLI spelling of this algorithm and the shape it operates on, in one
+    /// table so that the parser, the validation and the error message cannot
+    /// drift apart. Written out rather than derived from `ValueEnum`, whose
+    /// kebab-case would render `WeightedJaccard` as `weighted-jaccard` and put
+    /// a hyphen inside a name that has to be split off by its last one.
+    fn spec(&self) -> (&'static str, Shape) {
+        match self {
+            Algorithm::Cosine => ("cosine", Shape::Freq),
+            Algorithm::Dice => ("dice", Shape::Set),
+            Algorithm::Euclidean => ("euclidean", Shape::Freq),
+            Algorithm::Jaccard => ("jaccard", Shape::Set),
+            Algorithm::Lcs => ("lcs", Shape::Seq),
+            Algorithm::Levenshtein => ("levenshtein", Shape::Seq),
+            Algorithm::Simpson => ("simpson", Shape::Set),
+            Algorithm::WeightedJaccard => ("weightedjaccard", Shape::Freq),
+        }
+    }
+
+    /// The birthmark shape this algorithm computes over. Anything else it is
+    /// handed is converted to this first, which is why a pairing that does not
+    /// match is rejected rather than quietly re-encoded.
+    pub fn shape(&self) -> Shape {
+        self.spec().1
+    }
+
+    pub(crate) fn cli_name(&self) -> &'static str {
+        self.spec().0
+    }
+
     pub fn comparator(&self) -> Comparator {
         self.into()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ pub enum Error {
     BirthmarkType(String),
     Clap(clap::Error),
     Csv(csv::Error),
+    /// A birthmark shape paired with an algorithm that does not operate on it.
+    IncompatibleAnalysis(BirthmarkType, crate::prelude::Algorithm),
     InvalidPcode(u32),
     Io(PathBuf, std::io::Error),
     Json(PathBuf, serde_json::Error),
@@ -45,6 +47,15 @@ impl std::fmt::Display for Error {
             }
             Error::BirthmarkType(t) => write!(f, "{t}: unknown birthmark type"),
             Error::Csv(e) => write!(f, "CSV error: {}", e),
+            Error::IncompatibleAnalysis(bt, algorithm) => {
+                let (name, shape) = crate::birthmarks::algorithm_spec(algorithm);
+                write!(
+                    f,
+                    "{bt}-{name}: {name} operates on {}; use {}-{name}",
+                    shape.description(),
+                    bt.with_shape(shape)
+                )
+            }
             Error::InvalidPcode(code) => write!(f, "invalid pcode: {code}"),
             Error::Io(path, e) => write!(f, "IO error for {}: {}", path.display(), e),
             Error::Json(file, e) => write!(f, "{}: JSON error: {}", file.display(), e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,12 +48,12 @@ impl std::fmt::Display for Error {
             Error::BirthmarkType(t) => write!(f, "{t}: unknown birthmark type"),
             Error::Csv(e) => write!(f, "CSV error: {}", e),
             Error::IncompatibleAnalysis(bt, algorithm) => {
-                let (name, shape) = crate::birthmarks::algorithm_spec(algorithm);
+                let name = algorithm.cli_name();
                 write!(
                     f,
                     "{bt}-{name}: {name} operates on {}; use {}-{name}",
-                    shape.description(),
-                    bt.with_shape(shape)
+                    algorithm.shape().description(),
+                    bt.with_shape(algorithm.shape())
                 )
             }
             Error::InvalidPcode(code) => write!(f, "invalid pcode: {code}"),

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
-pub use crate::birthmarks::{AnalysisType, BirthmarkType, Data, Kgram, Metadata};
+pub use crate::birthmarks::{AnalysisType, BirthmarkType, Data, Kgram, Metadata, Shape};
 pub use crate::birthmarks::{Birthmark, Elements};
 pub use crate::compare::{
     Aggregator, Algorithm, Comparator, Comparison, PairingStrategy, escape_csv_string,


### PR DESCRIPTION
Fixes #38.

Three commits, each readable on its own.

## 1. Delegate the birthmark half

Two parsers read overlapping strings and never called each other:

```
BirthmarkType::try_from ──> parse_kgram ──> parse_k_value

AnalysisType::try_from  ──> (seven hand-written if/else branches)
                        └─> parse_kgram_and_algorithm ──> parse_kgram ──> parse_k_value
```

Now the longer string reads only its own part and hands the rest down:

```
AnalysisType::try_from ──> parse_algorithm            (the last segment)
                       └─> BirthmarkType::try_from    (everything before it)
```

Because the copy was partial, **fifteen of the sixty-four** combinations the CLI offers could not be parsed at all — the eight `fc-*`, since the branches only covered `op-`, and the seven `*-lcs`, since the suffix list omitted `lcs`.

| | before | after |
|---|---|---|
| `op-seq-lcs` | **ERR** | OK |
| `fc-set-jaccard` | **ERR** | OK |
| `fc-seq-lcs` | **ERR** | OK |
| `op-3gram-seq-lcs` | **ERR** | OK |

`BirthmarkType::try_from` already resolved `fc-set` and `op-3gram-seq` without complaint, so the gap was in the duplicate, not in what the strings mean. `parse_kgram_and_algorithm` is gone.

## 2. Reject pairings that cannot mean what they say

Uniform parsing accepts pairings the hand-written table implicitly rejected, and those cannot mean what they say. Each algorithm converts whatever shape it is handed into the one it operates on:

- `op-seq-euclidean` runs `seq2freq` and returns **exactly** what `op-freq-euclidean` returns, while its name promises a comparison over sequences
- `op-set-levenshtein` has no conversion available, so the comparator falls through to `0.0` and the run reports no similarity at all

Measured, not assumed — identical similarity matrices for `op-seq-jaccard` vs `op-set-jaccard`, `op-freq-dice` vs `op-set-dice`, and `op-seq-euclidean` vs `op-freq-euclidean`. Nothing is lost by rejecting the non-canonical spelling; the extraction is merely more expensive, building an ordered sequence only to discard the order.

The error names the pairing that was meant, carrying the `k` of a k-gram across:

```
op-seq-euclidean:        euclidean operates on frequency vectors; use op-freq-euclidean
op-set-levenshtein:      levenshtein operates on sequences;       use op-seq-levenshtein
fc-seq-jaccard:          jaccard operates on sets;                use fc-set-jaccard
op-3gram-seq-euclidean:  euclidean operates on frequency vectors; use op-3gram-freq-euclidean
```

`Error::IncompatibleAnalysis(BirthmarkType, Algorithm)` is a new variant, following the shape of the existing `Mismatch(BirthmarkType, BirthmarkType)`.

## 3. Validate in `new` as well

`try_from` validated; `new` did not — and `new` is public, so the check could be walked around by constructing the pair directly. The CLI took exactly that route: `From<&Analysis>` built all sixty-four pairings through `new`. And since `AnalysisType` stores a `Comparator` rather than the `Algorithm`, a caller could not inspect the result afterwards either.

The check now lives in `new`, with `try_from` delegating to it, so one place decides.

**API changes:**

| | before | after |
|---|---|---|
| `AnalysisType::new` | `-> Self` | `-> Result<Self>` |
| `From<Analysis> for AnalysisType` | `From` | `TryFrom` |
| `RunOpts::analysis_type` | `-> AnalysisType` | `-> Result<AnalysisType>` |

Newly public, so a caller can ask before building: `Shape`, `BirthmarkType::shape`, `BirthmarkType::with_shape`, `BirthmarkType::pairs_with`, `Algorithm::shape`. The algorithm's CLI name and its shape live in one table on `Algorithm` itself, so the parser, the validation and the error message cannot drift apart.

`perform_run` already returned `Result`, so it only gains a `?`. Every pairing the CLI lists is canonical, so nothing a user can express is newly rejected — verified by running `oinkie run -a op-set-jaccard` end to end.

## Tests

- Named combinations cover all eight `fc-*` alongside the `op-*` ones, and `*-lcs` on both
- k-gram cases gain `op-3gram-seq-lcs`, `op-9gram-*` and `op-12gram-*`, pinning down that the `k <= 6` ceiling belongs to the CLI enum and not to this parser
- `test_analysis_type_delegates_the_birthmark_half` asserts the delegation directly
- `test_analysis_type_rejects_non_canonical_pairings` checks the rejection and the suggested name, `k` included
- `test_analysis_type_accepts_every_canonical_pairing` walks every algorithm in the `op`, `fc` and `op-4gram` families
- `test_pairs_with_agrees_with_construction` walks all nine birthmark families against all eight algorithms and asserts `pairs_with`, `new` and `try_from` agree on all seventy-two

`cargo test` — 83 passed. `cargo fmt --all -- --check`, `cargo clippy -- -D warnings` and `cargo clippy --all-targets` all clean.

## Breaking changes

`AnalysisType::new` returns `Result`, `From<Analysis> for AnalysisType` became `TryFrom`, and `RunOpts::analysis_type` returns `Result`. All are library-level; the CLI surface is unchanged. v0.4.0 already carries breaking changes, so this is the release to land it in — worth a line in `.github/release-notes/v0.4.0.md` if the library API is considered public.

## Still to come

The CLI reaches `AnalysisType` through the `Analysis` enum rather than through `try_from`, so the parse errors above are not yet what a user sees. Routing it through the parser is #25.