### PR TITLE
fix: resolve the symbol a call refers to, so fc-* is not empty

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -78,6 +78,13 @@ and hands the rest to `BirthmarkType::try_from` (#38), so the eight `fc-*`
 combinations and the seven `*-lcs` ones now work, as does any `k` — previously
 fifteen of the sixty-four combinations the CLI offers could not be parsed at all.
 
+**`Op` gains a required method, `symbol_key`.** Any crate implementing `Op` for
+its own lifter must add it. It renders the operation's first operand as the
+program's symbol table keys it, so a call target can be resolved; returning
+`None` when the operand cannot name a symbol is what keeps an unresolvable
+target distinguishable from a lookup that found nothing. Ghidra's
+implementation parses the operand through the existing `Value` type.
+
 **New public items** for asking whether a pairing is valid before building one:
 `Shape`, `BirthmarkType::shape`, `BirthmarkType::with_shape`,
 `BirthmarkType::pairs_with` and `Algorithm::shape`.

--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -36,6 +36,18 @@ one directory per shell, with conventional file names (`oinkie`, `oinkie.elv`,
 `oinkie.fish`, `oinkie.ps1`, `_oinkie`). Packaging scripts that referenced the
 old `completions` directory need updating.
 
+**`fc-*` analyses produced a false positive.** The symbol lookup compared the
+call operand `"(ram, 0x100000480, 8)"` against a symbol table keyed
+`"0x100000480"`, so every call was discarded and every `fc-*` birthmark came out
+empty (#40). Two empty sets are identical, so any two programs compared as a
+perfect match through `fc-freq-cosine`, `fc-set-dice`, `fc-freq-euclidean`,
+`fc-set-jaccard`, `fc-seq-levenshtein`, `fc-seq-lcs`, `fc-set-simpson` and
+`fc-freq-weightedjaccard`.
+
+Any conclusion drawn from an `fc-*` comparison on v0.3.0 or earlier should be
+treated as unreliable and the comparison re-run. Birthmark files extracted with
+`fc-*` are empty and carry no information; regenerate them.
+
 ## Library API
 
 These affect code using oinkie as a crate. The command-line interface is
@@ -75,6 +87,8 @@ fifteen of the sixty-four combinations the CLI offers could not be parsed at all
 - **#30** — widened the birthmark hash prefix to 64 bits, removing a silent
   overwrite that was reachable at corpus scale
 - **#29** — fixed the `left`/`right` inversion in similarity CSVs
+- **#40** — `fc-*` birthmarks resolve their symbols again; they were empty, so
+  unrelated programs scored a perfect match through all eight of them
 - **#36** — `lift -i` with a relative path no longer resolves it twice into
   `irs/irs`, and the directory is created rather than having to exist
 - **#38** — analysis names are parsed in one place, and a pairing that cannot

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -169,7 +169,8 @@ where
 fn extract_function_calls<T: crate::Op>(f: &Function<T>, p: &Program<T>) -> Vec<String> {
     f.iter()
         .filter(|op| op.mnemonic() == "CALL")
-        .filter_map(|op| op.inputs().first().and_then(|addr| p.symbol(addr)))
+        .filter_map(|op| op.symbol_key())
+        .filter_map(|key| p.symbol(&key))
         .map(|s| s.to_string())
         .collect()
 }
@@ -252,6 +253,49 @@ mod tests {
         let path = Path::new("non_existent_file.xyz");
         let result = get_hash(path);
         assert!(result.is_err());
+    }
+
+    /// The fc-* family is built from the symbols a function calls. The call
+    /// operand names its target in the lifter's own notation, which is not the
+    /// form the symbol table is keyed by, so the two have to be reconciled
+    /// before the lookup — otherwise every call is discarded and the birthmark
+    /// comes out empty.
+    #[test]
+    fn test_extract_function_calls_resolves_the_symbol() {
+        let program: Program<crate::ghidra::Op> =
+            std::path::Path::new("testdata/hello_world/pcodes/hello_clang.json")
+                .try_into()
+                .expect("failed to load the fixture");
+        let function = program.iter().next().expect("fixture has no function");
+
+        let calls = extract_function_calls(function, &program);
+        assert_eq!(
+            calls,
+            vec!["_printf".to_string()],
+            "the fixture calls _printf exactly once"
+        );
+    }
+
+    /// Two empty sets are identical, so an fc-* birthmark that resolves nothing
+    /// makes unrelated programs look like a perfect match. Guard the property
+    /// that makes the emptiness dangerous, not just the emptiness.
+    #[test]
+    fn test_fc_birthmarks_are_not_empty() {
+        for fixture in [
+            "testdata/hello_world/pcodes/hello_clang.json",
+            "testdata/hello_world/pcodes/hello_gcc.json",
+        ] {
+            let program: Program<crate::ghidra::Op> = std::path::Path::new(fixture)
+                .try_into()
+                .unwrap_or_else(|e| panic!("{fixture}: {e}"));
+            let birthmark = Extractor::new(BirthmarkType::FcSet)
+                .extract_each(&program)
+                .unwrap_or_else(|e| panic!("{fixture}: {e}"));
+            assert!(
+                birthmark.elements.iter().any(|e| !e.is_empty()),
+                "{fixture}: every fc-set element is empty"
+            );
+        }
     }
 
     #[test]

--- a/src/ghidra.rs
+++ b/src/ghidra.rs
@@ -58,6 +58,17 @@ impl crate::Op for Op {
     fn ret(&self) -> Option<&str> {
         self.out.as_deref()
     }
+
+    fn symbol_key(&self) -> Option<String> {
+        // Only a call into ram names an address the symbol table could carry;
+        // a target held in a register or a temporary is resolved at run time
+        // and has no name to find here.
+        let target: Value = self.inputs.first()?.parse().ok()?;
+        match target.storage {
+            StorageType::Ram => Some(format!("0x{:x}", target.address)),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,15 @@ pub trait Op {
 
     /// returns the output of the operation, e.g., the destination register or memory location.
     fn ret(&self) -> Option<&str>;
+
+    /// returns this operation's target rendered as the program's symbol table
+    /// keys it, or `None` when the target is not something a symbol could name.
+    ///
+    /// The operand notation is the lifter's own — Ghidra writes
+    /// `"(ram, 0x100000480, 8)"` while its symbol table is keyed
+    /// `"0x100000480"` — so reconciling the two belongs with the lifter that
+    /// produced both, not with the extractor that is generic over them.
+    fn symbol_key(&self) -> Option<String>;
 }
 
 pub trait Iterable {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,8 +107,20 @@ pub trait Op {
     /// returns the output of the operation, e.g., the destination register or memory location.
     fn ret(&self) -> Option<&str>;
 
-    /// returns this operation's target rendered as the program's symbol table
-    /// keys it, or `None` when the target is not something a symbol could name.
+    /// returns this operation's first operand rendered as the program's symbol
+    /// table keys it, so that [`crate::program::Program::symbol`] can resolve
+    /// it, or `None` when that operand cannot name a symbol.
+    ///
+    /// Callers choose which operations to ask — the only caller today asks
+    /// calls, to build the `fc-*` birthmarks — so an implementation need not
+    /// inspect the opcode itself.
+    ///
+    /// Returning `None` for a target no symbol could name is the part that
+    /// matters. An indirect call through a register or a temporary is
+    /// resolved at run time and has no name to find; a key that cannot match
+    /// would be indistinguishable from a lookup that legitimately found
+    /// nothing, which is how the `fc-*` family came to be silently empty
+    /// before this method existed.
     ///
     /// The operand notation is the lifter's own — Ghidra writes
     /// `"(ram, 0x100000480, 8)"` while its symbol table is keyed


### PR DESCRIPTION
Fixes #40.

## The bug

`extract_function_calls` looked the call target up in the symbol table using the operand exactly as the lifter wrote it:

```rust
.filter_map(|op| op.inputs().first().and_then(|addr| p.symbol(addr)))
```

Ghidra writes the operand as `"(ram, 0x100000480, 8)"` and keys its symbol table `"0x100000480"`. The lookup never matched, so `filter_map` discarded every call.

## Why it mattered

Every `fc-*` birthmark came out **empty** — and two empty sets are identical, so `jaccard_index` returns `1.0`. Any two programs compared as a perfect match through all eight `fc-*` analyses, via both `compare` and `run`. A silent false positive, in a tool for detecting theft.

Before, on unmodified fixtures:

```
  hello_clang    [{'Seq': []}]
  hello_gcc      [{'Seq': []}]
  similarity: 1
```

After:

```
  hello_clang    [{'Seq': ['_printf']}]
  hello_gcc      [{'Seq': ['_printf']}]
  similarity: 1
```

The score is still `1`, and that is now the **right answer** — both fixtures are hello-world programs whose only call is `_printf`, so their call sets genuinely are identical. The difference is that the number now means something. This is worth noting because a comparison test alone could not tell the two situations apart, which is why the tests assert the birthmark's contents instead.

## Where the fix lives

Reconciling the two notations belongs with the lifter that produced both, not with `extract_function_calls`, which is generic over `T: Op` and has **no other Ghidra dependency**. Putting the operand parsing there would have added one, working against the decoupling #45 exists for.

So `Op` gains `symbol_key`, and the Ghidra implementation parses the operand through the `Value` type that already exists for exactly this notation:

```rust
fn symbol_key(&self) -> Option<String> {
    let target: Value = self.inputs.first()?.parse().ok()?;
    match target.storage {
        StorageType::Ram => Some(format!("0x{:x}", target.address)),
        _ => None,
    }
}
```

Only a call into `ram` names an address the symbol table could carry. A target held in a register or a temporary is resolved at run time and has no name to find, so it yields `None` rather than a key that cannot match — previously indistinguishable from the bug.

The `"CALL"` literal in the filter is untouched; making that per-lifter is #44.

## Tests

Both fail without the fix — verified by reverting it and re-running:

```
test test_extract_function_calls_resolves_the_symbol ... FAILED
test test_fc_birthmarks_are_not_empty ... FAILED
```

`test_extract_function_calls_resolves_the_symbol` asserts `_printf` is recovered from the fixture. `test_fc_birthmarks_are_not_empty` guards the property that makes the emptiness dangerous rather than the emptiness itself: an `fc-set` element must contain something, because two empty ones score `1.0`.

Nothing previously asserted that an `fc-*` birthmark contained anything — the whole family was uncovered, which is why an always-empty result went unnoticed.

## Verification

- `cargo test` — 87 passed
- `cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, `cargo clippy --all-targets` — all clean
- The original symptom is gone end to end, through both `compare` and `run`

## Release note

Added to `.github/release-notes/v0.4.0.md`, including the part users need to act on: **conclusions drawn from an `fc-*` comparison on v0.3.0 or earlier are unreliable and should be re-run**, and birthmark files extracted with `fc-*` carry no information and need regenerating.