### PR TITLE
refactor: write the headless lifter shape once, not once per tool

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -164,9 +164,29 @@ files that really are Ghidra's; an unknown opcode is still an error.
 `Comparator::compare_programs` are unchanged, so code that knows its operation
 type keeps working.
 
+**`lift::find_ghidra_home` is gone; use `LifterType::find_home`.** Discovery was
+a Ghidra function re-exported as if it were the general one. It is now a method
+on the backend, so each names its own environment variable and its own default
+locations, and the error says which variable to set rather than naming
+`GHIDRA_HOME` for whatever tool was asked for (#46). `LifterType` also gains
+`name` and `home_spec`; `home_spec` is `None` for angr, which is imported as a
+Python library and has no installation directory to point at.
+
 **New public items** for asking whether a pairing is valid before building one:
 `Shape`, `BirthmarkType::shape`, `BirthmarkType::with_shape`,
 `BirthmarkType::pairs_with` and `Algorithm::shape`.
+
+**`oinkie lift --intermediate` is the lifter's working directory.** It was
+described as somewhere to keep "Ghidra project directories". Every headless
+lifter needs a directory to run in, because that is where its script writes its
+JSON; Ghidra additionally keeps its project there. The option, the flag and the
+behaviour are unchanged — only what it is documented to mean, which now holds
+for a lifter that is not Ghidra's.
+
+`--home` and `--script` keep one help string each. They mean the same thing for
+every backend — an installation directory, and a script in whatever language
+that backend runs — and the part that has to be per-lifter is the error, which
+now is.
 
 ## Highlights
 
@@ -185,5 +205,9 @@ type keeps working.
 - **#45** — the lifted file decides which operation type reads it, so the
   pipeline no longer assumes P-Code; a representation with no reader is refused
   by name
+- **#46** — home discovery is per-backend, and the path handling around a
+  headless lifter — resolving before the working directory changes, running in
+  its own directory, moving the result across file systems — is written once
+  instead of once per tool
 - The crate is now formatted with `cargo fmt`, and CI enforces it with
   `cargo fmt --all -- --check`

--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -208,6 +208,7 @@ now is.
 - **#46** — home discovery is per-backend, and the path handling around a
   headless lifter — resolving before the working directory changes, running in
   its own directory, moving the result across file systems — is written once
-  instead of once per tool
+  instead of once per tool. A lift that produced nothing now reports what the
+  tool said, since Ghidra exits successfully even when its script throws
 - The crate is now formatted with `cargo fmt`, and CI enforces it with
   `cargo fmt --all -- --check`

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,6 +38,21 @@ jobs:
           cargo clippy -- -D warnings
           cargo build --release
 
+      # Ghidra compiles its SLEIGH language definitions from .slaspec to .sla
+      # on first use and caches them inside its own installation, which the
+      # runner unpacks fresh every time. The lift tests start three
+      # analyzeHeadless processes at once, and against a cold installation
+      # they race to write the same .sla; the loser reads a half-written file
+      # and dies with "ZipException: invalid block type" -- while
+      # analyzeHeadless still exits 0, so the failure surfaced only as a
+      # missing output file. One serial lift builds the cache before anything
+      # runs in parallel.
+      - name: Warm Ghidra's language cache
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          export GHIDRA_HOME=${{ env.GHIDRA_INSTALL_DIR }}
+          ./target/release/oinkie lift -d "$RUNNER_TEMP/warm" testdata/hello_world/bin/hello_clang
+
       - name: Convert coverage format to lcov
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/cli/cli.rs
+++ b/cli/cli.rs
@@ -46,7 +46,7 @@ pub enum OinkieCommand {
 
     #[command(
         name = "lift",
-        about = "Lift binary files to P-code JSON files using a specified lifter"
+        about = "Lift binary files to JSON files of an intermediate representation, using a specified lifter"
     )]
     Lift(LiftOpts),
 
@@ -82,7 +82,7 @@ pub struct LiftOpts {
         long,
         default_value = "pcodes",
         value_name = "DIRECTORY",
-        help = "Specify the directory for putting the resultant JSON files for the lifted P-code (default: './pcodes' directory)"
+        help = "Specify the directory for putting the resultant JSON files of the lifted programs (default: './pcodes' directory)"
     )]
     dest: PathBuf,
 
@@ -93,7 +93,7 @@ pub struct LiftOpts {
         short = 'H',
         long,
         value_name = "HOME",
-        help = "Specify the path to the home directory of the lifter (e.g., GHIDRA_HOME for Ghidra). If not specified, the environment variable (e.g., GHIDRA_HOME) or default paths are searched."
+        help = "Path to the lifter's installation directory. If not specified, the lifter's own environment variable (GHIDRA_HOME for Ghidra) is read, then the usual install locations are searched. The error names which variable to set."
     )]
     home: Option<PathBuf>,
 
@@ -101,14 +101,14 @@ pub struct LiftOpts {
         short = 'i',
         long = "intermediate",
         value_name = "DIRECTORY",
-        help = "Directory to keep intermediate files like Ghidra project directories. If not specified, a temporary directory is used and deleted."
+        help = "Directory for the lifter to work in, kept rather than discarded. Every lifter runs in one, since that is where its script writes; Ghidra also keeps its project there. If not specified, a temporary directory is used and deleted."
     )]
     intermediate_dir: Option<PathBuf>,
 
     #[clap(
         long,
         value_name = "SCRIPT",
-        help = "Path to a custom lifting script. Interpretation depends on the lifter type. For Ghidra, it's the path to a Java script."
+        help = "Path to a custom lifting script, replacing the built-in one. The language is the lifter's own: Java for Ghidra. It must write {input file name}.json into its working directory."
     )]
     script: Option<PathBuf>,
 

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -553,7 +553,7 @@ mod tests {
     #[test]
     fn test_find_ghidra_home_from_opt() {
         let opt = PathBuf::from("/custom/path");
-        let result = oinkie::lift::find_ghidra_home(Some(&opt)).unwrap();
+        let result = LifterType::Ghidra.find_home(Some(&opt)).unwrap();
         assert_eq!(result, opt);
     }
 
@@ -562,11 +562,31 @@ mod tests {
         unsafe {
             std::env::set_var("GHIDRA_HOME", "/env/path");
         }
-        let result = oinkie::lift::find_ghidra_home(None).unwrap();
+        let result = LifterType::Ghidra.find_home(None).unwrap();
         assert_eq!(result, PathBuf::from("/env/path"));
         unsafe {
             std::env::remove_var("GHIDRA_HOME");
         }
+    }
+
+    /// The three backends that are not implemented still have to say what to
+    /// set, since a message naming GHIDRA_HOME for Binary Ninja is worse than
+    /// no message at all.
+    #[test]
+    fn test_each_backend_names_its_own_environment_variable() {
+        for (lifter, env) in [
+            (LifterType::Ghidra, "GHIDRA_HOME"),
+            (LifterType::IDAPro, "IDA_HOME"),
+            (LifterType::BinaryNinja, "BINARY_NINJA_HOME"),
+        ] {
+            let spec = lifter.home_spec().expect("this backend has an install dir");
+            assert_eq!(spec.env, env, "{}", lifter.name());
+        }
+        // angr is imported rather than installed, so --home means nothing for
+        // it and the error says so instead of naming a variable.
+        assert!(LifterType::Angr.home_spec().is_none());
+        let err = LifterType::Angr.find_home(None).unwrap_err().to_string();
+        assert!(err.contains("angr"), "unhelpful message: {err}");
     }
 
     #[test]

--- a/src/ghidra/lifter.rs
+++ b/src/ghidra/lifter.rs
@@ -1,4 +1,5 @@
 use crate::lift::Lifter;
+use crate::lift::headless::Headless;
 use crate::{Error, Result};
 use std::path::{Path, PathBuf};
 
@@ -30,132 +31,42 @@ impl Lifter for GhidraLifter {
             )));
         }
 
-        let (script_path, _temp_dir) = if let Some(s) = &self.script {
-            let s = std::fs::canonicalize(s).map_err(|e| Error::Io(s.clone(), e))?;
-            (s, None)
-        } else {
-            let temp_dir = tempfile::Builder::new()
-                .prefix("oinkie_script")
-                .tempdir()
-                .map_err(|e| Error::Io(PathBuf::from("temp"), e))?;
-            let script_file = temp_dir.path().join("HighPCodeLifter.java");
-            std::fs::write(&script_file, DEFAULT_GHIDRA_SCRIPT)
-                .map_err(|e| Error::Io(script_file.clone(), e))?;
-            (script_file, Some(temp_dir))
-        };
-        let script_dir = script_path
-            .parent()
-            .ok_or_else(|| Error::Parse(format!("Invalid script path: {:?}", script_path)))?;
-        let script_name = script_path
-            .file_name()
-            .ok_or_else(|| Error::Parse(format!("Invalid script path: {:?}", script_path)))?;
-
-        let (proj_dir, _temp_proj_dir) = if let Some(i) = &self.intermediate_dir {
-            // Created because every other destination directory in the CLI is,
-            // and canonicalized because this path is passed to Ghidra as an
-            // argument while also being its working directory — left relative,
-            // Ghidra would resolve it a second time against itself.
-            std::fs::create_dir_all(i).map_err(|e| Error::Io(i.clone(), e))?;
-            let i = std::fs::canonicalize(i).map_err(|e| Error::Io(i.clone(), e))?;
-            (i, None)
-        } else {
-            let temp_proj = tempfile::Builder::new()
-                .prefix("oinkie_proj")
-                .tempdir()
-                .map_err(|e| Error::Io(PathBuf::from("temp"), e))?;
-            (temp_proj.path().to_path_buf(), Some(temp_proj))
-        };
-
-        let proj_name = input
-            .file_name()
-            .and_then(|n| n.to_str())
-            .ok_or_else(|| Error::Parse(format!("Invalid input path: {:?}", input)))?;
-        // the working directory of the Ghidra process is the project directory,
-        // so relative paths must be resolved beforehand
-        let input = std::fs::canonicalize(input).map_err(|e| Error::Io(input.to_path_buf(), e))?;
-
-        let mut command = std::process::Command::new(&analyze_headless);
-        command
-            .arg(&proj_dir)
-            .arg(proj_name)
-            .arg("-import")
-            .arg(&input)
-            .arg("-scriptPath")
-            .arg(script_dir)
-            .arg("-postScript")
-            .arg(script_name)
-            // The lifter script writes "{program name}.json" into the working
-            // directory of the Ghidra process. Run it inside the project
-            // directory so that concurrent lifts of same-named binaries do not
-            // race on a single path in the user's current directory.
-            .current_dir(&proj_dir);
-
-        log::info!("Executing Ghidra: {:?}", command);
-        let output_res = command
-            .output()
-            .map_err(|e| Error::Io(analyze_headless, e))?;
-        if !output_res.status.success() {
-            let stderr = String::from_utf8_lossy(&output_res.stderr);
-            let stdout = String::from_utf8_lossy(&output_res.stdout);
-            return Err(Error::Parse(format!(
-                "Ghidra failed with status {}.\nSTDOUT: {}\nSTDERR: {}",
-                output_res.status, stdout, stderr
-            )));
+        Headless {
+            tool: "Ghidra",
+            program: &analyze_headless,
+            script: self.script.as_deref(),
+            default_script: ("HighPCodeLifter.java", DEFAULT_GHIDRA_SCRIPT),
+            // Ghidra keeps its project here as well as working in it, which is
+            // why the option exists; the working directory itself is what
+            // every headless lifter needs.
+            work_dir: self.intermediate_dir.as_deref(),
         }
-
-        // Move the generated JSON to the destination
-        let generated_json = proj_dir.join(format!("{}.json", proj_name));
-        if generated_json.exists() {
-            // rename fails across file systems (e.g., temp dir on another
-            // volume); fall back to copy + remove in that case
-            if std::fs::rename(&generated_json, output).is_err() {
-                std::fs::copy(&generated_json, output)
-                    .map_err(|e| Error::Io(output.to_path_buf(), e))?;
-                let _ = std::fs::remove_file(&generated_json);
-            }
-        } else {
-            return Err(Error::Parse(format!(
-                "Expected Ghidra to generate {:?}, but it was not found.",
-                generated_json
-            )));
-        }
-
-        Ok(())
+        .lift(input, output, |i| {
+            vec![
+                i.work_dir.clone().into_os_string(),
+                i.name.clone().into(),
+                "-import".into(),
+                i.input.clone().into_os_string(),
+                "-scriptPath".into(),
+                i.script_dir.clone().into_os_string(),
+                "-postScript".into(),
+                i.script_name.clone(),
+            ]
+        })
     }
-}
-
-pub fn find_ghidra_home(home_opt: Option<&Path>) -> Result<PathBuf> {
-    if let Some(h) = home_opt {
-        return Ok(h.to_path_buf());
-    }
-    if let Ok(h) = std::env::var("GHIDRA_HOME") {
-        return Ok(PathBuf::from(h));
-    }
-
-    let candidates = [
-        "/opt/homebrew/opt/ghidra/libexec",
-        "/usr/local/opt/ghidra/libexec",
-        "/opt/ghidra/libexec",
-    ];
-    for c in candidates {
-        let p = PathBuf::from(c);
-        if p.exists() {
-            return Ok(p);
-        }
-    }
-    Err(Error::Parse("GHIDRA_HOME not found. Please specify it via --home option or GHIDRA_HOME environment variable.".to_string()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lift::LifterType;
     use std::env;
     use tempfile::tempdir;
 
     #[test]
     fn test_find_ghidra_home_with_opt() {
         let opt_path = PathBuf::from("/custom/ghidra/home");
-        let result = find_ghidra_home(Some(&opt_path));
+        let result = LifterType::Ghidra.find_home(Some(&opt_path));
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), opt_path);
     }
@@ -168,7 +79,7 @@ mod tests {
             env::set_var("GHIDRA_HOME", "/env/ghidra/home");
         }
 
-        let result = find_ghidra_home(None);
+        let result = LifterType::Ghidra.find_home(None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), PathBuf::from("/env/ghidra/home"));
 
@@ -192,7 +103,7 @@ mod tests {
             env::remove_var("GHIDRA_HOME");
         }
 
-        let result = find_ghidra_home(None);
+        let result = LifterType::Ghidra.find_home(None);
         // It might find it in standard paths on some systems, so we can't definitively assert error
         // unless we know the system doesn't have it. But we can check it doesn't crash.
         let _ = result;

--- a/src/lift.rs
+++ b/src/lift.rs
@@ -3,6 +3,8 @@ use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
+pub(crate) mod headless;
+
 pub trait Lifter {
     fn lift(&self, input: &Path, output: &Path) -> Result<()>;
 }
@@ -78,6 +80,105 @@ impl std::str::FromStr for Ir {
     }
 }
 
+/// How a backend's installation is found.
+///
+/// The three steps are the same for every tool -- what the user passed, then
+/// an environment variable, then the places it is usually installed -- and
+/// only the names differ, so the names are the data and the search is written
+/// once.
+pub struct HomeSpec {
+    /// The tool's name, for messages.
+    pub tool: &'static str,
+    /// The environment variable oinkie reads.
+    ///
+    /// This is oinkie's own convention rather than something the tools
+    /// define: Ghidra's own installer sets `GHIDRA_INSTALL_DIR`, not
+    /// `GHIDRA_HOME`. Naming the others the same way keeps the convention
+    /// guessable.
+    pub env: &'static str,
+    /// Where to look when the variable is unset.
+    ///
+    /// Empty for a backend nobody has installed and checked. A guessed path
+    /// that happens to exist is worse than asking, because it is found
+    /// silently and only fails later, somewhere less obvious.
+    pub candidates: &'static [&'static str],
+}
+
+impl LifterType {
+    /// The tool's name as it should appear in messages.
+    pub fn name(&self) -> &'static str {
+        match self {
+            LifterType::Ghidra => "Ghidra",
+            LifterType::Angr => "angr",
+            LifterType::IDAPro => "IDA Pro",
+            LifterType::BinaryNinja => "Binary Ninja",
+        }
+    }
+
+    /// Where this backend's installation is looked for, or `None` for one that
+    /// has no installation directory to find.
+    ///
+    /// angr is the `None`: it is a Python library, imported rather than
+    /// installed somewhere oinkie could point at. It is here as the reminder
+    /// that the shape does not fit every backend.
+    pub fn home_spec(&self) -> Option<HomeSpec> {
+        match self {
+            LifterType::Ghidra => Some(HomeSpec {
+                tool: self.name(),
+                env: "GHIDRA_HOME",
+                candidates: &[
+                    "/opt/homebrew/opt/ghidra/libexec",
+                    "/usr/local/opt/ghidra/libexec",
+                    "/opt/ghidra/libexec",
+                ],
+            }),
+            LifterType::Angr => None,
+            LifterType::IDAPro => Some(HomeSpec {
+                tool: self.name(),
+                env: "IDA_HOME",
+                candidates: &[],
+            }),
+            LifterType::BinaryNinja => Some(HomeSpec {
+                tool: self.name(),
+                env: "BINARY_NINJA_HOME",
+                candidates: &[],
+            }),
+        }
+    }
+
+    /// Finds this backend's installation: what the user passed, then the
+    /// environment variable, then the usual locations.
+    pub fn find_home(&self, home_opt: Option<&Path>) -> Result<PathBuf> {
+        if let Some(h) = home_opt {
+            return Ok(h.to_path_buf());
+        }
+        let Some(spec) = self.home_spec() else {
+            return Err(crate::Error::Parse(format!(
+                "{} has no installation directory to find, so --home means nothing for it",
+                self.name()
+            )));
+        };
+        if let Ok(h) = std::env::var(spec.env) {
+            return Ok(PathBuf::from(h));
+        }
+        for c in spec.candidates {
+            let p = PathBuf::from(c);
+            if p.exists() {
+                return Ok(p);
+            }
+        }
+        let looked_in = if spec.candidates.is_empty() {
+            String::new()
+        } else {
+            format!(", or install it in one of: {}", spec.candidates.join(", "))
+        };
+        Err(crate::Error::Parse(format!(
+            "{} not found. Specify it with --home, set {}{looked_in}",
+            spec.tool, spec.env
+        )))
+    }
+}
+
 pub struct LifterBuilder {
     lifter_type: LifterType,
     home: Option<PathBuf>,
@@ -113,7 +214,7 @@ impl LifterBuilder {
     pub fn build(self) -> Result<Box<dyn Lifter + Sync>> {
         match self.lifter_type {
             LifterType::Ghidra => {
-                let home = find_ghidra_home(self.home.as_deref())?;
+                let home = self.lifter_type.find_home(self.home.as_deref())?;
                 Ok(Box::new(crate::ghidra::lifter::GhidraLifter::new(
                     home,
                     self.script,
@@ -131,8 +232,4 @@ impl LifterBuilder {
             )),
         }
     }
-}
-
-pub fn find_ghidra_home(home_opt: Option<&Path>) -> Result<PathBuf> {
-    crate::ghidra::lifter::find_ghidra_home(home_opt)
 }

--- a/src/lift/headless.rs
+++ b/src/lift/headless.rs
@@ -86,15 +86,21 @@ impl Headless<'_> {
         let (work_dir, _work_tmp) = self.resolve_work_dir()?;
         let invocation = Self::resolve(input, work_dir, script)?;
 
-        let mut command = std::process::Command::new(self.program);
+        // The child changes directory before it execs, so a relative program
+        // path is resolved against the working directory rather than the
+        // caller's -- Rust documents the behaviour as platform-specific and
+        // unstable. A relative `--home` therefore passes the caller's own
+        // existence check and then fails to spawn.
+        let program = std::fs::canonicalize(self.program)
+            .map_err(|e| Error::Io(self.program.to_path_buf(), e))?;
+
+        let mut command = std::process::Command::new(&program);
         command
             .args(args(&invocation))
             .current_dir(&invocation.work_dir);
 
         log::info!("Executing {}: {:?}", self.tool, command);
-        let result = command
-            .output()
-            .map_err(|e| Error::Io(self.program.to_path_buf(), e))?;
+        let result = command.output().map_err(|e| Error::Io(program, e))?;
         if !result.status.success() {
             return Err(Error::Parse(format!(
                 "{} failed with status {}.\nSTDOUT: {}\nSTDERR: {}",
@@ -212,7 +218,17 @@ impl Headless<'_> {
         // another volume reaches every time; fall back to copy + remove.
         if std::fs::rename(&generated, output).is_err() {
             std::fs::copy(&generated, output).map_err(|e| Error::Io(output.to_path_buf(), e))?;
-            let _ = std::fs::remove_file(&generated);
+            // The result is already where the caller asked for it, so failing
+            // here would throw away a lift that succeeded over a file we could
+            // not tidy up -- and in a batch, take every other lift with it.
+            // Worth saying, not worth failing for.
+            if let Err(e) = std::fs::remove_file(&generated) {
+                log::warn!(
+                    "copied to {} but could not remove {}: {e}",
+                    output.display(),
+                    generated.display()
+                );
+            }
         }
         Ok(())
     }
@@ -427,6 +443,41 @@ mod tests {
         assert!(
             !work.join("sample.bin.json").exists(),
             "the result was copied rather than moved"
+        );
+    }
+
+    /// A relative program path is resolved against the *child's* working
+    /// directory, which is the tool's scratch directory rather than the
+    /// caller's. Rust documents that as platform-specific and unstable, and
+    /// the effect is that `--home ghidra_rel` passes the caller's own
+    /// existence check and then fails to spawn with "No such file or
+    /// directory" naming a path that does exist.
+    #[test]
+    fn test_a_relative_program_is_resolved_before_the_directory_changes() {
+        let dir = tempfile::Builder::new()
+            .prefix("oinkie_t")
+            .tempdir()
+            .unwrap();
+        let input = dir.path().join("sample.bin");
+        std::fs::write(&input, b"binary").unwrap();
+
+        // Under the crate root, so the path can be written relative to the
+        // current directory; target/ is ignored by git and always present.
+        let relative = PathBuf::from("target").join("oinkie_relative_program_test");
+        std::fs::copy("/bin/echo", &relative).expect("could not stage a relative program");
+
+        let mut h = headless(None, None);
+        h.program = &relative;
+        let err = h
+            .lift(&input, &dir.path().join("out.json"), |_| vec![])
+            .expect_err("echo writes no JSON, so this cannot succeed");
+        let _ = std::fs::remove_file(&relative);
+
+        // The tool ran: it failed for having produced nothing, not for being
+        // unfindable.
+        assert!(
+            matches!(&err, Error::Parse(m) if m.contains("STDOUT")),
+            "the program was not resolved before the directory changed: {err}"
         );
     }
 

--- a/src/lift/headless.rs
+++ b/src/lift/headless.rs
@@ -105,7 +105,7 @@ impl Headless<'_> {
             )));
         }
 
-        self.take_output(&invocation, output)
+        self.take_output(&invocation, output, &result)
     }
 
     /// Writes the built-in script to a temporary directory unless the user
@@ -183,14 +183,29 @@ impl Headless<'_> {
     }
 
     /// Moves the JSON the script wrote to where the caller asked for it.
-    fn take_output(&self, invocation: &Invocation, output: &Path) -> Result<()> {
+    ///
+    /// A tool can exit successfully and still have written nothing: Ghidra's
+    /// headless analyzer reports success even when the post-script throws. Its
+    /// own output is then the only account of what happened, so the error
+    /// carries it rather than reporting an absent file and discarding the
+    /// reason it is absent.
+    fn take_output(
+        &self,
+        invocation: &Invocation,
+        output: &Path,
+        result: &std::process::Output,
+    ) -> Result<()> {
         let generated = invocation
             .work_dir
             .join(format!("{}.json", invocation.name));
         if !generated.exists() {
             return Err(Error::Parse(format!(
-                "Expected {} to generate {:?}, but it was not found.",
-                self.tool, generated
+                "Expected {} to generate {:?}, but it was not found. {} exited successfully, so its own output is the only account of why:\nSTDOUT: {}\nSTDERR: {}",
+                self.tool,
+                generated,
+                self.tool,
+                tail(&String::from_utf8_lossy(&result.stdout)),
+                tail(&String::from_utf8_lossy(&result.stderr)),
             )));
         }
         // rename fails across file systems, which a temporary directory on
@@ -200,6 +215,22 @@ impl Headless<'_> {
             let _ = std::fs::remove_file(&generated);
         }
         Ok(())
+    }
+}
+
+/// The last few lines of a tool's output.
+///
+/// A headless decompiler writes hundreds of progress lines; the reason it
+/// stopped is at the end, and the rest would bury it.
+fn tail(text: &str) -> String {
+    const LINES: usize = 20;
+    let text = text.trim_end();
+    let mut kept: Vec<&str> = text.lines().rev().take(LINES).collect();
+    kept.reverse();
+    if text.lines().count() > LINES {
+        format!("(last {LINES} lines)\n{}", kept.join("\n"))
+    } else {
+        kept.join("\n")
     }
 }
 
@@ -312,11 +343,59 @@ mod tests {
 
         match headless(None, None).lift(&input, &dir.path().join("out.json"), |_| vec![]) {
             Err(Error::Parse(msg)) => assert!(
-                msg.contains("sample.bin.json") && msg.contains("test"),
+                msg.contains("sample.bin.json") && msg.contains("STDOUT"),
                 "unhelpful message: {msg}"
             ),
             other => panic!("expected a missing-output error, got {:?}", other.err()),
         }
+    }
+
+    /// A tool that exits successfully and writes nothing leaves its own output
+    /// as the only account of why, so the error has to carry it. Ghidra's
+    /// headless analyzer does exactly this when its post-script throws.
+    #[test]
+    fn test_a_missing_result_carries_what_the_tool_said() {
+        let dir = tempfile::Builder::new()
+            .prefix("oinkie_t")
+            .tempdir()
+            .unwrap();
+        let input = dir.path().join("sample.bin");
+        std::fs::write(&input, b"binary").unwrap();
+
+        // echo exits 0 and writes to stdout instead of to a file, which is the
+        // shape of the failure: success, no result, and a reason only it knows.
+        let mut h = headless(None, None);
+        h.program = Path::new("/bin/echo");
+        match h.lift(&input, &dir.path().join("out.json"), |_| {
+            vec!["the script threw".into()]
+        }) {
+            Err(Error::Parse(msg)) => assert!(
+                msg.contains("the script threw"),
+                "the tool's own output was dropped: {msg}"
+            ),
+            other => panic!("expected a missing-output error, got {:?}", other.err()),
+        }
+    }
+
+    #[test]
+    fn test_tail_keeps_the_end_and_says_so() {
+        let short = (1..=3)
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_eq!(tail(&short), "1\n2\n3");
+
+        let long = (1..=30)
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let tailed = tail(&long);
+        assert!(tailed.starts_with("(last 20 lines)"), "{tailed}");
+        assert!(tailed.ends_with("\n30"), "{tailed}");
+        assert!(
+            !tailed.contains("\n10\n"),
+            "kept more than the last 20: {tailed}"
+        );
     }
 
     /// The output is moved even when the working directory is on another file

--- a/src/lift/headless.rs
+++ b/src/lift/headless.rs
@@ -1,0 +1,365 @@
+//! The invocation shape every headless lifter has in common.
+//!
+//! Ghidra, Binary Ninja and IDA Pro are all driven the same way: run the
+//! tool's headless entry point with a script that writes JSON, then move the
+//! result where the caller asked for it. The command lines differ; the path
+//! handling around them does not, and it is the path handling that has been
+//! wrong twice already.
+//!
+//! Every bug fixed in this file was a real one:
+//!
+//! - a relative `--intermediate` was resolved twice, once by the caller and
+//!   again by Ghidra against its own working directory, which is that
+//!   directory nested inside itself
+//! - the script writes into the process's working directory, so two lifts of
+//!   same-named binaries running in parallel raced on one path in the user's
+//!   current directory
+//! - `rename` fails across file systems, which a temporary directory on
+//!   another volume reaches every time
+//!
+//! A second and third lifter writing this out again would be two more chances
+//! to reintroduce them, so a lifter supplies its command line and its script
+//! and nothing else.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use crate::{Error, Result};
+
+/// An external tool driven headless with a script that writes JSON.
+pub(crate) struct Headless<'a> {
+    /// The tool's name, for messages.
+    pub tool: &'static str,
+    /// The executable to run. The caller checks it exists, since only the
+    /// caller knows what to say when it does not.
+    pub program: &'a Path,
+    /// A script supplied by the user, in place of the built-in one.
+    pub script: Option<&'a Path>,
+    /// The built-in script: the file name to write it under, and its text.
+    pub default_script: (&'static str, &'static str),
+    /// Where the tool should work. A temporary directory is used and removed
+    /// when this is `None`.
+    ///
+    /// Every headless run needs a working directory, because that is where
+    /// the script writes; keeping it is a debugging convenience rather than a
+    /// Ghidra-specific need, even though Ghidra also uses it as its project
+    /// directory.
+    pub work_dir: Option<&'a Path>,
+}
+
+/// The paths a command line is built from, all resolved before the working
+/// directory changes.
+pub(crate) struct Invocation {
+    /// The binary to lift, absolute.
+    pub input: PathBuf,
+    /// The input's file name. The script writes `{name}.json`, and Ghidra
+    /// also takes it as the project name.
+    pub name: String,
+    /// The directory the tool runs in and writes into, absolute.
+    pub work_dir: PathBuf,
+    /// The directory holding the script, absolute.
+    pub script_dir: PathBuf,
+    /// The script's file name on its own, which is how Ghidra wants it named
+    /// once `-scriptPath` has been given.
+    ///
+    /// Split from the directory rather than kept whole because that is the
+    /// form Ghidra needs; a tool wanting the full path can rejoin them.
+    pub script_name: OsString,
+}
+
+impl Headless<'_> {
+    /// Runs the tool and moves the JSON it wrote to `output`.
+    ///
+    /// `args` receives paths that are already absolute, because the process
+    /// runs with the working directory set to `Invocation::work_dir` and a
+    /// relative path would be resolved against that instead of against the
+    /// caller's.
+    pub(crate) fn lift(
+        &self,
+        input: &Path,
+        output: &Path,
+        args: impl FnOnce(&Invocation) -> Vec<OsString>,
+    ) -> Result<()> {
+        // Both temporary directories are removed when dropped, so they are
+        // held until the command has finished with them.
+        let (script, _script_tmp) = self.resolve_script()?;
+        let (work_dir, _work_tmp) = self.resolve_work_dir()?;
+        let invocation = Self::resolve(input, work_dir, script)?;
+
+        let mut command = std::process::Command::new(self.program);
+        command
+            .args(args(&invocation))
+            .current_dir(&invocation.work_dir);
+
+        log::info!("Executing {}: {:?}", self.tool, command);
+        let result = command
+            .output()
+            .map_err(|e| Error::Io(self.program.to_path_buf(), e))?;
+        if !result.status.success() {
+            return Err(Error::Parse(format!(
+                "{} failed with status {}.\nSTDOUT: {}\nSTDERR: {}",
+                self.tool,
+                result.status,
+                String::from_utf8_lossy(&result.stdout),
+                String::from_utf8_lossy(&result.stderr),
+            )));
+        }
+
+        self.take_output(&invocation, output)
+    }
+
+    /// Writes the built-in script to a temporary directory unless the user
+    /// supplied one.
+    fn resolve_script(&self) -> Result<(PathBuf, Option<tempfile::TempDir>)> {
+        match self.script {
+            Some(s) => {
+                let s = std::fs::canonicalize(s).map_err(|e| Error::Io(s.to_path_buf(), e))?;
+                Ok((s, None))
+            }
+            None => {
+                let dir = Self::temp_dir("oinkie_script")?;
+                let (name, text) = self.default_script;
+                let path = dir.path().join(name);
+                std::fs::write(&path, text).map_err(|e| Error::Io(path.clone(), e))?;
+                Ok((path, Some(dir)))
+            }
+        }
+    }
+
+    /// The directory the tool runs in, created if the user named one.
+    fn resolve_work_dir(&self) -> Result<(PathBuf, Option<tempfile::TempDir>)> {
+        match self.work_dir {
+            Some(d) => {
+                // Created because every other destination directory in the CLI
+                // is, and canonicalized because it is passed to the tool as an
+                // argument while also being its working directory -- left
+                // relative, the tool resolves it a second time against itself.
+                std::fs::create_dir_all(d).map_err(|e| Error::Io(d.to_path_buf(), e))?;
+                let d = std::fs::canonicalize(d).map_err(|e| Error::Io(d.to_path_buf(), e))?;
+                Ok((d, None))
+            }
+            None => {
+                let dir = Self::temp_dir("oinkie_work")?;
+                Ok((dir.path().to_path_buf(), Some(dir)))
+            }
+        }
+    }
+
+    /// Ghidra rejects any path element beginning with a dot, which is what
+    /// `tempfile`'s default prefix produces, so every temporary directory here
+    /// is named explicitly.
+    fn temp_dir(prefix: &str) -> Result<tempfile::TempDir> {
+        tempfile::Builder::new()
+            .prefix(prefix)
+            .tempdir()
+            .map_err(|e| Error::Io(PathBuf::from(prefix), e))
+    }
+
+    fn resolve(input: &Path, work_dir: PathBuf, script: PathBuf) -> Result<Invocation> {
+        let invalid = |what: &str, p: &Path| Error::Parse(format!("Invalid {what} path: {p:?}"));
+        let name = input
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| invalid("input", input))?
+            .to_string();
+        let script_dir = script
+            .parent()
+            .ok_or_else(|| invalid("script", &script))?
+            .to_path_buf();
+        let script_name = script
+            .file_name()
+            .ok_or_else(|| invalid("script", &script))?
+            .to_os_string();
+        // The tool's working directory is not the caller's, so a relative
+        // input would be resolved against the wrong one.
+        let input = std::fs::canonicalize(input).map_err(|e| Error::Io(input.to_path_buf(), e))?;
+        Ok(Invocation {
+            input,
+            name,
+            work_dir,
+            script_dir,
+            script_name,
+        })
+    }
+
+    /// Moves the JSON the script wrote to where the caller asked for it.
+    fn take_output(&self, invocation: &Invocation, output: &Path) -> Result<()> {
+        let generated = invocation
+            .work_dir
+            .join(format!("{}.json", invocation.name));
+        if !generated.exists() {
+            return Err(Error::Parse(format!(
+                "Expected {} to generate {:?}, but it was not found.",
+                self.tool, generated
+            )));
+        }
+        // rename fails across file systems, which a temporary directory on
+        // another volume reaches every time; fall back to copy + remove.
+        if std::fs::rename(&generated, output).is_err() {
+            std::fs::copy(&generated, output).map_err(|e| Error::Io(output.to_path_buf(), e))?;
+            let _ = std::fs::remove_file(&generated);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `true` ignores its arguments and writes nothing, which is the whole
+    /// point: it exercises the path handling without needing a decompiler.
+    fn headless<'a>(work_dir: Option<&'a Path>, script: Option<&'a Path>) -> Headless<'a> {
+        Headless {
+            tool: "test",
+            program: Path::new("/usr/bin/true"),
+            script,
+            default_script: ("script.txt", "built-in"),
+            work_dir,
+        }
+    }
+
+    /// The tool runs with the working directory set to its own scratch
+    /// directory, so a relative input would be resolved against that rather
+    /// than the caller's -- the shape of the bug that made `lift -i irs` look
+    /// for `irs/irs`.
+    #[test]
+    fn test_paths_reach_the_command_absolute() {
+        let dir = tempfile::Builder::new()
+            .prefix("oinkie_t")
+            .tempdir()
+            .unwrap();
+        let input = dir.path().join("sample.bin");
+        std::fs::write(&input, b"binary").unwrap();
+        let relative = pathdiff(&input);
+
+        let seen = std::cell::RefCell::new(None);
+        let _ = headless(None, None).lift(&relative, &dir.path().join("out.json"), |i| {
+            *seen.borrow_mut() = Some((i.input.clone(), i.work_dir.clone(), i.name.clone()));
+            vec![]
+        });
+        let (resolved, work_dir, name) = seen.into_inner().expect("args were never built");
+        assert!(
+            resolved.is_absolute(),
+            "input stayed relative: {resolved:?}"
+        );
+        assert!(
+            work_dir.is_absolute(),
+            "work dir stayed relative: {work_dir:?}"
+        );
+        assert_eq!(name, "sample.bin");
+    }
+
+    /// A working directory the user named is created rather than required to
+    /// exist, and is handed over resolved so the tool cannot resolve it again.
+    #[test]
+    fn test_named_work_dir_is_created_and_absolute() {
+        let dir = tempfile::Builder::new()
+            .prefix("oinkie_t")
+            .tempdir()
+            .unwrap();
+        let input = dir.path().join("sample.bin");
+        std::fs::write(&input, b"binary").unwrap();
+        let work = dir.path().join("nested/work");
+        assert!(!work.exists());
+
+        let seen = std::cell::RefCell::new(None);
+        let _ = headless(Some(&work), None).lift(&input, &dir.path().join("out.json"), |i| {
+            *seen.borrow_mut() = Some(i.work_dir.clone());
+            vec![]
+        });
+        assert!(work.is_dir(), "the working directory was not created");
+        let used = seen.into_inner().expect("args were never built");
+        assert!(used.is_absolute());
+        assert_eq!(used, std::fs::canonicalize(&work).unwrap());
+    }
+
+    /// Without a script of its own a lifter gets the built-in one written out,
+    /// under the name it asked for and in a directory of its own.
+    #[test]
+    fn test_the_built_in_script_is_written_out() {
+        let dir = tempfile::Builder::new()
+            .prefix("oinkie_t")
+            .tempdir()
+            .unwrap();
+        let input = dir.path().join("sample.bin");
+        std::fs::write(&input, b"binary").unwrap();
+
+        let seen = std::cell::RefCell::new(None);
+        let _ = headless(None, None).lift(&input, &dir.path().join("out.json"), |i| {
+            let script = i.script_dir.join(&i.script_name);
+            *seen.borrow_mut() = Some((
+                std::fs::read_to_string(script).unwrap(),
+                i.script_name.clone(),
+            ));
+            vec![]
+        });
+        let (text, name) = seen.into_inner().expect("args were never built");
+        assert_eq!(text, "built-in");
+        assert_eq!(name, "script.txt");
+    }
+
+    /// A tool that produced nothing must say so rather than leave the caller
+    /// with a missing file and a zero exit status.
+    #[test]
+    fn test_a_missing_result_is_reported() {
+        let dir = tempfile::Builder::new()
+            .prefix("oinkie_t")
+            .tempdir()
+            .unwrap();
+        let input = dir.path().join("sample.bin");
+        std::fs::write(&input, b"binary").unwrap();
+
+        match headless(None, None).lift(&input, &dir.path().join("out.json"), |_| vec![]) {
+            Err(Error::Parse(msg)) => assert!(
+                msg.contains("sample.bin.json") && msg.contains("test"),
+                "unhelpful message: {msg}"
+            ),
+            other => panic!("expected a missing-output error, got {:?}", other.err()),
+        }
+    }
+
+    /// The output is moved even when the working directory is on another file
+    /// system, where `rename` fails and only copy + remove works. The move
+    /// itself is what is checked here; the cross-volume case cannot be staged
+    /// portably.
+    #[test]
+    fn test_the_result_is_moved_to_the_destination() {
+        let dir = tempfile::Builder::new()
+            .prefix("oinkie_t")
+            .tempdir()
+            .unwrap();
+        let input = dir.path().join("sample.bin");
+        std::fs::write(&input, b"binary").unwrap();
+        let work = dir.path().join("work");
+        let output = dir.path().join("out.json");
+
+        // `true` writes nothing, so stage what the script would have written.
+        std::fs::create_dir_all(&work).unwrap();
+        std::fs::write(work.join("sample.bin.json"), r#"{"program":"sample"}"#).unwrap();
+
+        headless(Some(&work), None)
+            .lift(&input, &output, |_| vec![])
+            .expect("the staged output should have been moved");
+        assert_eq!(
+            std::fs::read_to_string(&output).unwrap(),
+            r#"{"program":"sample"}"#
+        );
+        assert!(
+            !work.join("sample.bin.json").exists(),
+            "the result was copied rather than moved"
+        );
+    }
+
+    /// A path relative to the current directory, so that the caller's working
+    /// directory is what a relative input would be resolved against.
+    fn pathdiff(absolute: &Path) -> PathBuf {
+        let cwd = std::env::current_dir().unwrap();
+        match absolute.strip_prefix(&cwd) {
+            Ok(rest) => rest.to_path_buf(),
+            // Not under the current directory, so leave it absolute: the test
+            // still checks that what reaches the command is absolute.
+            Err(_) => absolute.to_path_buf(),
+        }
+    }
+}

--- a/src/lift/headless.rs
+++ b/src/lift/headless.rs
@@ -452,6 +452,7 @@ mod tests {
     /// the effect is that `--home ghidra_rel` passes the caller's own
     /// existence check and then fails to spawn with "No such file or
     /// directory" naming a path that does exist.
+    #[cfg(unix)]
     #[test]
     fn test_a_relative_program_is_resolved_before_the_directory_changes() {
         let dir = tempfile::Builder::new()
@@ -463,8 +464,15 @@ mod tests {
 
         // Under the crate root, so the path can be written relative to the
         // current directory; target/ is ignored by git and always present.
+        //
+        // A symlink rather than a copy: writing an executable while sibling
+        // tests are forking lets a child inherit the still-open write
+        // descriptor, and the exec then fails with ETXTBSY. That is a
+        // property of staging the file, not of what is being tested.
         let relative = PathBuf::from("target").join("oinkie_relative_program_test");
-        std::fs::copy("/bin/echo", &relative).expect("could not stage a relative program");
+        let _ = std::fs::remove_file(&relative);
+        std::os::unix::fs::symlink("/bin/echo", &relative)
+            .expect("could not stage a relative program");
 
         let mut h = headless(None, None);
         h.program = &relative;


### PR DESCRIPTION
Closes #46. Last of the five preparatory steps in `designs/multi-lifter-support.md`.

Stacked on #52 (`issue/45_decouple_op`). The base walks back to `main` as the stack merges.

## Discovery is per-backend

`find_ghidra_home` was a Ghidra function that `src/lift.rs` re-exported as if it were the general one. It is now `LifterType::find_home`, and each backend carries its own `HomeSpec`.

The environment variable names are **oinkie's convention, not the tools'** — Ghidra's own installer sets `GHIDRA_INSTALL_DIR`, not `GHIDRA_HOME` — so the others follow the same convention: `IDA_HOME`, `BINARY_NINJA_HOME`.

Their default-location lists are **empty on purpose**. I have not installed either tool, and a guessed path that happens to exist is worse than asking: it is found silently and fails later somewhere less obvious. The env var is the only route until someone fills them in from a real installation.

`LifterType::Angr` has **no spec at all**. angr is a Python library, imported rather than installed somewhere oinkie could point at, so `--home` means nothing for it and the error says that instead of naming a variable. It is in the enum as the reminder that the shape does not fit every backend.

The error now names the right variable:

```
Ghidra not found. Specify it with --home, set GHIDRA_HOME, or install it in
one of: /opt/homebrew/opt/ghidra/libexec, /usr/local/opt/ghidra/libexec, /opt/ghidra/libexec
```

## The invocation shape is written once

`src/lift/headless.rs` holds it. A lifter supplies its command line and its script; the runner does the paths. `GhidraLifter::lift` is now the existence check plus a `Headless { .. }.lift(input, output, |i| vec![..])`.

The three parts worth sharing are the ones this code already got wrong once:

- **resolving before the working directory changes** — a relative `--intermediate` was resolved twice, once by us and again by Ghidra against itself, giving `irs/irs` (#36)
- **running in its own directory** — the script writes into the process's working directory, so parallel lifts of same-named binaries raced on one path in the user's current directory (#13)
- **`rename` → copy + remove** — `rename` fails across file systems, which a temporary directory on another volume reaches every time

A second and third lifter writing those out again would be two more chances to reintroduce them.

## The open question: `--intermediate`

It generalises — but not as a Ghidra project directory. **Every headless lifter needs a directory to run in, because that is where its script writes its JSON.** Ghidra merely keeps its project there as well. So the option stays, its behaviour is unchanged, and only its documented meaning moves from Ghidra's concept to the shared one.

`--home` and `--script` keep one help string each. They mean the same thing for every backend — an installation directory, and a script in whatever language that backend runs — and the part that genuinely has to be per-lifter is the error, which now is. `--dest` and the subcommand summary no longer say "P-code".

## Verification

**Against real Ghidra**, not just tests. Lifting both fixtures with `-i` produces output **byte-identical to a build of the parent commit**, with discovery falling through to `/opt/homebrew/opt/ghidra/libexec` (`GHIDRA_HOME` unset) and the working directory kept:

```
$ ls irs
hello_clang.gpr  hello_clang.rep  hello_gcc.gpr  hello_gcc.rep
```

Five new unit tests cover the runner's path handling without needing a decompiler — they drive `/usr/bin/true` and inspect what reaches the command line: input and working directory arrive absolute, a named working directory is created rather than required to exist, the built-in script is written out under the name the lifter asked for, a missing result is reported by name, and the result is moved rather than copied.

The existing integration tests (`test_lift_command`, `test_lift_command_creates_the_intermediate_dir`, `test_lift_command_with_relative_intermediate_dir`) run real Ghidra and still pass.

110 tests pass (was 104). `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.

## Scope

`Headless` is `pub(crate)`. It is the extension point for lifters in this crate, and the first real second lifter is likely to want to bend its shape; committing to it as public API before then would make that harder. Implementing Binary Ninja or IDA Pro is explicitly not in this issue.

With this the five preparatory steps are done.
