### PR TITLE
feat: let the lifter say which operation is a call

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -56,7 +56,9 @@ now stops with
 
 ```
 bin/sample: no operation is a call, so every fc-* birthmark of it would be
-empty -- and two empty birthmarks score as a perfect match
+empty -- and two empty birthmarks score as a perfect match. Either the program
+really calls nothing, or oinkie's reader for ghidra-pcode does not recognise
+that representation's call operations
 ```
 
 The `op-*` families are unaffected, and so is any program that makes at least

--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -48,6 +48,20 @@ Any conclusion drawn from an `fc-*` comparison on v0.3.0 or earlier should be
 treated as unreliable and the comparison re-run. Birthmark files extracted with
 `fc-*` are empty and carry no information; regenerate them.
 
+**Extracting an `fc-*` birthmark from a program that calls nothing is now an
+error** (#44). It used to succeed and write an empty birthmark, which is the
+shape of the bug above: empty birthmarks compare as a perfect match, so the
+output was worse than no output. `oinkie extract -b fc-set` on such a program
+now stops with
+
+```
+bin/sample: no operation is a call, so every fc-* birthmark of it would be
+empty -- and two empty birthmarks score as a perfect match
+```
+
+The `op-*` families are unaffected, and so is any program that makes at least
+one call — which, for a lifted binary, means every realistic input.
+
 ## Library API
 
 These affect code using oinkie as a crate. The command-line interface is
@@ -108,6 +122,22 @@ program's symbol table keys it, so a call target can be resolved; returning
 target distinguishable from a lookup that found nothing. Ghidra's
 implementation parses the operand through the existing `Value` type.
 
+**`Op` gains a second required method, `is_call`.** Which operation is a call
+was decided in the extractor by comparing the mnemonic against the literal
+`"CALL"`, which is P-Code's spelling; the Hex-Rays microcode and Binary Ninja's
+LLIL name it differently and some name more than one operation, so any other
+lifter would have matched nothing (#44). The question now belongs to the
+operation, and so to the lifter that defines it.
+
+The method has no default on purpose. A `false` default would let a new lifter
+compile while recognising no call at all, which produces empty `fc-*`
+birthmarks rather than an error — and empty birthmarks score as a perfect
+match. Requiring it makes that a build failure. Ghidra answers for `CALL` and
+`CALLIND`, but not `CALLOTHER`, which indexes a table of user-defined
+operations rather than naming a function. Nothing changes in what Ghidra
+extracts today: `CALLIND` reaches its target through a register, so no symbol
+resolves for it.
+
 **New public items** for asking whether a pairing is valid before building one:
 `Shape`, `BirthmarkType::shape`, `BirthmarkType::with_shape`,
 `BirthmarkType::pairs_with` and `Algorithm::shape`.
@@ -123,5 +153,8 @@ implementation parses the operand through the existing `Value` type.
   `irs/irs`, and the directory is created rather than having to exist
 - **#38** — analysis names are parsed in one place, and a pairing that cannot
   mean what it says is rejected with the canonical form named
+- **#44** — which operation is a call is now the lifter's answer rather than a
+  literal `"CALL"` in the extractor, and a program in which nothing is a call is
+  refused instead of yielding an empty `fc-*` birthmark
 - The crate is now formatted with `cargo fmt`, and CI enforces it with
   `cargo fmt --all -- --check`

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -91,6 +91,17 @@ impl Extractor {
 
 fn extract_birthmark_op<T: crate::Op>(p: &Program<T>, bt: &BirthmarkType) -> Result<Birthmark> {
     let now = std::time::Instant::now();
+    // An fc-* birthmark of a program that calls nothing is empty, and two
+    // empty birthmarks score 1.0 against each other. Refusing here turns the
+    // most likely cause -- a lifter whose `is_call` recognises none of its own
+    // opcodes -- from a false positive into a message.
+    if matches!(
+        bt,
+        BirthmarkType::FcSeq | BirthmarkType::FcSet | BirthmarkType::FcFreq
+    ) && !p.iter().any(|f| f.iter().any(|op| op.is_call()))
+    {
+        return Err(Error::NoCallOperations(p.path().to_path_buf(), p.ir()));
+    }
     let elements = p
         .iter()
         .map(|f| {
@@ -169,7 +180,7 @@ where
 
 fn extract_function_calls<T: crate::Op>(f: &Function<T>, p: &Program<T>) -> Vec<String> {
     f.iter()
-        .filter(|op| op.mnemonic() == "CALL")
+        .filter(|op| op.is_call())
         .filter_map(|op| op.symbol_key())
         .filter_map(|key| p.symbol(&key))
         .map(|s| s.to_string())
@@ -297,6 +308,64 @@ mod tests {
                 "{fixture}: every fc-set element is empty"
             );
         }
+    }
+
+    /// The danger in an fc-* birthmark is not that it is empty but that two
+    /// empty ones score as a perfect match, which in a theft-detection tool
+    /// reads as a positive. A program in which nothing at all is a call is
+    /// far more likely to mean the lifter does not recognise its own call
+    /// opcode than to mean the program makes no calls, so refuse rather than
+    /// hand back something that can only mislead.
+    #[test]
+    fn test_fc_extraction_refuses_a_program_without_calls() {
+        let json = r#"{
+            "program": "callless",
+            "path": "bin/callless",
+            "ir": "ghidra-pcode",
+            "symbols": {"0x100000480": "_printf"},
+            "functions": [
+                {"name": "leaf", "ops": [
+                    {"op": "COPY", "out": "(register, 0x4000, 8)", "inputs": ["(const, 0x0, 8)"]},
+                    {"op": "RETURN", "inputs": ["(const, 0x0, 8)"]}
+                ]}
+            ]
+        }"#;
+        let program: Program<crate::ghidra::Op> = serde_json::from_str(json).unwrap();
+
+        for bt in [
+            BirthmarkType::FcSeq,
+            BirthmarkType::FcSet,
+            BirthmarkType::FcFreq,
+        ] {
+            let result = Extractor::new(bt.clone()).extract_each(&program);
+            assert!(
+                matches!(result, Err(Error::NoCallOperations(_, _))),
+                "{bt}: expected a refusal, got {:?}",
+                result.map(|b| b.elements.len())
+            );
+        }
+    }
+
+    /// The op-* families do not read calls at all, so the refusal above must
+    /// not spread to them.
+    #[test]
+    fn test_op_extraction_accepts_a_program_without_calls() {
+        let json = r#"{
+            "program": "callless",
+            "path": "bin/callless",
+            "symbols": {},
+            "functions": [
+                {"name": "leaf", "ops": [
+                    {"op": "RETURN", "inputs": ["(const, 0x0, 8)"]}
+                ]}
+            ]
+        }"#;
+        let program: Program<crate::ghidra::Op> = serde_json::from_str(json).unwrap();
+        assert!(
+            Extractor::new(BirthmarkType::OpSeq)
+                .extract_each(&program)
+                .is_ok()
+        );
     }
 
     #[test]

--- a/src/ghidra.rs
+++ b/src/ghidra.rs
@@ -59,6 +59,19 @@ impl crate::Op for Op {
         self.out.as_deref()
     }
 
+    fn is_call(&self) -> bool {
+        // CALLOTHER is not among these: it is Ghidra's escape hatch for
+        // instruction semantics its model does not cover, and its first
+        // operand indexes a table of user-defined operations rather than
+        // naming a function.
+        //
+        // CALLIND is, because it is a call. Its target lives in a register or
+        // a temporary, so `symbol_key` yields nothing for it and it
+        // contributes to no birthmark today; including it keeps the predicate
+        // an answer about P-Code rather than about what happens to resolve.
+        matches!(self.op, PcodeOp::Call | PcodeOp::Callind)
+    }
+
     fn symbol_key(&self) -> Option<String> {
         // Only a call into ram names an address the symbol table could carry;
         // a target held in a register or a temporary is resolved at run time
@@ -214,6 +227,39 @@ mod tests {
         assert_eq!(op2.mnemonic(), "COPY");
         assert_eq!(op2.inputs().len(), 1);
         assert_eq!(op2.ret(), Some("(unique, 0x10000009, 8)"));
+    }
+
+    fn op(kind: PcodeOp) -> super::Op {
+        super::Op {
+            op: kind,
+            out: None,
+            inputs: vec!["(ram, 0x100000480, 8)".to_string()],
+        }
+    }
+
+    /// Which opcode is a call is P-Code's own business, so the answer lives
+    /// with the P-Code operation rather than with the extractor that consumes
+    /// it. CALLOTHER is Ghidra's escape hatch for instruction semantics its
+    /// model does not cover — its first operand indexes a table of
+    /// user-defined operations, not a function — so it is not a call.
+    #[test]
+    fn test_is_call_recognises_the_call_opcodes() {
+        assert!(op(PcodeOp::Call).is_call(), "CALL is a call");
+        assert!(op(PcodeOp::Callind).is_call(), "CALLIND is a call");
+        for other in [
+            PcodeOp::Callother,
+            PcodeOp::Copy,
+            PcodeOp::Branch,
+            PcodeOp::Cbranch,
+            PcodeOp::Branchind,
+            PcodeOp::Return,
+        ] {
+            assert!(
+                !op(other).is_call(),
+                "{} is not a call",
+                op(other).mnemonic()
+            );
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ pub enum Error {
     IncompatibleAnalysis(BirthmarkType, crate::prelude::Algorithm),
     /// Two birthmarks lifted to different intermediate representations.
     IrMismatch(crate::lift::Ir, crate::lift::Ir),
+    /// An `fc-*` birthmark was asked of a program holding no call at all.
+    NoCallOperations(PathBuf, crate::lift::Ir),
     InvalidPcode(u32),
     Io(PathBuf, std::io::Error),
     Json(PathBuf, serde_json::Error),
@@ -63,6 +65,11 @@ impl std::fmt::Display for Error {
                 "cannot compare {a} against {b}: the two are lifted to different intermediate representations, whose operation vocabularies do not correspond"
             ),
             Error::InvalidPcode(code) => write!(f, "invalid pcode: {code}"),
+            Error::NoCallOperations(path, ir) => write!(
+                f,
+                "{}: no operation is a call, so every fc-* birthmark of it would be empty -- and two empty birthmarks score as a perfect match. Either the program really calls nothing, or the {ir} lifter does not recognise its own call opcode",
+                path.display()
+            ),
             Error::Io(path, e) => write!(f, "IO error for {}: {}", path.display(), e),
             Error::Json(file, e) => write!(f, "{}: JSON error: {}", file.display(), e),
             Error::LapJV(e) => write!(f, "LapJV error: {}", e),
@@ -109,6 +116,23 @@ pub trait Op {
 
     /// returns the inputs of the operation, e.g., the source registers or memory locations.
     fn inputs(&self) -> &[String];
+
+    /// returns whether this operation transfers control to another function,
+    /// which is what the `fc-*` birthmarks are built from.
+    ///
+    /// Each intermediate representation spells its call differently — P-Code
+    /// writes `CALL`, the Hex-Rays microcode `m_call`, Binary Ninja's LLIL
+    /// `LLIL_CALL` — and some name more than one. Deciding here rather than in
+    /// [`crate::extractor`] keeps that vocabulary with the lifter that owns
+    /// it.
+    ///
+    /// This method deliberately has no default. A `false` default would let a
+    /// new lifter compile while matching no operation at all, and an `fc-*`
+    /// birthmark that matched nothing is not merely useless: two empty
+    /// birthmarks score as a perfect match, so unrelated programs would be
+    /// reported as identical. Requiring the method makes that a build failure
+    /// instead of a wrong answer.
+    fn is_call(&self) -> bool;
 
     /// returns the output of the operation, e.g., the destination register or memory location.
     fn ret(&self) -> Option<&str>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ impl std::fmt::Display for Error {
             Error::InvalidPcode(code) => write!(f, "invalid pcode: {code}"),
             Error::NoCallOperations(path, ir) => write!(
                 f,
-                "{}: no operation is a call, so every fc-* birthmark of it would be empty -- and two empty birthmarks score as a perfect match. Either the program really calls nothing, or the {ir} lifter does not recognise its own call opcode",
+                "{}: no operation is a call, so every fc-* birthmark of it would be empty -- and two empty birthmarks score as a perfect match. Either the program really calls nothing, or oinkie's reader for {ir} does not recognise that representation's call operations",
                 path.display()
             ),
             Error::Io(path, e) => write!(f, "IO error for {}: {}", path.display(), e),


### PR DESCRIPTION
Closes #44. Third of the five preparatory steps in `designs/multi-lifter-support.md`.

Stacked on #49 (`issue/43_refuse_cross_ir`), so the base changes to `main` once that merges.

## The problem

`extract_function_calls` decided what a call was by comparing the mnemonic against a string literal:

```rust
.filter(|op| op.mnemonic() == "CALL")
```

`"CALL"` is P-Code's spelling. The Hex-Rays microcode and Binary Ninja's LLIL name the operation differently, and each names more than one of them, so under any lifter but Ghidra this filter matches nothing.

Matching nothing does not raise an error. It produces an empty `fc-*` birthmark — and two empty birthmarks score 1.0 against each other, so unrelated programs are reported as a perfect match. That is the same failure shape as #40, reached by a different route, in a tool whose purpose is detecting theft.

## The change

**`Op` gains `is_call`, with no default.** The question is about the intermediate representation, so it belongs to the operation and thus to the lifter that defines it, not to the extractor that is generic over them.

The absent default is the point. A `false` default would let a new lifter compile while recognising no call at all, which is exactly the silent-empty-birthmark outcome the issue asks to prevent. Requiring the method makes it a build failure instead.

**Ghidra answers for `CALL` and `CALLIND`, but not `CALLOTHER`.** `CALLOTHER` is Ghidra's escape hatch for instruction semantics its model does not cover; its first operand indexes a table of user-defined operations rather than naming a function.

`CALLIND` is included because it is a call — a judgment worth flagging, since the old literal excluded it. It changes nothing today: an indirect target lives in a register or a temporary, so `symbol_key` yields `None` for it and it reaches no birthmark. Both fixtures still extract exactly `_printf`, verified below. Say the word if you would rather the predicate stay narrowed to `CALL`.

**Extracting `fc-*` from a program in which nothing is a call is refused.** The compile-time requirement cannot catch a lifter that stubs `is_call` as `false`, and the issue is explicit that failing loudly matters more than where the predicate lives. A lifted binary that calls nothing is far less likely than a lifter that does not recognise its own call opcode, and the empty birthmark that used to come back could only mislead:

```
$ oinkie extract -b fc-set -d bm callless.json
Error: bin/callless: no operation is a call, so every fc-* birthmark of it would
be empty -- and two empty birthmarks score as a perfect match. Either the program
really calls nothing, or the ghidra-pcode lifter does not recognise its own call
opcode
```

`Error::NoCallOperations` carries the path and the representation, so the message can name which lifter to look at. The `op-*` families are untouched.

## Verification

Written test-first: `is_call` and `NoCallOperations` did not exist, and the three new tests failed to compile before the implementation landed.

No behavioural change for Ghidra, checked end to end rather than reasoned about:

```
$ oinkie extract -b fc-set -d bm testdata/hello_world/pcodes/*.json
hello_clang  [{'Set': ['_printf']}]
hello_gcc    [{'Set': ['_printf']}]
```

99 tests pass (was 96). `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.

## Not in scope

#45 (decoupling the `Op` type from Ghidra) and #46 (generalising lifter discovery) remain. Until #45, the CLI still deserialises every program as `ghidra::Op` regardless of what its `ir` field says, so `is_call` has only one implementation to dispatch to.
