### PR TITLE
test: hand the home search its environment instead of writing to ours

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -237,6 +237,14 @@ now is.
 - **#54** — the tests that run a real Ghidra no longer run at the same time as
   each other, so they cannot corrupt its language cache; two of them that
   differed only in their `-i` path are now one
+- **#24** — the tests no longer set `GHIDRA_HOME` and put it back afterwards.
+  Two of them ran at once in the same binary and saw each other's writes, which
+  is what made CI fail on a branch whose own checks were green; in edition 2024
+  `set_var` is `unsafe` precisely because a concurrent read of the environment
+  is undefined behaviour rather than merely a wrong answer. The search now takes
+  its environment, and its test for whether a path exists, as parameters — so a
+  test describes a machine instead of having to become one, and the case where
+  nothing is installed can be asserted for the first time
 - **#55** — `lift` is serial by default, with `-j/--jobs N` to opt back into
   parallelism; the old default could corrupt Ghidra's language cache on a fresh
   installation, and the corruption was reported as a missing output

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -614,18 +614,6 @@ mod tests {
         assert_eq!(result, opt);
     }
 
-    #[test]
-    fn test_find_ghidra_home_from_env() {
-        unsafe {
-            std::env::set_var("GHIDRA_HOME", "/env/path");
-        }
-        let result = LifterType::Ghidra.find_home(None).unwrap();
-        assert_eq!(result, PathBuf::from("/env/path"));
-        unsafe {
-            std::env::remove_var("GHIDRA_HOME");
-        }
-    }
-
     /// The three backends that are not implemented still have to say what to
     /// set, since a message naming GHIDRA_HOME for Binary Ninja is worse than
     /// no message at all.

--- a/src/ghidra/lifter.rs
+++ b/src/ghidra/lifter.rs
@@ -59,62 +59,10 @@ impl Lifter for GhidraLifter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lift::LifterType;
-    use std::env;
     use tempfile::tempdir;
 
-    #[test]
-    fn test_find_ghidra_home_with_opt() {
-        let opt_path = PathBuf::from("/custom/ghidra/home");
-        let result = LifterType::Ghidra.find_home(Some(&opt_path));
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), opt_path);
-    }
-
-    #[test]
-    fn test_find_ghidra_home_with_env() {
-        // Backup the env
-        let old_env = env::var("GHIDRA_HOME").ok();
-        unsafe {
-            env::set_var("GHIDRA_HOME", "/env/ghidra/home");
-        }
-
-        let result = LifterType::Ghidra.find_home(None);
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), PathBuf::from("/env/ghidra/home"));
-
-        // Restore env
-        if let Some(val) = old_env {
-            unsafe {
-                env::set_var("GHIDRA_HOME", val);
-            }
-        } else {
-            unsafe {
-                env::remove_var("GHIDRA_HOME");
-            }
-        }
-    }
-
-    #[test]
-    fn test_find_ghidra_home_not_found() {
-        // Backup the env
-        let old_env = env::var("GHIDRA_HOME").ok();
-        unsafe {
-            env::remove_var("GHIDRA_HOME");
-        }
-
-        let result = LifterType::Ghidra.find_home(None);
-        // It might find it in standard paths on some systems, so we can't definitively assert error
-        // unless we know the system doesn't have it. But we can check it doesn't crash.
-        let _ = result;
-
-        // Restore env
-        if let Some(val) = old_env {
-            unsafe {
-                env::set_var("GHIDRA_HOME", val);
-            }
-        }
-    }
+    // Where Ghidra's installation is looked for is tested in `crate::lift`,
+    // alongside the search itself.
 
     #[test]
     fn test_ghidra_lifter_new() {

--- a/src/lift.rs
+++ b/src/lift.rs
@@ -104,6 +104,48 @@ pub struct HomeSpec {
     pub candidates: &'static [&'static str],
 }
 
+impl HomeSpec {
+    /// Runs the search -- the environment variable, then the usual install
+    /// locations -- against a given environment and a given test for whether a
+    /// path exists.
+    ///
+    /// Both are handed in rather than read directly so that a test can
+    /// describe a machine instead of having to become one. The tests used to
+    /// set `GHIDRA_HOME` and put it back afterwards; the environment is
+    /// process-global, so two of them running at once in the same test binary
+    /// saw each other's writes, and in edition 2024 `set_var` is `unsafe`
+    /// precisely because a concurrent read of it is undefined behaviour rather
+    /// than merely a wrong answer (#24).
+    ///
+    /// It also makes the "not found" case testable at all. It could assert
+    /// nothing before, because the machine running the test might genuinely
+    /// have Ghidra at one of the candidates.
+    pub(crate) fn find_in(
+        &self,
+        env: impl Fn(&str) -> Option<String>,
+        exists: impl Fn(&Path) -> bool,
+    ) -> Result<PathBuf> {
+        if let Some(h) = env(self.env) {
+            return Ok(PathBuf::from(h));
+        }
+        for c in self.candidates {
+            let p = PathBuf::from(c);
+            if exists(&p) {
+                return Ok(p);
+            }
+        }
+        let looked_in = if self.candidates.is_empty() {
+            String::new()
+        } else {
+            format!(", or install it in one of: {}", self.candidates.join(", "))
+        };
+        Err(crate::Error::Parse(format!(
+            "{} not found. Specify it with --home, set {}{looked_in}",
+            self.tool, self.env
+        )))
+    }
+}
+
 impl LifterType {
     /// The tool's name as it should appear in messages.
     pub fn name(&self) -> &'static str {
@@ -158,24 +200,7 @@ impl LifterType {
                 self.name()
             )));
         };
-        if let Ok(h) = std::env::var(spec.env) {
-            return Ok(PathBuf::from(h));
-        }
-        for c in spec.candidates {
-            let p = PathBuf::from(c);
-            if p.exists() {
-                return Ok(p);
-            }
-        }
-        let looked_in = if spec.candidates.is_empty() {
-            String::new()
-        } else {
-            format!(", or install it in one of: {}", spec.candidates.join(", "))
-        };
-        Err(crate::Error::Parse(format!(
-            "{} not found. Specify it with --home, set {}{looked_in}",
-            spec.tool, spec.env
-        )))
+        spec.find_in(|k| std::env::var(k).ok(), |p| p.exists())
     }
 }
 
@@ -231,5 +256,99 @@ impl LifterBuilder {
                 "Binary Ninja lifter is not yet implemented.".to_string(),
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The search never runs: `--home` is taken as given, without checking
+    /// that it exists, so that the error names the path the user actually
+    /// passed rather than a guess.
+    #[test]
+    fn test_the_home_the_user_passed_wins() {
+        let opt = PathBuf::from("/custom/ghidra/home");
+        assert_eq!(LifterType::Ghidra.find_home(Some(&opt)).unwrap(), opt);
+    }
+
+    #[test]
+    fn test_the_environment_variable_is_read_when_no_home_was_passed() {
+        let spec = LifterType::Ghidra.home_spec().unwrap();
+        let home = spec
+            .find_in(
+                |k| (k == "GHIDRA_HOME").then(|| "/env/ghidra/home".to_string()),
+                |_| panic!("the usual locations were searched despite GHIDRA_HOME being set"),
+            )
+            .unwrap();
+        assert_eq!(home, PathBuf::from("/env/ghidra/home"));
+    }
+
+    /// An installed Ghidra does not override the one the user pointed at. The
+    /// `exists` above never runs, so this says the same thing from the other
+    /// side: with both available, the variable is what comes back.
+    #[test]
+    fn test_the_environment_variable_beats_an_installed_ghidra() {
+        let spec = LifterType::Ghidra.home_spec().unwrap();
+        let home = spec
+            .find_in(|_| Some("/env/ghidra/home".to_string()), |_| true)
+            .unwrap();
+        assert_eq!(home, PathBuf::from("/env/ghidra/home"));
+    }
+
+    #[test]
+    fn test_the_usual_locations_are_searched_when_the_variable_is_unset() {
+        let spec = LifterType::Ghidra.home_spec().unwrap();
+        let last = Path::new(spec.candidates.last().unwrap());
+        let home = spec.find_in(|_| None, |p| p == last).unwrap();
+        assert_eq!(home, last);
+    }
+
+    /// Two installations are a real situation on a Mac with both Homebrew
+    /// prefixes populated, and the order the candidates are listed in is the
+    /// answer to it.
+    #[test]
+    fn test_the_first_of_several_installations_wins() {
+        let spec = LifterType::Ghidra.home_spec().unwrap();
+        let home = spec.find_in(|_| None, |_| true).unwrap();
+        assert_eq!(home, PathBuf::from(spec.candidates[0]));
+    }
+
+    /// This is what a machine with no Ghidra sees, and until the search took
+    /// its environment as a parameter it could not be asserted: the test ran
+    /// on a machine that might have Ghidra at one of the candidates, so it
+    /// checked only that nothing panicked.
+    #[test]
+    fn test_a_ghidra_that_is_nowhere_says_what_to_set_and_where_it_looked() {
+        let spec = LifterType::Ghidra.home_spec().unwrap();
+        let err = spec.find_in(|_| None, |_| false).unwrap_err().to_string();
+        assert!(err.contains("--home"), "does not offer --home: {err}");
+        assert!(
+            err.contains("GHIDRA_HOME"),
+            "does not name the variable: {err}"
+        );
+        for c in spec.candidates {
+            assert!(err.contains(c), "does not say it looked in {c}: {err}");
+        }
+    }
+
+    /// A backend nobody has installed and checked has no candidates, and the
+    /// message has to stop after the variable rather than invite the user to
+    /// install it in one of nowhere.
+    #[test]
+    fn test_a_backend_with_no_usual_locations_does_not_offer_an_empty_list() {
+        let spec = LifterType::IDAPro.home_spec().unwrap();
+        let err = spec
+            .find_in(|_| None, |_| panic!("there is nothing to look at"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("IDA_HOME"),
+            "does not name the variable: {err}"
+        );
+        assert!(
+            !err.contains("install it in one of"),
+            "offers an empty list: {err}"
+        );
     }
 }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -58,18 +58,23 @@ fn test_lift_command() {
 /// it was given -- so the assertion is that the value reached Ghidra's home,
 /// not merely that the run failed. No Ghidra starts, so this does not join
 /// the `ghidra` group.
+///
+/// The home is a fixed absolute path rather than one under the temporary
+/// directory. It only has to be somewhere Ghidra is not, and naming it
+/// literally keeps the expected string a literal too. Derived from `TMPDIR`,
+/// it would have to survive both `to_str` and the `{:?}` the error message
+/// formats it with -- a non-UTF-8 `TMPDIR` panics on the first, and one
+/// holding a quote or a backslash comes back escaped from the second. Either
+/// way the test would report the environment variable as broken on a machine
+/// where the only unusual thing is where it puts its temporary files.
 #[test]
 fn test_the_lifter_home_is_read_from_the_environment() {
-    let temp_dir = tempfile::Builder::new()
-        .prefix("oinkie_test")
-        .tempdir()
-        .unwrap();
-    let home = temp_dir.path().join("not-a-ghidra");
+    let temp_dir = tempdir().unwrap();
     let dest = temp_dir.path().join("lifted");
 
     Command::cargo_bin("oinkie")
         .unwrap()
-        .env("GHIDRA_HOME", &home)
+        .env("GHIDRA_HOME", "/oinkie-no-such-ghidra")
         .arg("lift")
         .arg("-d")
         .arg(&dest)
@@ -77,7 +82,7 @@ fn test_the_lifter_home_is_read_from_the_environment() {
         .assert()
         .failure()
         .stderr(predicate::str::contains(
-            home.join("support/analyzeHeadless").to_str().unwrap(),
+            "/oinkie-no-such-ghidra/support/analyzeHeadless",
         ));
 }
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -47,6 +47,40 @@ fn test_lift_command() {
     assert!(out_file.exists(), "hello_clang.json was not generated");
 }
 
+/// Nothing inside the library can check that the environment variable is
+/// actually read: the search takes its environment as a parameter now, so
+/// that the tests stop writing to the process' own (#24), and a test that
+/// injects the lookup cannot also prove the real one is wired to it.
+///
+/// A child process can. `GHIDRA_HOME` is set for that process alone, which is
+/// hermetic in the way `set_var` never was, and pointing it at a directory
+/// with no `support/analyzeHeadless` makes the run fail while naming the path
+/// it was given -- so the assertion is that the value reached Ghidra's home,
+/// not merely that the run failed. No Ghidra starts, so this does not join
+/// the `ghidra` group.
+#[test]
+fn test_the_lifter_home_is_read_from_the_environment() {
+    let temp_dir = tempfile::Builder::new()
+        .prefix("oinkie_test")
+        .tempdir()
+        .unwrap();
+    let home = temp_dir.path().join("not-a-ghidra");
+    let dest = temp_dir.path().join("lifted");
+
+    Command::cargo_bin("oinkie")
+        .unwrap()
+        .env("GHIDRA_HOME", &home)
+        .arg("lift")
+        .arg("-d")
+        .arg(&dest)
+        .arg("testdata/hello_world/bin/hello_clang")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            home.join("support/analyzeHeadless").to_str().unwrap(),
+        ));
+}
+
 #[test]
 fn test_extract_command() {
     let temp_dir = tempdir().unwrap();


### PR DESCRIPTION
Closes #24 — and with it the failure that turned `main` red after #53 merged.

## What actually failed

The [push run on `main`](https://github.com/tamada/oinkie/actions/runs/33455661494) after #53 landed:

```
---- ghidra::lifter::tests::test_find_ghidra_home_with_env stdout ----
panicked at src/ghidra/lifter.rs:84:9:
assertion `left == right` failed
  left: "/opt/hostedtoolcache/ghidra/2f0817.../x64"
 right: "/env/ghidra/home"
```

Nothing in #53 caused it. Three tests set `GHIDRA_HOME` and put it back afterwards, they live in one test binary, and cargo runs them concurrently:

1. `_not_found` saves the runner's `GHIDRA_HOME` and removes it
2. `_with_env` sets it to `/env/ghidra/home`
3. `_not_found` **restores** what it saved
4. `_with_env` reads it and gets the runner's path

The left-hand value in the panic is exactly what the workflow exports before running the tests, which is why only the ubuntu job — the only one that runs tests, and the only one with `GHIDRA_HOME` set — could show it. Locally the variable is unset, so step 3 does nothing and the window never opens.

**It is not merely flaky.** The environment is process-global, and in edition 2024 `set_var` is `unsafe` precisely because reading it from another thread during a write is undefined behaviour rather than a wrong answer. Every call site already carried an `unsafe` block whose safety condition was not met.

## The fix

`HomeSpec::find_in` takes the environment lookup and the "does this path exist" test as parameters; `find_home` passes the real ones.

```rust
pub(crate) fn find_in(
    &self,
    env: impl Fn(&str) -> Option<String>,
    exists: impl Fn(&Path) -> bool,
) -> Result<PathBuf>
```

A test now **describes a machine instead of having to become one**. Nothing mutates the process, and no `unsafe` is left anywhere in the crate.

The order of the search, the message, and the public signature of `find_home` are all unchanged. `find_in` is `pub(crate)`, so this is not a library API change.

## It makes the search assertable for the first time

`test_find_ghidra_home_not_found` asserted **nothing**. It ended in `let _ = result;` under a comment explaining why:

> It might find it in standard paths on some systems, so we can't definitively assert error unless we know the system doesn't have it.

With `exists` handed in, that stops being true. The replacements assert:

| | |
| --- | --- |
| `test_the_home_the_user_passed_wins` | `--home` short-circuits the search |
| `test_the_environment_variable_is_read_when_no_home_was_passed` | the variable is read, and the usual locations are not even looked at |
| `test_the_environment_variable_beats_an_installed_ghidra` | an installed Ghidra does not override what the user pointed at |
| `test_the_usual_locations_are_searched_when_the_variable_is_unset` | the candidate list is used |
| `test_the_first_of_several_installations_wins` | order matters, and it is the listed order — a real situation on a Mac with both Homebrew prefixes populated |
| `test_a_ghidra_that_is_nowhere_says_what_to_set_and_where_it_looked` | the message offers `--home`, names `GHIDRA_HOME`, and lists every candidate |
| `test_a_backend_with_no_usual_locations_does_not_offer_an_empty_list` | IDA Pro's message stops after the variable rather than inviting the user to install it in one of nothing |

The tests move from `src/ghidra/lifter.rs` to `src/lift.rs`, where `find_home` has lived since #46. `cli/main.rs` loses its duplicate of the environment one.

## One test that injection cannot replace

Injecting the lookup everywhere leaves nothing to prove the real one is wired to it. So `tests/cli_test.rs` sets `GHIDRA_HOME` **for a child process** — hermetic in the way `set_var` never was — pointing at a directory with no `support/analyzeHeadless`:

```rust
Command::cargo_bin("oinkie").unwrap()
    .env("GHIDRA_HOME", &home)
    .arg("lift").arg("-d").arg(&dest)
    .arg("testdata/hello_world/bin/hello_clang")
    .assert()
    .failure()
    .stderr(predicate::str::contains(
        home.join("support/analyzeHeadless").to_str().unwrap(),
    ));
```

The run fails **naming the path it was given**, so the assertion is that the value reached Ghidra's home — not merely that the run failed. No Ghidra starts, so it does not join the `ghidra` serial group.

## Verification

**Reproduced first.** The old tests, filtered so the two land adjacent, fail **321 times in 500 runs** with the panic CI reported — same file, same line, same shape. (The full suite did not reproduce it in 60 runs: with 95 tests the two rarely get scheduled together, which is why it took CI to find.)

**The fix holds.** The new lib suite passes **500 of 500** under the same conditions, and passes with `GHIDRA_HOME` unset, set to a real installation, and set to nonsense — it no longer depends on the ambient environment at all.

**Every fix reverted in turn**, and each is caught:

| reverted | caught by |
| --- | --- |
| the environment lookup | `..._is_read_when_no_home_was_passed`, `..._beats_an_installed_ghidra`, and the child-process test |
| candidates searched in reverse | `test_the_first_of_several_installations_wins` |
| never reporting a missing install | `..._says_what_to_set_and_where_it_looked`, `..._does_not_offer_an_empty_list` |
| offering an empty candidate list | `..._does_not_offer_an_empty_list` |
| **`find_home` no longer reading the process environment** | **the child-process test alone** |

The last row is what earns the integration test its place: it is the only thing that notices the wiring coming loose, which is precisely the coverage the deleted `cli/main.rs` test had been providing by accident.

**120 tests**, up from 116 (99 lib, 10 `cli/main.rs`, 8 `cli_test`, 3 `lib_test`). `cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings` are clean.
