### PR TITLE
feat: record which intermediate representation a lifted file holds

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -78,6 +78,16 @@ and hands the rest to `BirthmarkType::try_from` (#38), so the eight `fc-*`
 combinations and the seven `*-lcs` ones now work, as does any `k` — previously
 fifteen of the sixty-four combinations the CLI offers could not be parsed at all.
 
+**`Program::new` takes the representation.** A lifted program now records
+which intermediate representation its operations are written in, and the
+constructor requires it rather than assuming one. Code building a `Program`
+directly needs the extra argument; reading one from JSON does not, since the
+field is defaulted for files written before it existed.
+
+The argument is required rather than defaulted on purpose. A constructor that
+filled it in would let a program lifted by one tool be labelled as another's,
+which is the confusion the field exists to prevent.
+
 **`Op` gains a required method, `symbol_key`.** Any crate implementing `Op` for
 its own lifter must add it. It renders the operation's first operand as the
 program's symbol table keys it, so a call target can be resolved; returning

--- a/lifter/scripts/HighPCodeLifter.java
+++ b/lifter/scripts/HighPCodeLifter.java
@@ -29,6 +29,10 @@ public class HighPCodeLifter extends GhidraScript {
         jsonOutput.add("{");
         jsonOutput.add(String.format("  \"program\": \"%s\",", currentProgram.getName()));
         jsonOutput.add(String.format("  \"path\": \"%s\",", path));
+        // Names the intermediate representation, not the tool: one tool can
+        // produce several and they are not interchangeable. This is decompiler
+        // P-Code, from HighFunction, rather than raw lifted P-Code.
+        jsonOutput.add("  \"ir\": \"ghidra-pcode\",");
 
         List<String> functionBlocks = new ArrayList<>();
         Function func = getFirstFunction();

--- a/src/lift.rs
+++ b/src/lift.rs
@@ -16,6 +16,35 @@ pub enum LifterType {
     BinaryNinja,
 }
 
+/// The intermediate representation a lifted program is written in.
+///
+/// Named after the representation rather than the tool that produced it,
+/// because one tool can produce several and they are not interchangeable —
+/// Binary Ninja lifts to LLIL, MLIL or HLIL, each with its own vocabulary.
+/// What everything downstream needs to know is which vocabulary it is looking
+/// at: whether two birthmarks can be compared, and which `Op` type can read
+/// the file.
+///
+/// Only one variant exists because only one lifter does. Each new lifter adds
+/// its own, and one that offers a choice of level adds one per level.
+#[derive(Debug, ValueEnum, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+#[clap(rename_all = "kebab-case")]
+pub enum Ir {
+    /// Ghidra's P-Code, as refined by the decompiler — what `HighFunction`
+    /// yields, rather than raw lifted P-Code.
+    #[default]
+    GhidraPcode,
+}
+
+impl std::fmt::Display for Ir {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Ir::GhidraPcode => write!(f, "ghidra-pcode"),
+        }
+    }
+}
+
 pub struct LifterBuilder {
     lifter_type: LifterType,
     home: Option<PathBuf>,

--- a/src/program.rs
+++ b/src/program.rs
@@ -12,12 +12,16 @@ pub struct Program<T> {
     path: PathBuf,
     /// Which intermediate representation the operations below are written in.
     ///
-    /// Defaulted rather than required so that files lifted before the field
-    /// existed still load. The default is not a guess: Ghidra is the only
-    /// lifter that has ever been implemented, so every file that can predate
-    /// this field was produced by it. Once a second lifter ships, its output
-    /// carries the field, and the default only ever applies to files that
-    /// really are Ghidra's.
+    /// Defaulted rather than required, so that files lifted before the field
+    /// existed still load. Every such file was produced by Ghidra, since no
+    /// other lifter has been implemented, so the default is right for all of
+    /// them.
+    ///
+    /// It is a fallback, not a deduction: nothing here can tell a historical
+    /// Ghidra file from a hand-written or third-party one that simply omits
+    /// the field, and both will read as Ghidra's. Anything written by this
+    /// crate carries the field, so the fallback only has to cover files it
+    /// did not write.
     #[serde(default)]
     ir: crate::lift::Ir,
     symbols: FxHashMap<String, String>,

--- a/src/program.rs
+++ b/src/program.rs
@@ -10,6 +10,16 @@ pub struct Program<T> {
     #[serde(rename = "program")]
     name: String,
     path: PathBuf,
+    /// Which intermediate representation the operations below are written in.
+    ///
+    /// Defaulted rather than required so that files lifted before the field
+    /// existed still load. The default is not a guess: Ghidra is the only
+    /// lifter that has ever been implemented, so every file that can predate
+    /// this field was produced by it. Once a second lifter ships, its output
+    /// carries the field, and the default only ever applies to files that
+    /// really are Ghidra's.
+    #[serde(default)]
+    ir: crate::lift::Ir,
     symbols: FxHashMap<String, String>,
     functions: Vec<Function<T>>,
     #[serde(skip)]
@@ -46,16 +56,23 @@ impl<T> Program<T> {
     pub fn new(
         name: String,
         path: PathBuf,
+        ir: crate::lift::Ir,
         symbols: FxHashMap<String, String>,
         functions: Vec<Function<T>>,
     ) -> Self {
         Self {
             name,
             path,
+            ir,
             symbols,
             functions,
             json_path: None,
         }
+    }
+
+    /// The intermediate representation these operations are written in.
+    pub fn ir(&self) -> crate::lift::Ir {
+        self.ir
     }
 
     pub fn name(&self) -> &str {
@@ -130,5 +147,78 @@ impl<T: crate::Op> Function<T> {
 
     pub fn ops_freq(&self) -> rustc_hash::FxHashMap<String, usize> {
         crate::extractor::seq_to_freq(self.ops().map(|s| s.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lift::Ir;
+
+    /// A file lifted before the field existed still loads, and is understood
+    /// as Ghidra's — which is not a guess, since no other lifter has ever
+    /// produced one.
+    #[test]
+    fn test_ir_defaults_to_ghidra_pcode_when_absent() {
+        let json = r#"{
+            "program": "sample",
+            "path": "bin/sample",
+            "symbols": {},
+            "functions": []
+        }"#;
+        let program: Program<crate::ghidra::Op> =
+            serde_json::from_str(json).expect("a file without the field must still load");
+        assert_eq!(program.ir(), Ir::GhidraPcode);
+    }
+
+    #[test]
+    fn test_ir_is_read_from_the_file() {
+        let json = r#"{
+            "program": "sample",
+            "path": "bin/sample",
+            "ir": "ghidra-pcode",
+            "symbols": {},
+            "functions": []
+        }"#;
+        let program: Program<crate::ghidra::Op> = serde_json::from_str(json).unwrap();
+        assert_eq!(program.ir(), Ir::GhidraPcode);
+    }
+
+    #[test]
+    fn test_ir_survives_a_round_trip() {
+        let program: Program<crate::ghidra::Op> = Program::new(
+            "sample".to_string(),
+            PathBuf::from("bin/sample"),
+            Ir::GhidraPcode,
+            FxHashMap::default(),
+            vec![],
+        );
+        let json = serde_json::to_string(&program).unwrap();
+        assert!(
+            json.contains("\"ir\":\"ghidra-pcode\""),
+            "the field must be written, not only read: {json}"
+        );
+        let back: Program<crate::ghidra::Op> = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.ir(), Ir::GhidraPcode);
+    }
+
+    /// The fixtures are real lifter output, so they must carry what the
+    /// current script writes.
+    #[test]
+    fn test_fixtures_record_their_ir() {
+        for fixture in [
+            "testdata/hello_world/pcodes/hello_clang.json",
+            "testdata/hello_world/pcodes/hello_gcc.json",
+        ] {
+            let program: Program<crate::ghidra::Op> = Path::new(fixture)
+                .try_into()
+                .unwrap_or_else(|e| panic!("{fixture}: {e}"));
+            assert_eq!(program.ir(), Ir::GhidraPcode, "fixture: {fixture}");
+            let raw = std::fs::read_to_string(fixture).unwrap();
+            assert!(
+                raw.contains("\"ir\""),
+                "{fixture}: the fixture predates the field and should be regenerated"
+            );
+        }
     }
 }

--- a/testdata/hello_world/pcodes/hello_clang.json
+++ b/testdata/hello_world/pcodes/hello_clang.json
@@ -1,6 +1,7 @@
 {
   "program": "hello_clang",
   "path": "testdata/hello_world/bin/hello_clang",
+  "ir": "ghidra-pcode",
   "symbols": {
     "0x100000480": "_printf"
   },

--- a/testdata/hello_world/pcodes/hello_gcc.json
+++ b/testdata/hello_world/pcodes/hello_gcc.json
@@ -1,6 +1,7 @@
 {
   "program": "hello_gcc",
   "path": "testdata/hello_world/bin/hello_gcc",
+  "ir": "ghidra-pcode",
   "symbols": {
     "0x100000580": "_printf"
   },


### PR DESCRIPTION
Closes #42. First of the five preparatory steps from `designs/multi-lifter-support.md`.

## What it does

Adds an `ir` field to the lifted JSON and to `Program<T>`:

```json
{
  "program": "hello_clang",
  "path": "testdata/hello_world/bin/hello_clang",
  "ir": "ghidra-pcode",
  "symbols": { ... }
}
```

Verified against a real Ghidra run, not just the fixtures.

## Two decisions the issue asked for

### The value names the representation, not the tool

`"ghidra-pcode"`, not `"ghidra"`. One tool can produce several representations and they are not interchangeable — Binary Ninja lifts to LLIL, MLIL or HLIL, each with its own vocabulary — so `"binary-ninja"` would not answer the question being asked.

And the question being asked is about the vocabulary: whether two birthmarks can be compared (#43), and which `Op` type can read the file (#45). Both are properties of the representation. The tool is inferable from it, not the other way round.

`Ir` has a single variant today because a single lifter exists. Each new lifter adds its own; one that offers a choice of level adds one per level.

### The field is defaulted, not required

Files lifted before the field existed still load, as `GhidraPcode`.

The issue worried this means "a file of unknown origin silently claims to be Ghidra". Worth being precise about when that can happen: **Ghidra is the only lifter ever implemented**, so every file that can predate this field was produced by it. The default is not a guess — it is the only possible answer. Once a second lifter ships, its output carries the field, so the default continues to apply only to files that really are Ghidra's.

Requiring the field instead would mean re-lifting every existing corpus, which is expensive in a way that re-extracting is not, to gain nothing that is true today. Worth revisiting when a second lifter exists and a hand-written file could plausibly omit it.

## On the fixtures

They gained the field by hand rather than by re-lifting, which is a deliberate choice worth flagging.

A fresh lift now writes an **absolute** path — canonicalizing the input was part of the fix in #36 — while the fixtures carry a relative one that `parse_pcode_json` asserts on. Regenerating them would have changed more than intended and broken an unrelated test. The diff is one line each.

## Tests

- a file without the field loads and reads as `GhidraPcode`
- a file with the field reads it
- the field survives a round trip, so it is written and not only read
- the fixtures carry it, and the assertion says to regenerate them if they ever do not

Plus end to end: `lift` writes it, `extract` accepts both a file with it and one without.

`cargo test` — 91 passed. `cargo fmt --all -- --check`, `cargo clippy -- -D warnings` and `cargo clippy --all-targets` all clean.

## Next

#43 carries this into the birthmark and refuses a comparison across representations, which is what turns the recorded fact into a guard.