### PR TITLE
feat: refuse to compare birthmarks from different representations

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -78,6 +78,19 @@ and hands the rest to `BirthmarkType::try_from` (#38), so the eight `fc-*`
 combinations and the seven `*-lcs` ones now work, as does any `k` — previously
 fifteen of the sixty-four combinations the CLI offers could not be parsed at all.
 
+**Birthmarks record the representation they were extracted from, and a
+comparison across two of them is refused.** A birthmark is only meaningful
+against another built the same way, and two lifters describe the same
+instruction with different operations, so comparing across them would measure
+the disagreement between the tools rather than anything about the programs
+(#42, #43). Only Ghidra exists today, so nothing currently reachable is
+refused.
+
+`Metadata` gains an `ir` field, and the `birthmark` record in a similarity CSV
+gains a seventh column for it. The column is appended rather than inserted, so
+the positions earlier readers depend on are unchanged, and a six-column record
+written by an earlier version still parses.
+
 **`Op` gains a required method, `symbol_key`.** Any crate implementing `Op` for
 its own lifter must add it. It renders the operation's first operand as the
 program's symbol table keys it, so a call target can be resolved; returning

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,6 +38,21 @@ jobs:
           cargo clippy -- -D warnings
           cargo build --release
 
+      # Ghidra compiles its SLEIGH language definitions from .slaspec to .sla
+      # on first use and caches them inside its own installation, which the
+      # runner unpacks fresh every time. The lift tests start three
+      # analyzeHeadless processes at once, and against a cold installation
+      # they race to write the same .sla; the loser reads a half-written file
+      # and dies with "ZipException: invalid block type" -- while
+      # analyzeHeadless still exits 0, so the failure surfaced only as a
+      # missing output file. One serial lift builds the cache before anything
+      # runs in parallel.
+      - name: Warm Ghidra's language cache
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          export GHIDRA_HOME=${{ env.GHIDRA_INSTALL_DIR }}
+          ./target/release/oinkie lift -d "$RUNNER_TEMP/warm" testdata/hello_world/bin/hello_clang
+
       - name: Convert coverage format to lcov
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -134,17 +134,26 @@ pub struct Metadata {
     )]
     pub duration: std::time::Duration,
     pub birthmark_type: BirthmarkType,
+    /// The representation the program was lifted to, carried over so that two
+    /// birthmarks can be told apart by more than their type.
+    ///
+    /// Defaulted for the same reason the field on `Program` is: every
+    /// birthmark that can predate it was extracted from Ghidra's P-Code,
+    /// because no other lifter has existed.
+    #[serde(default)]
+    pub ir: crate::lift::Ir,
 }
 
 impl Metadata {
     pub fn csv_info(&self) -> String {
         format!(
-            "birthmark,{},{},{},{},{}",
+            "birthmark,{},{},{},{},{},{}",
             crate::compare::escape_csv_string(&self.file_name),
             crate::compare::escape_csv_string(&self.path.display().to_string()),
             self.birthmark_type,
             self.extracted_at.to_rfc3339(),
-            self.duration.as_nanos()
+            self.duration.as_nanos(),
+            self.ir
         )
     }
 
@@ -156,9 +165,12 @@ impl Metadata {
         if let Some(result) = r.into_records().next() {
             let record = result.map_err(Error::Csv)?;
             let items = record.iter().collect::<Vec<_>>();
-            if items.len() != 6 {
+            // Six is a record written before the ir field existed; seven is
+            // one written since. Both are read, for the same reason the JSON
+            // field is defaulted.
+            if items.len() != 6 && items.len() != 7 {
                 return Err(Error::Parse(format!(
-                    "expected 6 items in metadata, got {}",
+                    "expected 6 or 7 items in metadata, got {}",
                     items.len()
                 )));
             }
@@ -171,12 +183,19 @@ impl Metadata {
             let duration = items[5]
                 .parse::<u64>()
                 .map_err(|e| Error::Parse(format!("invalid duration: {}", e)))?;
+            let ir = match items.get(6) {
+                Some(text) => text
+                    .parse()
+                    .map_err(|e| Error::Parse(format!("invalid ir: {e}")))?,
+                None => crate::lift::Ir::default(),
+            };
             Ok(Self {
                 file_name,
                 path,
                 birthmark_type,
                 extracted_at,
                 duration: Duration::from_nanos(duration),
+                ir,
             })
         } else {
             Err(Error::Parse(format!("invalid metadata line: {line}")))
@@ -235,8 +254,36 @@ impl Birthmark {
         self.json_path = Some(path);
     }
 
+    /// Explains why these two cannot be compared, when they cannot.
+    ///
+    /// A birthmark is only meaningful against another built the same way. The
+    /// type has always had to match; the representation now does too, because
+    /// two lifters describe the same instruction with different operations,
+    /// and comparing across them measures the disagreement between the tools
+    /// rather than anything about the programs.
+    ///
+    /// The `fc-*` family is the one that could eventually cross this line: it
+    /// holds symbol names read from the binary rather than operations read
+    /// from the IR, so two tools should recover much the same set. It is
+    /// refused all the same, because the spellings still differ between tools
+    /// (`_printf` against `printf`) and nothing normalises them yet. Relaxing
+    /// this is worth doing once that normalisation exists and a second lifter
+    /// can be used to measure whether the result is worth trusting.
+    pub fn check_comparable_with(&self, other: &Birthmark) -> Result<()> {
+        if self.metadata.ir != other.metadata.ir {
+            return Err(Error::IrMismatch(self.metadata.ir, other.metadata.ir));
+        }
+        if self.metadata.birthmark_type != other.metadata.birthmark_type {
+            return Err(Error::Mismatch(
+                self.metadata.birthmark_type.clone(),
+                other.metadata.birthmark_type.clone(),
+            ));
+        }
+        Ok(())
+    }
+
     pub fn comparable_with(&self, other: &Birthmark) -> bool {
-        self.metadata.birthmark_type == other.metadata.birthmark_type
+        self.check_comparable_with(other).is_ok()
     }
 
     pub fn name(&self) -> &str {
@@ -470,6 +517,7 @@ mod tests {
             extracted_at: chrono::Utc::now(),
             duration: Duration::from_nanos(42),
             birthmark_type: BirthmarkType::OpSeq,
+            ir: crate::lift::Ir::GhidraPcode,
         };
         let parsed =
             Metadata::parse(&metadata.csv_info()).expect("failed to parse escaped metadata");
@@ -497,7 +545,28 @@ mod tests {
     #[test]
     fn test_parse_metadata_rejects_wrong_field_count() {
         let err = Metadata::parse("birthmark,name,path").unwrap_err();
-        assert!(matches!(err, Error::Parse(msg) if msg.contains("expected 6 items")));
+        assert!(matches!(err, Error::Parse(msg) if msg.contains("expected 6 or 7 items")));
+    }
+
+    /// A record written before the ir field existed still parses, and reads as
+    /// Ghidra's P-Code — the only representation any of them can hold.
+    #[test]
+    fn test_parse_metadata_without_ir() {
+        let metadata = Metadata::parse(
+            "birthmark,bzip2,/tmp/bzip2,op-seq,2026-04-17T04:57:55.385904+00:00,4462500",
+        )
+        .expect("a six-field record must still parse");
+        assert_eq!(metadata.ir, crate::lift::Ir::GhidraPcode);
+    }
+
+    #[test]
+    fn test_parse_metadata_rejects_an_unknown_ir() {
+        assert!(
+            Metadata::parse(
+                "birthmark,b,/tmp/b,op-seq,2026-04-17T04:57:55+00:00,1,not-a-representation"
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -807,6 +876,7 @@ mod tests {
                 extracted_at: chrono::Utc::now(),
                 duration: Duration::from_nanos(7),
                 birthmark_type: BirthmarkType::OpSeq,
+                ir: crate::lift::Ir::GhidraPcode,
             },
             elements: vec![Elements {
                 name: "main".to_string(),
@@ -841,6 +911,44 @@ mod tests {
         assert!(b1.comparable_with(&b2));
         b2.metadata.birthmark_type = BirthmarkType::OpSet;
         assert!(!b1.comparable_with(&b2));
+    }
+
+    /// A representation mismatch must be reported as such. Before this, the
+    /// two were indistinguishable: any refusal came back as a type mismatch,
+    /// and a comparison across representations was not refused at all.
+    #[test]
+    fn test_refuses_a_comparison_across_representations() {
+        let b1 = sample_birthmark();
+        let mut b2 = sample_birthmark();
+        b2.metadata.ir = crate::lift::Ir::IdaMicrocode;
+
+        match b1.check_comparable_with(&b2) {
+            Err(Error::IrMismatch(..)) => {}
+            Err(e) => panic!("expected an IrMismatch, got: {e}"),
+            Ok(()) => panic!("a comparison across representations must be refused"),
+        }
+        assert!(!b1.comparable_with(&b2));
+    }
+
+    /// The type check still reports a type mismatch rather than being
+    /// swallowed by the new one.
+    #[test]
+    fn test_still_refuses_a_mismatched_type() {
+        let b1 = sample_birthmark();
+        let mut b2 = sample_birthmark();
+        b2.metadata.birthmark_type = BirthmarkType::OpSet;
+
+        match b1.check_comparable_with(&b2) {
+            Err(Error::Mismatch(..)) => {}
+            Err(e) => panic!("expected a Mismatch, got: {e}"),
+            Ok(()) => panic!("a mismatched type must be refused"),
+        }
+    }
+
+    #[test]
+    fn test_allows_the_same_representation_and_type() {
+        let b = sample_birthmark();
+        assert!(b.check_comparable_with(&b).is_ok());
     }
 
     #[test]

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -137,9 +137,11 @@ pub struct Metadata {
     /// The representation the program was lifted to, carried over so that two
     /// birthmarks can be told apart by more than their type.
     ///
-    /// Defaulted for the same reason the field on `Program` is: every
-    /// birthmark that can predate it was extracted from Ghidra's P-Code,
-    /// because no other lifter has existed.
+    /// Defaulted as a fallback for the same reason the field on `Program` is:
+    /// every birthmark this crate wrote before the field existed came from
+    /// Ghidra's P-Code, since no other lifter has existed. It is not a
+    /// deduction — a file that simply omits the field reads the same way —
+    /// but anything written since carries it.
     #[serde(default)]
     pub ir: crate::lift::Ir,
 }
@@ -183,10 +185,11 @@ impl Metadata {
             let duration = items[5]
                 .parse::<u64>()
                 .map_err(|e| Error::Parse(format!("invalid duration: {}", e)))?;
+            // Ir::from_str already reports what was wrong and in this
+            // Error type, so wrapping it again would only prefix a second
+            // "Parse error:" onto the same sentence.
             let ir = match items.get(6) {
-                Some(text) => text
-                    .parse()
-                    .map_err(|e| Error::Parse(format!("invalid ir: {e}")))?,
+                Some(text) => text.parse()?,
                 None => crate::lift::Ir::default(),
             };
             Ok(Self {

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -217,12 +217,10 @@ trait BirthmarkComparator {
         b2: &'a Birthmark,
         aggregator: &Aggregator,
     ) -> Result<Comparison<'a, Birthmark>> {
-        if !b1.comparable_with(b2) {
-            return Err(Error::Mismatch(
-                b1.metadata.birthmark_type.clone(),
-                b2.metadata.birthmark_type.clone(),
-            ));
-        }
+        // Asking the birthmark rather than re-deriving the conditions here
+        // keeps the reason in the error: a mismatch of representation reads
+        // differently from a mismatch of type.
+        b1.check_comparable_with(b2)?;
         let p1_len = b1.elements.len();
         let p2_len = b2.elements.len();
         let size = std::cmp::max(p1_len, p2_len);
@@ -1177,6 +1175,7 @@ mod tests {
                 extracted_at: chrono::Utc::now(),
                 duration: std::time::Duration::from_nanos(1),
                 birthmark_type: BirthmarkType::OpSeq,
+                ir: crate::lift::Ir::GhidraPcode,
             },
             elements: funcs.iter().map(|(n, ops)| elements(n, seq(ops))).collect(),
             json_path: None,

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -140,6 +140,7 @@ fn build_metadata<T>(
         extracted_at,
         duration,
         birthmark_type: bt,
+        ir: p.ir(),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub enum Error {
     Csv(csv::Error),
     /// A birthmark shape paired with an algorithm that does not operate on it.
     IncompatibleAnalysis(BirthmarkType, crate::prelude::Algorithm),
+    /// Two birthmarks lifted to different intermediate representations.
+    IrMismatch(crate::lift::Ir, crate::lift::Ir),
     InvalidPcode(u32),
     Io(PathBuf, std::io::Error),
     Json(PathBuf, serde_json::Error),
@@ -56,6 +58,10 @@ impl std::fmt::Display for Error {
                     bt.with_shape(algorithm.shape())
                 )
             }
+            Error::IrMismatch(a, b) => write!(
+                f,
+                "cannot compare {a} against {b}: the two are lifted to different intermediate representations, whose operation vocabularies do not correspond"
+            ),
             Error::InvalidPcode(code) => write!(f, "invalid pcode: {code}"),
             Error::Io(path, e) => write!(f, "IO error for {}: {}", path.display(), e),
             Error::Json(file, e) => write!(f, "{}: JSON error: {}", file.display(), e),

--- a/src/lift.rs
+++ b/src/lift.rs
@@ -25,8 +25,11 @@ pub enum LifterType {
 /// at: whether two birthmarks can be compared, and which `Op` type can read
 /// the file.
 ///
-/// Only one variant exists because only one lifter does. Each new lifter adds
-/// its own, and one that offers a choice of level adds one per level.
+/// Variants are declared ahead of the lifters that produce them, the way
+/// [`LifterType`] already declares backends that are not implemented yet.
+/// Binary Ninja is absent on purpose: it lifts to LLIL, MLIL or HLIL, and
+/// which of those is worth using has to be settled by measurement rather than
+/// named in advance.
 #[derive(Debug, ValueEnum, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 #[clap(rename_all = "kebab-case")]
@@ -35,12 +38,31 @@ pub enum Ir {
     /// yields, rather than raw lifted P-Code.
     #[default]
     GhidraPcode,
+    /// The Hex-Rays microcode, the representation IDA Pro's decompiler works
+    /// in. Unlike Binary Ninja's, there is only one of it, so it can be named
+    /// before the lifter that reads it exists.
+    IdaMicrocode,
 }
 
 impl std::fmt::Display for Ir {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Ir::GhidraPcode => write!(f, "ghidra-pcode"),
+            Ir::IdaMicrocode => write!(f, "ida-microcode"),
+        }
+    }
+}
+
+impl std::str::FromStr for Ir {
+    type Err = crate::Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "ghidra-pcode" => Ok(Ir::GhidraPcode),
+            "ida-microcode" => Ok(Ir::IdaMicrocode),
+            _ => Err(crate::Error::Parse(format!(
+                "{s}: unknown intermediate representation"
+            ))),
         }
     }
 }


### PR DESCRIPTION
Closes #43. Second of the five preparatory steps. **Stacked on #48** — review that first; this PR targets its branch, so the diff here is only the refusal.

## What it does

`Metadata` carries the representation the program was lifted to, taken from `Program` (#42), and a comparison across two of them is refused:

```
$ oinkie compare -a jaccard -A hungarian -s all -d sim ghidra.json ida.json
Error: cannot compare ghidra-pcode against ida-microcode: the two are lifted to
       different intermediate representations, whose operation vocabularies do
       not correspond
$ echo $?
2
```

No `results.csv` is written. Before, the same comparison exited **0** with a similarity of `0` — a number that reads as a finding.

## Three decisions worth reviewing

### The reason lives with the check

`check_comparable_with` returns *why*, and `comparable_with` delegates to it. Re-deriving the conditions in `compare.rs` would have worked, but every refusal there came back as `Error::Mismatch` — so a representation mismatch would have been reported as a **type** mismatch. One source of truth, accurate errors, and the existing predicate keeps its shape.

### `fc-*` is refused too, for now

It is the family that could eventually cross this line: despite the name it holds **symbol names read from the binary**, not operations read from the IR, so two tools should recover much the same set.

It is refused anyway, because the spellings still differ between tools (`_printf` against `printf`) and nothing normalises them. Allowing it would be asserting something no measurement supports — and there is no second lifter yet to measure with. The reasoning is recorded on the method, for whoever relaxes it once the normalisation exists.

### `Ir` gains `IdaMicrocode`

This one changes the framing in #48, which said a variant arrives with its lifter.

With a single variant, a mismatch is **unrepresentable** — serde rejects an unknown name, `FromStr` rejects it, so the guard could not be exercised at all. Shipping an untested correctness check, in a PR whose whole purpose is to stop silent wrong answers, is not a trade worth making.

Microcode is the variant that can be named honestly ahead of its lifter: there is exactly one of it, whereas Binary Ninja's level (LLIL, MLIL or HLIL) is an open question the design note says to settle by measurement. And `LifterType` already declares `Angr`, `IDAPro` and `BinaryNinja` with no implementation, so the precedent is the repository's own.

## On the CSV format

The `ir` column is **appended** to the `birthmark` record, not inserted. `cli/reaggregator.rs` and `read_result_file` both read the path at `record.get(3)`, so inserting would have shifted it silently. `Metadata::parse` accepts six columns or seven, so a record written by an earlier version still parses.

Checked by running `reaggregate` end to end after the change.

## Tests

- a representation mismatch is refused, and reported as `IrMismatch` rather than as a type mismatch
- a type mismatch is still reported as `Mismatch`, not swallowed by the new check
- matching pairs are still allowed
- a six-column metadata record parses and reads as Ghidra's
- an unknown representation in a record is rejected

Plus end to end: the refusal exits 2 and writes nothing, and `reaggregate` still works.

`cargo test` — 96 passed. `cargo fmt --all -- --check`, `cargo clippy -- -D warnings` and `cargo clippy --all-targets` all clean.