### PR TITLE
feat: let the lifted file choose the type that reads it

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -138,6 +138,32 @@ operations rather than naming a function. Nothing changes in what Ghidra
 extracts today: `CALLIND` reaches its target through a register, so no symbol
 resolves for it.
 
+**`Op` loses `code`.** It returned the numeric opcode and had no callers: the
+birthmark is built from `mnemonic`, a string. Keeping it would have made every
+future lifter invent a numbering for a value nothing reads (#45).
+
+**Which operation type reads a lifted file is now decided by the file.**
+`Program<T>` was generic, but nothing chose `T` — every caller wrote
+`Program<ghidra::Op>`, so a file lifted by another tool would have been read
+against P-Code's vocabulary. `AnyProgram::load` reads the `ir` field first and
+picks the reader from it, and `Extractor::extract_any` and
+`Comparator::compare_any` take what it returns (#45).
+
+A representation with no reader is now refused by name:
+
+```
+foreign.json: no reader for ida-microcode; this build can read ghidra-pcode
+```
+
+Read as P-Code it would have failed anyway, since the opcode enum is closed —
+but on whichever foreign opcode it happened to meet first, reported as an
+unknown variant among seventy-five alternatives. That check is unchanged for
+files that really are Ghidra's; an unknown opcode is still an error.
+
+`Program::new` and the typed `Extractor::extract_each` and
+`Comparator::compare_programs` are unchanged, so code that knows its operation
+type keeps working.
+
 **New public items** for asking whether a pairing is valid before building one:
 `Shape`, `BirthmarkType::shape`, `BirthmarkType::with_shape`,
 `BirthmarkType::pairs_with` and `Algorithm::shape`.
@@ -156,5 +182,8 @@ resolves for it.
 - **#44** — which operation is a call is now the lifter's answer rather than a
   literal `"CALL"` in the extractor, and a program in which nothing is a call is
   refused instead of yielding an empty `fc-*` birthmark
+- **#45** — the lifted file decides which operation type reads it, so the
+  pipeline no longer assumes P-Code; a representation with no reader is refused
+  by name
 - The crate is now formatted with `cargo fmt`, and CI enforces it with
   `cargo fmt --all -- --check`

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -3,7 +3,6 @@ mod info;
 
 use clap::{Parser, ValueEnum};
 use indicatif::ProgressBar;
-use oinkie::ghidra::Op;
 use oinkie::prelude::*;
 use rayon::prelude::*;
 use std::io::Write;
@@ -20,6 +19,15 @@ where
     let d = s.elapsed().as_millis();
     log::info!("Loading {path:?} done in {d} msec");
     Ok(item)
+}
+
+/// Reads a lifted program, letting the file say which representation it holds
+/// rather than assuming Ghidra's.
+fn load_program(path: &Path) -> Result<AnyProgram> {
+    let s = Instant::now();
+    let program = AnyProgram::load(path)?;
+    log::info!("Loading {path:?} done in {} msec", s.elapsed().as_millis());
+    Ok(program)
 }
 
 fn perform_run(opts: cli::RunOpts) -> Result<Vec<Duration>> {
@@ -47,11 +55,11 @@ fn perform_run(opts: cli::RunOpts) -> Result<Vec<Duration>> {
                 read_result_file(&dest_file, i, path1, path2)
             } else {
                 pbar.set_message(format!("Loading program from {:?}", path1.display()));
-                let mut p1: Program<Op> = load(path1.to_path_buf())?;
+                let mut p1 = load_program(path1)?;
                 p1.set_json_path(path1.to_path_buf());
                 pbar.inc(1);
                 pbar.set_message(format!("Loading program from {:?}", path2.display()));
-                let mut p2: Program<Op> = load(path2.to_path_buf())?;
+                let mut p2 = load_program(path2)?;
                 p2.set_json_path(path2.to_path_buf());
                 pbar.inc(1);
                 pbar.set_message(format!(
@@ -59,7 +67,7 @@ fn perform_run(opts: cli::RunOpts) -> Result<Vec<Duration>> {
                     i + 1,
                     comparing_count
                 ));
-                let result = atype.comparator().compare_programs(&p1, &p2, aggregator)?;
+                let result = atype.comparator().compare_any(&p1, &p2, aggregator)?;
                 pbar.inc(1);
                 result.store(&dest_file)?;
                 Ok(CompareResult::new(
@@ -319,8 +327,8 @@ fn extract_impl(path: &Path, dest: &Path, extractor: &Extractor, skip: bool) -> 
         );
         return Ok(());
     }
-    let p: Program<Op> = path.try_into()?;
-    let birthmarks = extractor.extract_each(&p)?;
+    let p = load_program(path)?;
+    let birthmarks = extractor.extract_any(&p)?;
     let json =
         serde_json::to_string_pretty(&birthmarks).map_err(|e| Error::Json(dest_path.clone(), e))?;
     std::fs::write(&dest_path, json).map_err(|e| Error::Io(dest_path.clone(), e))?;

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -311,38 +311,35 @@ fn hungarian_algorithm(similarity_matrix: &Array2<f64>) -> Result<(Vec<f64>, Vec
     }
 }
 
+/// A finished comparison before it is attached to the two things compared.
+///
+/// The programs are held by reference in a [`Comparison`], so producing one
+/// fixes the type they are reported as. Returning the result on its own lets
+/// the same computation be reported against a `Program<T>` or against the
+/// [`AnyProgram`] a caller loaded without naming `T`.
+type Scored = (Array2<f64>, Vec<f64>, std::time::Duration);
+
 trait ProgramComparator<T: crate::Op> {
-    fn compare_programs<'a>(
+    fn score_programs(
         &self,
-        p1: &'a Program<T>,
-        p2: &'a Program<T>,
+        p1: &Program<T>,
+        p2: &Program<T>,
         aggregator: &Aggregator,
-    ) -> Result<Comparison<'a, Program<T>>> {
+    ) -> Result<Scored> {
         let p1_len = p1.len();
         let p2_len = p2.len();
         let size = std::cmp::max(p1_len, p2_len);
+        let zero = std::time::Duration::from_millis(0);
         if p1_len == 0 && p2_len == 0 {
-            Ok(Comparison::new(
-                p1,
-                p2,
-                Array2::<f64>::zeros((0, 0)),
-                vec![1.0],
-                std::time::Duration::from_millis(0),
-            ))
+            Ok((Array2::<f64>::zeros((0, 0)), vec![1.0], zero))
         } else if p1_len == 0 || p2_len == 0 {
-            Ok(Comparison::new(
-                p1,
-                p2,
-                Array2::<f64>::zeros((0, 0)),
-                vec![0.0],
-                std::time::Duration::from_millis(0),
-            ))
+            Ok((Array2::<f64>::zeros((0, 0)), vec![0.0], zero))
         } else {
             let start = Instant::now();
             let r = build_matrix(p1, p2, size, |f1, f2| self.compare_func(f1, f2))?;
             aggregator
                 .aggregate(&r)
-                .map(|sim| Comparison::new(p1, p2, r, sim, start.elapsed()))
+                .map(|sim| (r, sim, start.elapsed()))
         }
     }
 
@@ -469,22 +466,58 @@ impl From<&Algorithm> for Comparator {
 }
 
 impl Comparator {
+    fn score_programs<T: crate::Op>(
+        &self,
+        p1: &Program<T>,
+        p2: &Program<T>,
+        aggregator: &Aggregator,
+    ) -> Result<Scored> {
+        match &self.inner {
+            ComparatorImpl::Cosine(c) => c.score_programs(p1, p2, aggregator),
+            ComparatorImpl::Dice(d) => d.score_programs(p1, p2, aggregator),
+            ComparatorImpl::Euclidean(e) => e.score_programs(p1, p2, aggregator),
+            ComparatorImpl::Jaccard(j) => j.score_programs(p1, p2, aggregator),
+            ComparatorImpl::Levenshtein(l) => l.score_programs(p1, p2, aggregator),
+            ComparatorImpl::Lcs(lcs) => lcs.score_programs(p1, p2, aggregator),
+            ComparatorImpl::Simpson(s) => s.score_programs(p1, p2, aggregator),
+            ComparatorImpl::WeightedJaccard(wj) => wj.score_programs(p1, p2, aggregator),
+        }
+    }
+
     pub fn compare_programs<'a, T: crate::Op>(
         &self,
         p1: &'a Program<T>,
         p2: &'a Program<T>,
         aggregator: &Aggregator,
     ) -> Result<Comparison<'a, Program<T>>> {
-        match &self.inner {
-            ComparatorImpl::Cosine(c) => c.compare_programs(p1, p2, aggregator),
-            ComparatorImpl::Dice(d) => d.compare_programs(p1, p2, aggregator),
-            ComparatorImpl::Euclidean(e) => e.compare_programs(p1, p2, aggregator),
-            ComparatorImpl::Jaccard(j) => j.compare_programs(p1, p2, aggregator),
-            ComparatorImpl::Levenshtein(l) => l.compare_programs(p1, p2, aggregator),
-            ComparatorImpl::Lcs(lcs) => lcs.compare_programs(p1, p2, aggregator),
-            ComparatorImpl::Simpson(s) => s.compare_programs(p1, p2, aggregator),
-            ComparatorImpl::WeightedJaccard(wj) => wj.compare_programs(p1, p2, aggregator),
+        let (matrix, similarities, duration) = self.score_programs(p1, p2, aggregator)?;
+        Ok(Comparison::new(p1, p2, matrix, similarities, duration))
+    }
+
+    /// Compares two programs read without naming their operation type.
+    ///
+    /// Two representations describe the same instruction with different
+    /// operations, so a comparison across them would measure the disagreement
+    /// between the lifters rather than anything about the programs. That is
+    /// refused here for the same reason it is refused for birthmarks in
+    /// [`Self::compare_birthmarks`]. Only one representation can be read
+    /// today, so nothing reachable is refused yet; the check is what keeps
+    /// that true when a second one arrives.
+    pub fn compare_any<'a>(
+        &self,
+        p1: &'a AnyProgram,
+        p2: &'a AnyProgram,
+        aggregator: &Aggregator,
+    ) -> Result<Comparison<'a, AnyProgram>> {
+        if p1.ir() != p2.ir() {
+            return Err(Error::IrMismatch(p1.ir(), p2.ir()));
         }
+        let (matrix, similarities, duration) = match (p1, p2) {
+            (AnyProgram::GhidraPcode(a), AnyProgram::GhidraPcode(b)) => {
+                self.score_programs(a, b, aggregator)?
+            }
+        };
+        Ok(Comparison::new(p1, p2, matrix, similarities, duration))
     }
 
     pub fn compare_birthmarks<'a>(
@@ -962,6 +995,36 @@ mod tests {
     use super::*;
     use crate::birthmarks::Metadata;
     use std::path::PathBuf;
+
+    /// Dispatching on the file's representation must change nothing about the
+    /// answer -- only about who chose the operation type.
+    #[test]
+    fn test_compare_any_agrees_with_the_typed_comparison() {
+        let paths = [
+            "testdata/hello_world/pcodes/hello_clang.json",
+            "testdata/hello_world/pcodes/hello_gcc.json",
+        ];
+        let typed: Vec<Program<crate::ghidra::Op>> = paths
+            .iter()
+            .map(|p| Path::new(p).try_into().unwrap())
+            .collect();
+        let any: Vec<AnyProgram> = paths
+            .iter()
+            .map(|p| AnyProgram::load(Path::new(p)).unwrap())
+            .collect();
+
+        let comparator = Algorithm::Jaccard.comparator();
+        let aggregator = &Aggregator::Hungarian;
+        let expected = comparator
+            .compare_programs(&typed[0], &typed[1], aggregator)
+            .unwrap()
+            .similarity();
+        let actual = comparator
+            .compare_any(&any[0], &any[1], aggregator)
+            .unwrap()
+            .similarity();
+        assert_eq!(actual, expected);
+    }
 
     #[test]
     fn compare_count_does_not_panic_on_empty_targets() {

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -87,6 +87,16 @@ impl Extractor {
     pub fn extract_each<T: crate::Op>(&self, p: &Program<T>) -> Result<Birthmark> {
         extract_birthmark_op(p, &self.bt)
     }
+
+    /// Extracts from a program read without naming its operation type.
+    ///
+    /// The birthmark is the same either way; this only spares the caller from
+    /// deciding which lifter produced the file, which the file already says.
+    pub fn extract_any(&self, p: &crate::program::AnyProgram) -> Result<Birthmark> {
+        match p {
+            crate::program::AnyProgram::GhidraPcode(p) => self.extract_each(p),
+        }
+    }
 }
 
 fn extract_birthmark_op<T: crate::Op>(p: &Program<T>, bt: &BirthmarkType) -> Result<Birthmark> {

--- a/src/ghidra.rs
+++ b/src/ghidra.rs
@@ -1,39 +1,11 @@
-use std::{
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use std::str::FromStr;
 
 use crate::ghidra::pcode::PcodeOp;
-use crate::program::Program;
 use crate::{Error, Result};
-use serde::{Deserialize, Serialize, Serializer, de::DeserializeOwned};
+use serde::{Deserialize, Serialize, Serializer};
 
 pub(crate) mod lifter;
 pub mod pcode;
-
-impl<T> TryFrom<PathBuf> for Program<T>
-where
-    T: DeserializeOwned + crate::Op,
-{
-    type Error = Error;
-
-    fn try_from(path: PathBuf) -> Result<Self> {
-        std::fs::File::open(&path)
-            .map_err(|e| Error::Io(path.clone(), e))
-            .and_then(|f| serde_json::from_reader(f).map_err(|e| Error::Json(path, e)))
-    }
-}
-
-impl<T> TryFrom<&Path> for Program<T>
-where
-    T: DeserializeOwned + crate::Op,
-{
-    type Error = Error;
-
-    fn try_from(path: &Path) -> Result<Self> {
-        Self::try_from(path.to_path_buf())
-    }
-}
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Op {
@@ -45,10 +17,6 @@ pub struct Op {
 impl crate::Op for Op {
     fn mnemonic(&self) -> &str {
         self.op.mnemonic()
-    }
-
-    fn code(&self) -> u32 {
-        self.op as u32
     }
 
     fn inputs(&self) -> &[String] {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub enum Error {
     IrMismatch(crate::lift::Ir, crate::lift::Ir),
     /// An `fc-*` birthmark was asked of a program holding no call at all.
     NoCallOperations(PathBuf, crate::lift::Ir),
+    /// A lifted file naming a representation this build cannot read.
+    UnsupportedIr(PathBuf, crate::lift::Ir),
     InvalidPcode(u32),
     Io(PathBuf, std::io::Error),
     Json(PathBuf, serde_json::Error),
@@ -77,6 +79,16 @@ impl std::fmt::Display for Error {
             Error::ParseFloat(s, e) => write!(f, "{s}: Parse float error {e}"),
             Error::Parse(s) => write!(f, "Parse error: {}", s),
             Error::ParseInt(s, e) => write!(f, "{s}: Parse int error {e}"),
+            Error::UnsupportedIr(path, ir) => write!(
+                f,
+                "{}: no reader for {ir}; this build can read {}",
+                path.display(),
+                crate::lift::Ir::readable()
+                    .iter()
+                    .map(|ir| ir.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
             Error::Clap(e) => write!(f, "Clap error: {}", e),
             Error::ShapeError(e) => write!(f, "Shape error: {}", e),
         }
@@ -110,9 +122,6 @@ impl Error {
 pub trait Op {
     /// returns the mnemonic of the operation, e.g., "ADD", "SUB", etc.
     fn mnemonic(&self) -> &str;
-
-    /// returns the unique code of the operation, e.g., the pcode opcode.
-    fn code(&self) -> u32;
 
     /// returns the inputs of the operation, e.g., the source registers or memory locations.
     fn inputs(&self) -> &[String];

--- a/src/lift.rs
+++ b/src/lift.rs
@@ -44,6 +44,17 @@ pub enum Ir {
     IdaMicrocode,
 }
 
+impl Ir {
+    /// The representations this build can actually read a lifted file in.
+    ///
+    /// [`Ir`] names representations ahead of the code that reads them, so the
+    /// two lists are not the same and the difference is what
+    /// [`crate::Error::UnsupportedIr`] reports.
+    pub fn readable() -> &'static [Ir] {
+        &[Ir::GhidraPcode]
+    }
+}
+
 impl std::fmt::Display for Ir {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -4,8 +4,9 @@ pub use crate::compare::{
     Aggregator, Algorithm, Comparator, Comparison, PairingStrategy, escape_csv_string,
 };
 pub use crate::extractor::Extractor;
+pub use crate::lift::Ir;
 pub use crate::lift::{Lifter, LifterBuilder, LifterType};
-pub use crate::program::{Function, Program};
+pub use crate::program::{AnyProgram, Function, Program};
 pub use crate::{Error, Iterable, Op, Result};
 
 pub trait CsvInfo {

--- a/src/program.rs
+++ b/src/program.rs
@@ -1,9 +1,10 @@
 use std::path::{Path, PathBuf};
 
 use rustc_hash::FxHashMap;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
-use crate::Iterable;
+use crate::lift::Ir;
+use crate::{Error, Iterable, Result};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Program<T> {
@@ -28,6 +29,132 @@ pub struct Program<T> {
     functions: Vec<Function<T>>,
     #[serde(skip)]
     pub json_path: Option<PathBuf>,
+}
+
+impl<T> TryFrom<PathBuf> for Program<T>
+where
+    T: DeserializeOwned + crate::Op,
+{
+    type Error = Error;
+
+    fn try_from(path: PathBuf) -> Result<Self> {
+        std::fs::File::open(&path)
+            .map_err(|e| Error::Io(path.clone(), e))
+            .and_then(|f| serde_json::from_reader(f).map_err(|e| Error::Json(path, e)))
+    }
+}
+
+impl<T> TryFrom<&Path> for Program<T>
+where
+    T: DeserializeOwned + crate::Op,
+{
+    type Error = Error;
+
+    fn try_from(path: &Path) -> Result<Self> {
+        Self::try_from(path.to_path_buf())
+    }
+}
+
+/// A lifted program whose operation type was chosen by the file rather than by
+/// the caller.
+///
+/// [`Program`] is generic over its operation type, but nothing was deciding
+/// that type: every caller wrote `Program<ghidra::Op>` and a file lifted by
+/// anything else would have been read against P-Code's vocabulary. The
+/// decision belongs to the `ir` field the file carries, and this is where it
+/// is made.
+///
+/// One variant is not an oversight. Ghidra is the only lifter implemented, so
+/// it is the only representation with an operation type to read into; naming
+/// the others here would mean inventing types for opcodes nobody has seen yet.
+/// Adding a lifter adds a variant, and the compiler then points at every place
+/// that has to account for it — which is the property the enum exists for.
+pub enum AnyProgram {
+    GhidraPcode(Program<crate::ghidra::Op>),
+}
+
+/// Just enough of a lifted file to learn which representation it is in.
+///
+/// Deserializing this skips the operations rather than building them, so
+/// reading the representation costs a scan of the text and no allocation.
+#[derive(Deserialize)]
+struct IrProbe {
+    #[serde(default)]
+    ir: Ir,
+}
+
+impl AnyProgram {
+    /// Reads a lifted program, choosing the operation type from the file's own
+    /// `ir` field.
+    ///
+    /// A representation with no reader is refused by name. Read as P-Code it
+    /// would fail anyway, since the opcode enum is closed — but on the first
+    /// foreign opcode it happened to meet, reported as an unknown variant
+    /// among seventy-five alternatives rather than as the one fact that
+    /// matters.
+    pub fn load(path: &Path) -> Result<Self> {
+        // Read once and deserialize twice from the same bytes: the probe has
+        // to see the file before the reader can be chosen, and reading it
+        // again would cost more than the scan does.
+        let bytes = std::fs::read(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
+        let json_err = |e| Error::Json(path.to_path_buf(), e);
+        let probe: IrProbe = serde_json::from_slice(&bytes).map_err(json_err)?;
+        match probe.ir {
+            Ir::GhidraPcode => serde_json::from_slice(&bytes)
+                .map(Self::GhidraPcode)
+                .map_err(json_err),
+            ir => Err(Error::UnsupportedIr(path.to_path_buf(), ir)),
+        }
+    }
+
+    /// The representation this program's operations are written in.
+    pub fn ir(&self) -> Ir {
+        match self {
+            Self::GhidraPcode(p) => p.ir(),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            Self::GhidraPcode(p) => p.name(),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::GhidraPcode(p) => p.path(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::GhidraPcode(p) => p.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn set_json_path(&mut self, path: PathBuf) {
+        match self {
+            Self::GhidraPcode(p) => p.set_json_path(path),
+        }
+    }
+}
+
+impl crate::prelude::CsvInfo for AnyProgram {
+    fn csv_info(&self) -> String {
+        match self {
+            Self::GhidraPcode(p) => p.csv_info(),
+        }
+    }
+
+    fn names(&self) -> Vec<String> {
+        match self {
+            Self::GhidraPcode(p) => p.names(),
+        }
+    }
 }
 
 impl<T> crate::prelude::CsvInfo for Program<T> {
@@ -204,6 +331,68 @@ mod tests {
         );
         let back: Program<crate::ghidra::Op> = serde_json::from_str(&json).unwrap();
         assert_eq!(back.ir(), Ir::GhidraPcode);
+    }
+
+    /// The point of the dispatch: the file decides, not the caller.
+    #[test]
+    fn test_any_program_reads_ghidra_pcode() {
+        let program = AnyProgram::load(Path::new("testdata/hello_world/pcodes/hello_clang.json"))
+            .expect("the fixture must load");
+        assert_eq!(program.ir(), Ir::GhidraPcode);
+        assert_eq!(program.name(), "hello_clang");
+        assert_eq!(program.len(), 1);
+    }
+
+    /// A file written before the `ir` field existed carries no representation
+    /// to dispatch on, and must still reach the reader it was written for.
+    #[test]
+    fn test_any_program_reads_a_file_without_the_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("legacy.json");
+        std::fs::write(
+            &path,
+            r#"{"program":"legacy","path":"bin/legacy","symbols":{},"functions":[]}"#,
+        )
+        .unwrap();
+        let program = AnyProgram::load(&path).expect("a file without the field must still load");
+        assert_eq!(program.ir(), Ir::GhidraPcode);
+    }
+
+    /// Read as P-Code, a foreign file fails on whichever of its opcodes came
+    /// first, reported as an unknown variant among seventy-five alternatives.
+    /// Naming the representation instead says the one thing the user can act
+    /// on.
+    #[test]
+    fn test_any_program_refuses_a_representation_it_cannot_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("foreign.json");
+        std::fs::write(
+            &path,
+            r#"{"program":"foreign","path":"bin/foreign","ir":"ida-microcode",
+                "symbols":{},"functions":[{"name":"main","ops":[
+                  {"op":"m_call","inputs":["r0"]}]}]}"#,
+        )
+        .unwrap();
+        match AnyProgram::load(&path) {
+            Err(Error::UnsupportedIr(_, ir)) => assert_eq!(ir, Ir::IdaMicrocode),
+            other => panic!("expected UnsupportedIr, got {other:?}", other = other.err()),
+        }
+    }
+
+    /// The closed opcode enum is the one Ghidra assumption that fails loudly,
+    /// and dispatching on the representation must not have loosened it.
+    #[test]
+    fn test_an_unknown_opcode_is_still_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bogus.json");
+        std::fs::write(
+            &path,
+            r#"{"program":"bogus","path":"bin/bogus","ir":"ghidra-pcode",
+                "symbols":{},"functions":[{"name":"main","ops":[
+                  {"op":"LLIL_SET_REG","inputs":["(register, 0x0, 8)"]}]}]}"#,
+        )
+        .unwrap();
+        assert!(matches!(AnyProgram::load(&path), Err(Error::Json(_, _))));
     }
 
     /// The fixtures are real lifter output, so they must carry what the


### PR DESCRIPTION
Closes #45. Fourth of the five preparatory steps in `designs/multi-lifter-support.md`.

Stacked on #50 (`issue/44_per_lifter_call`), which is stacked on #49. The base walks back to `main` as those merge.

## The problem

`Program<T>` was already generic, but nothing was deciding `T`. `cli/main.rs` opened with `use oinkie::ghidra::Op;` and named it at three sites, so a file lifted by any other tool would have been read against P-Code's vocabulary.

## The choice

**Option B** of the three in the issue: per-lifter `Op` types, dispatched on the `ir` field from #42.

`AnyProgram::load` reads that field first and picks the reader from it. `Extractor::extract_any` and `Comparator::compare_any` take what it returns, and the CLI no longer names an operation type at all.

**One enum variant is not an oversight.** Ghidra is the only lifter implemented, so it is the only representation with an operation type to read into; naming the others would mean inventing types for opcodes nobody has seen. Adding a lifter adds a variant, and the compiler then points at everything that has to account for it — which is the property the enum exists for.

Option A (a `String` mnemonic) would have removed both bindings in fewer lines but given up the closed opcode enum, which the issue calls the one Ghidra assumption that fails loudly. Option C (a common vocabulary) is a research question, not an implementation detail.

## An unreadable representation is refused by name

```
$ oinkie extract -b op-seq -d out foreign.json
Error: foreign.json: no reader for ida-microcode; this build can read ghidra-pcode
```

Read as P-Code it would have failed anyway — but on whichever foreign opcode it happened to meet first, reported as an unknown variant among seventy-five alternatives. `Ir::readable()` is what the message lists, so it stays honest as lifters are added.

**The closed enum is untouched for files that really are Ghidra's:**

```
$ oinkie extract -b op-seq -d out bogus.json   # ir: ghidra-pcode, op: LLIL_SET_REG
Error: bogus.json: JSON error: unknown variant `LLIL_SET_REG`, expected one of
`UNIMPLEMENTED`, `COPY`, `LOAD`, ... `PCODE_MAX` at line 2 column 56
```

## Also here

**`Op` loses `code`.** It returned the numeric opcode and had no callers — the birthmark is built from `mnemonic`, a string. Keeping it would have made every future lifter invent a numbering for a value nothing reads. The issue flags this; removing it is what decoupling the trait means in practice.

**`ProgramComparator::compare_programs` now returns the score without the programs.** A `Comparison` borrows the two programs and so fixes the type they are reported as, which is why the same computation could not be handed back against `AnyProgram`. The public `compare_programs` wraps the score unchanged; `compare_any` wraps the identical score against `AnyProgram`.

**`compare_any` refuses a cross-representation pair**, for the reason #43 refuses one for birthmarks. Nothing reachable is refused today; the check is what keeps that true when a second lifter arrives.

The typed `Program::new`, `Extractor::extract_each` and `Comparator::compare_programs` are unchanged, so library code that knows its operation type keeps working.

## Verification

Output is byte-identical to a build of the parent commit across six analyses — `op-seq-levenshtein`, `op-set-jaccard`, `fc-set-jaccard`, `op3gram-freq-cosine`, `op-freq-euclidean`, `fc-seq-lcs` — comparing similarity values and every CSV row but the timings. A unit test also asserts `compare_any` and `compare_programs` return the same score.

104 tests pass (was 99). `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.

## One thing found on the way

Measuring the cost of the `ir` probe turned up something much larger, filed as #51 and **not fixed here**: both JSON loaders hand `serde_json::from_reader` a bare `File`, which reads a byte per syscall. On a 10 MB lifted file, release build:

| | |
| --- | --- |
| `from_reader(File)` — current | **2.97 s** |
| `from_reader(BufReader)` | 26 ms |
| `fs::read` + `from_slice` | 13 ms |

`AnyProgram::load` reads once into bytes and deserializes twice from them, because it has to see the `ir` field before choosing a reader — so this PR incidentally makes program loading ~150x faster, and the probe itself costs about half of the now-fast parse rather than anything measurable against the old one. **`Birthmark::try_from` — the whole of the `compare` subcommand — is still slow**, which is what #51 is for.

## Not in scope

#46 (generalising lifter discovery and invocation) is the last of the five.
