### PR TITLE
test: stop the Ghidra tests from running at the same time

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -232,6 +232,9 @@ now is.
 - **#45** — the lifted file decides which operation type reads it, so the
   pipeline no longer assumes P-Code; a representation with no reader is refused
   by name
+- **#54** — the tests that run a real Ghidra no longer run at the same time as
+  each other, so they cannot corrupt its language cache; two of them that
+  differed only in their `-i` path are now one
 - **#55** — `lift` is serial by default, with `-j/--jobs N` to opt back into
   parallelism; the old default could corrupt Ghidra's language cache on a fresh
   installation, and the corruption was reported as a missing output

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,21 +38,6 @@ jobs:
           cargo clippy -- -D warnings
           cargo build --release
 
-      # Ghidra compiles its SLEIGH language definitions from .slaspec to .sla
-      # on first use and caches them inside its own installation, which the
-      # runner unpacks fresh every time. The lift tests start three
-      # analyzeHeadless processes at once, and against a cold installation
-      # they race to write the same .sla; the loser reads a half-written file
-      # and dies with "ZipException: invalid block type" -- while
-      # analyzeHeadless still exits 0, so the failure surfaced only as a
-      # missing output file. One serial lift builds the cache before anything
-      # runs in parallel.
-      - name: Warm Ghidra's language cache
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          export GHIDRA_HOME=${{ env.GHIDRA_INSTALL_DIR }}
-          ./target/release/oinkie lift -d "$RUNNER_TEMP/warm" testdata/hello_world/bin/hello_clang
-
       - name: Convert coverage format to lcov
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,7 +199,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -317,7 +317,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -416,6 +416,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-task"
@@ -542,7 +553,7 @@ checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -564,7 +575,7 @@ checksum = "ccfb0b7ce7938f84a5ecbdca5d0a991e46bc9d6d078934ad5e92c5270fe547db"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -589,6 +600,15 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -650,7 +670,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -694,6 +714,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "tempfile",
 ]
@@ -709,6 +730,29 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -780,7 +824,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -831,6 +875,15 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -894,6 +947,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,7 +979,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -934,6 +993,31 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serial_test"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6df5ed973ad8d834e09f824f9e9f449af6b9a3745f78dec7cc752770bd3bf11"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22144e767da4ddd8416dbf383700542ffd8a5dc493dfecedfe1fe3ad03c98ae"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -960,6 +1044,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1060,17 @@ name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1012,7 +1113,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1092,7 +1193,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -1136,7 +1237,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1147,7 +1248,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ path = "cli/main.rs"
 [dev-dependencies]
 assert_cmd = "2.2.2"
 predicates = "3.1.4"
+serial_test = "4.0.1"
 
 [[bin]]
 name = "gencomp"

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1,7 +1,19 @@
 use assert_cmd::Command;
 use predicates::prelude::*;
+use serial_test::serial;
 use std::fs;
 use tempfile::tempdir;
+
+// Tests marked `#[serial(ghidra)]` start a real Ghidra. They are serialised
+// against each other because Ghidra compiles its SLEIGH language definitions
+// on first use and caches them *inside its own installation*, so two headless
+// runs against an installation nobody has used yet write the same file at the
+// same time and the loser reads a half-written one. analyzeHeadless exits
+// successfully regardless, so it arrives as a missing output rather than an
+// error (#54).
+//
+// The group is named for what is shared rather than left anonymous, so that a
+// future test needing the same exclusion knows which one to join.
 
 #[test]
 fn test_info_command() {
@@ -15,6 +27,7 @@ fn test_info_command() {
 }
 
 #[test]
+#[serial(ghidra)]
 fn test_lift_command() {
     let temp_dir = tempdir().unwrap();
     let dest = temp_dir.path().join("lifted");
@@ -196,8 +209,26 @@ fn test_reaggregate_command() {
 /// also used as the working directory of the Ghidra process. A relative path
 /// must therefore be resolved before the process starts, or Ghidra resolves it
 /// a second time against itself and looks for `irs/irs`.
+/// Both `-i` regressions in one run, because each run is a whole decompiler.
+///
+/// A path given to `-i` is created rather than required to exist, as every
+/// other destination directory in the CLI is and as the temporary directory
+/// used without `-i` is by construction. And it is resolved once: it used to
+/// be resolved twice, by us and again by Ghidra against its own working
+/// directory, so `-i irs` went looking for `irs/irs`.
+///
+/// A relative path that does not exist yet covers both at once, and being
+/// nested covers creating intermediate levels rather than just the last.
+///
+/// Either regression makes the run itself fail here, which is how #36 was
+/// reported -- Ghidra complaining that `irs/irs` did not exist -- rather than
+/// showing up as a stray directory. Both were checked by reverting each fix in
+/// turn. The explicit assertions below still earn their place: they name which
+/// of the two broke, and they catch a variant that doubles the path without
+/// failing outright.
 #[test]
-fn test_lift_command_with_relative_intermediate_dir() {
+#[serial(ghidra)]
+fn test_lift_command_intermediate_dir_is_created_and_resolved_once() {
     // Ghidra rejects any path element starting with '.', and tempdir() names
     // its directories ".tmpXXXX", so the project location needs a plain prefix.
     let temp_dir = tempfile::Builder::new()
@@ -206,52 +237,24 @@ fn test_lift_command_with_relative_intermediate_dir() {
         .unwrap();
     let input = fs::canonicalize("testdata/hello_world/bin/hello_clang").unwrap();
     let dest = temp_dir.path().join("lifted");
-    fs::create_dir(temp_dir.path().join("irs")).unwrap();
 
     Command::cargo_bin("oinkie")
         .unwrap()
         .current_dir(temp_dir.path())
         .arg("lift")
         .arg("-i")
-        .arg("irs")
+        .arg("irs/nested")
         .arg("-d")
         .arg(&dest)
         .arg(&input)
         .assert()
         .success();
 
+    let intermediate = temp_dir.path().join("irs/nested");
+    assert!(intermediate.is_dir(), "the -i directory was not created");
     assert!(
-        !temp_dir.path().join("irs").join("irs").exists(),
+        !intermediate.join("irs/nested").exists(),
         "the -i path was resolved twice"
     );
-    assert!(dest.join("hello_clang.json").exists());
-}
-
-/// Every other destination directory in the CLI is created for the user, and
-/// the temporary directory used when `-i` is omitted exists by construction.
-/// A path passed to `-i` should be no different.
-#[test]
-fn test_lift_command_creates_the_intermediate_dir() {
-    // See the note above: the project location must not sit under a dot-directory.
-    let temp_dir = tempfile::Builder::new()
-        .prefix("oinkie_test")
-        .tempdir()
-        .unwrap();
-    let input = fs::canonicalize("testdata/hello_world/bin/hello_clang").unwrap();
-    let dest = temp_dir.path().join("lifted");
-    let intermediate = temp_dir.path().join("does/not/exist/yet");
-
-    Command::cargo_bin("oinkie")
-        .unwrap()
-        .arg("lift")
-        .arg("-i")
-        .arg(&intermediate)
-        .arg("-d")
-        .arg(&dest)
-        .arg(&input)
-        .assert()
-        .success();
-
-    assert!(intermediate.is_dir(), "the -i directory was not created");
     assert!(dest.join("hello_clang.json").exists());
 }


### PR DESCRIPTION
Closes #54 — the half #56 could not reach.

Stacked on #56 (`issue/55_lift_jobs`).

## Why #56 did not finish this

#56 made oinkie's own lifting serial by default. But the three lift tests in `tests/cli_test.rs` each spawn a separate `oinkie` process, and **the concurrency is cargo's**, not oinkie's — nothing inside the tool can reach it.

The mechanism is the same one: Ghidra compiles its SLEIGH language definitions on first use and caches them *inside its own installation*, so two headless runs against an installation nobody has used yet write the same file at once and the loser reads a half-written one. `analyzeHeadless` exits 0 regardless, so it arrives as a missing output rather than an error.

The evidence that it is a write race rather than a corrupt file: in the failing run, **two of the three tests read the same `.sla` successfully while the third did not**. A file that was simply broken would have failed all three.

## `serial_test` over a hand-rolled Mutex

`#[serial(ghidra)]` on the tests that start Ghidra.

Two reasons beyond the obvious one that a crate is better tested than five lines written here. First, **the annotation sits where someone adding a test will see it**, rather than being a line inside a body that a new test can simply omit. Second, **the hand-rolled failure mode is nasty**: a plain `.unwrap()` on a poisoned lock means the first test to fail takes every other one down with it and buries its own cause, and only someone who already knows to write `unwrap_or_else(|e| e.into_inner())` avoids it.

The group is named `ghidra` rather than left anonymous, so the annotation says *what* is shared and a later test needing the same exclusion knows which group to join.

It is a dev-dependency, so nothing reaches the published crate.

## Three Ghidra runs become two

`test_lift_command_with_relative_intermediate_dir` and `test_lift_command_creates_the_intermediate_dir` differed only in the `-i` path they passed. Each run is a whole decompiler, so that was one run more than the coverage needed.

A **relative path that does not exist yet and is nested** covers both at once: it must be created (including intermediate levels), and it must be resolved once rather than twice.

Verified rather than assumed — each fix was reverted in turn and the merged test fails for either:

| reverted | result |
| --- | --- |
| `create_dir_all` on the `-i` path | FAILED |
| `canonicalize` of the working directory | FAILED |
| neither | ok |

Both make the run itself fail, which is how #36 was reported in the first place — Ghidra complaining that `irs/irs` did not exist. The explicit assertions are kept anyway: they name which of the two broke, and they catch a variant that doubles the path without failing outright.

## Verification

`cli_test` is 7 tests where it was 8, all passing; the full suite is 115. `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.

## The warm-up step goes with it

The workflow step added in #53 built Ghidra's language cache with one serial lift so the three lift tests could not race to write it. With them serialised there is nothing left for it to prevent, so it is removed here — it only cost about eight seconds a run.

**Removed in this PR rather than in #53, deliberately.** The PRs below this one in the stack do not have the serialisation, and taking the step out any earlier would leave them exposed to the flake it was added for. It has to outlive its replacement by exactly as long as it takes for the replacement to land.
