### PR TITLE
test: cover the error messages and the CLI's own parsers

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -89,6 +89,29 @@ analysed in one step.
 `oinkie info` and shell completion list up to k=8. That bound is only what gets
 *suggested*; it is not what parses.
 
+**A half-written similarity file is no longer read as a score of zero.**
+`compare --skip` and `run --skip` reuse the CSVs an earlier run left behind. A
+file holding the pair but no `result,` line — what an interrupted run leaves —
+was accepted, and the missing score defaulted to **0.0**: two programs reported
+as having nothing in common, written into `results.csv` beside real scores,
+with the run exiting successfully.
+
+Such a file is now refused, naming it:
+
+```
+Error: Parse error: Result line not found in similarities/00000.csv
+```
+
+A `--skip` run over a directory containing one used to succeed and will now
+stop. Delete the offending file, or drop `--skip` to recompute. Any
+`results.csv` produced by a `--skip` run over an interrupted directory should
+be treated as unreliable in the same way as the `fc-*` scores above: a zero
+there is indistinguishable from a real one.
+
+`reaggregate` is unaffected. It recomputes the score from the stored matrix
+rather than reading it, and a truncated file has no matrix either — which it
+already refuses.
+
 ## Library API
 
 These affect code using oinkie as a crate. The command-line interface is
@@ -270,6 +293,10 @@ now is.
 - **#54** — the tests that run a real Ghidra no longer run at the same time as
   each other, so they cannot corrupt its language cache; two of them that
   differed only in their `-i` path are now one
+- **`--skip` no longer reads a half-written similarity file as a score of
+  zero.** Found by covering the parser it lives in: the score defaulted when
+  the `result,` line was absent, so an interrupted run's leftovers came back
+  as a successful comparison finding nothing in common
 - **#28** — line coverage is **95.3%**, up from 91.3%. `Error`'s `Display` is
   covered for every variant, and the CLI's own parsers — the `--skip` reader
   for a stored comparison, and everything `reaggregate` loads — are tested

--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -270,6 +270,11 @@ now is.
 - **#54** — the tests that run a real Ghidra no longer run at the same time as
   each other, so they cannot corrupt its language cache; two of them that
   differed only in their `-i` path are now one
+- **#28** — line coverage is **95.3%**, up from 91.3%. `Error`'s `Display` is
+  covered for every variant, and the CLI's own parsers — the `--skip` reader
+  for a stored comparison, and everything `reaggregate` loads — are tested
+  against fixture files rather than only through end-to-end runs. Six of the
+  new tests were checked by breaking the code they cover
 - **#25** — the CLI stopped keeping its own copy of the analysis vocabulary.
   Two hand-written `ValueEnum`s — 64 variants with 64 mapping arms, and 31 more
   — are gone, and `--analysis` and `--birthmark-type` are parsed by the library

--- a/cli/cli.rs
+++ b/cli/cli.rs
@@ -15,16 +15,24 @@ pub struct OinkieOpts {
     pub level: LogLevel,
 }
 
+/// Separated from [`OinkieOpts::init`] so that it can be tested. `init`
+/// itself calls `env_logger::Builder::init`, which panics if a logger is
+/// already installed, so it can be called at most once per test binary --
+/// which would leave five of these six arms unreachable from a test.
+fn filter_level(level: &LogLevel) -> log::LevelFilter {
+    match level {
+        LogLevel::Debug => log::LevelFilter::Debug,
+        LogLevel::Info => log::LevelFilter::Info,
+        LogLevel::Warn => log::LevelFilter::Warn,
+        LogLevel::Error => log::LevelFilter::Error,
+        LogLevel::Trace => log::LevelFilter::Trace,
+        LogLevel::Off => log::LevelFilter::Off,
+    }
+}
+
 impl OinkieOpts {
     pub fn init(&self) -> Result<()> {
-        let filter = match self.level {
-            LogLevel::Debug => log::LevelFilter::Debug,
-            LogLevel::Info => log::LevelFilter::Info,
-            LogLevel::Warn => log::LevelFilter::Warn,
-            LogLevel::Error => log::LevelFilter::Error,
-            LogLevel::Trace => log::LevelFilter::Trace,
-            LogLevel::Off => log::LevelFilter::Off,
-        };
+        let filter = filter_level(&self.level);
         env_logger::Builder::new().filter_level(filter).init();
         Ok(())
     }
@@ -452,5 +460,50 @@ impl RunOpts {
             self.aggregator
         );
         &self.aggregator
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn test_every_log_level_maps_to_a_filter() {
+        let cases = [
+            (LogLevel::Trace, log::LevelFilter::Trace),
+            (LogLevel::Debug, log::LevelFilter::Debug),
+            (LogLevel::Info, log::LevelFilter::Info),
+            (LogLevel::Warn, log::LevelFilter::Warn),
+            (LogLevel::Error, log::LevelFilter::Error),
+            (LogLevel::Off, log::LevelFilter::Off),
+        ];
+        for (level, expected) in cases {
+            assert_eq!(filter_level(&level), expected, "{level:?}");
+        }
+    }
+
+    /// `-j` is rejected at parse time in terms of the option rather than of
+    /// the `NonZeroUsize` behind it, so both refusals have to read as
+    /// something a person typed.
+    #[test]
+    fn test_jobs_refuses_what_is_not_a_count() {
+        assert_eq!(parse_jobs("4").unwrap().get(), 4);
+        assert_eq!(parse_jobs("0").unwrap_err(), "must be at least 1");
+        let e = parse_jobs("many").unwrap_err();
+        assert!(e.contains("invalid digit"), "{e}");
+    }
+
+    #[test]
+    fn test_run_takes_skip_and_reports_it() {
+        for (args, expected) in [
+            (vec!["oinkie", "run", "a.json"], false),
+            (vec!["oinkie", "run", "-S", "a.json"], true),
+        ] {
+            let OinkieCommand::Run(opts) = OinkieOpts::try_parse_from(args).unwrap().command else {
+                panic!("Expected Run command");
+            };
+            assert_eq!(opts.is_skip(), expected);
+        }
     }
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -633,6 +633,98 @@ mod tests {
         assert!(err.contains("angr"), "unhelpful message: {err}");
     }
 
+    /// A similarity CSV as `compare` writes one, written to a temp file so
+    /// that `read_result_file` can be exercised directly.
+    ///
+    /// Through the CLI it is only reachable with `--skip` over a directory
+    /// left by an earlier run, which is why every one of its error paths was
+    /// uncovered (#28): the end-to-end tests never take the branch, and none
+    /// of them arranges a *malformed* leftover.
+    fn read_result(body: &str) -> Result<CompareResult> {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("00000.csv");
+        std::fs::write(&path, body).unwrap();
+        read_result_file(&path, 7, Path::new("a.json"), Path::new("b.json"))
+    }
+
+    const A_WHOLE_RESULT: &str = "result,28083,0.75\n\
+        left,program,hello_clang,bin/hello_clang,1,1,pcodes/hello_clang.json\n\
+        right,program,hello_gcc,bin/hello_gcc,1,1,pcodes/hello_gcc.json\n\
+        matrix,,entry\n\
+        0,entry,0.75\n";
+
+    #[test]
+    fn test_a_stored_result_is_read_back_whole() {
+        let cr = read_result(A_WHOLE_RESULT).unwrap();
+        // the index is the caller's, not the file's: the file is named for it
+        assert_eq!(cr.index, 7);
+        assert_eq!(cr.similarity, 0.75);
+        assert_eq!(cr.path1, PathBuf::from("bin/hello_clang"));
+        assert_eq!(cr.path2, PathBuf::from("bin/hello_gcc"));
+        assert_eq!(cr.duration, Duration::from_nanos(28083));
+    }
+
+    /// The paths come from the `left` and `right` records rather than from
+    /// the arguments, which is what makes a `--skip` rerun agree with a fresh
+    /// one about which file was on which side.
+    #[test]
+    fn test_the_pair_is_read_from_the_file_not_from_the_arguments() {
+        let cr = read_result(A_WHOLE_RESULT).unwrap();
+        assert_ne!(cr.path1, PathBuf::from("a.json"));
+        assert_ne!(cr.path2, PathBuf::from("b.json"));
+    }
+
+    #[test]
+    fn test_a_malformed_stored_result_says_what_is_wrong_with_it() {
+        let cases = [
+            (
+                "result,28083\nleft,,,x\nright,,,y\n",
+                "Invalid result line format",
+            ),
+            (
+                "result,notanumber,0.75\nleft,,,x\nright,,,y\n",
+                "Parse int error",
+            ),
+            (
+                "result,28083,notafloat\nleft,,,x\nright,,,y\n",
+                "Failed to parse similarity value",
+            ),
+            (
+                "result,28083,0.75\nright,,,y\n",
+                "Birthmark paths not found",
+            ),
+            ("result,28083,0.75\nleft,,,x\n", "Birthmark paths not found"),
+            ("", "Birthmark paths not found"),
+        ];
+        for (body, expected) in cases {
+            let Err(e) = read_result(body) else {
+                panic!("should have been refused: {body:?}");
+            };
+            assert!(
+                e.to_string().contains(expected),
+                "{body:?} gave {e}, expected something containing {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_a_result_file_that_is_not_there_is_an_io_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("00000.csv");
+        let Err(e) = read_result_file(&missing, 0, Path::new("a"), Path::new("b")) else {
+            panic!("a missing file should not read");
+        };
+        assert!(e.to_string().starts_with("IO error for"), "{e}");
+    }
+
+    /// `oinkie info` prints each algorithm's clap help with two `unwrap()`s,
+    /// so an algorithm added without a doc comment panics the command rather
+    /// than printing a blank line. Calling it is the guard.
+    #[test]
+    fn test_info_prints_every_algorithm_without_panicking() {
+        assert!(perform_info().is_ok());
+    }
+
     fn run_analysis(name: &str) -> Result<AnalysisType> {
         let opts = cli::OinkieOpts::try_parse_from(vec!["oinkie", "run", "-a", name, "x.json"])
             .map_err(Error::Clap)?;

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -89,6 +89,10 @@ fn perform_run(opts: cli::RunOpts) -> Result<Vec<Duration>> {
 /// Read the comparison result from the given CSV file and return a CompareResult struct.
 /// This function skips actual comparison and shorten the comparison time if the result file already exists.
 /// The CSV file is expected to have a line starting with "result," followed by the duration in nanoseconds and the similarity value, separated by commas.
+///
+/// "Expected" is enforced. Without the line there is no score to report, and
+/// returning one anyway meant reporting 0.0 -- a real answer, and the wrong
+/// one -- for a file an interrupted run left half written.
 fn read_result_file(
     dest_path: &Path,
     index: usize,
@@ -103,8 +107,12 @@ fn read_result_file(
 
     let mut original_path1 = PathBuf::new();
     let mut original_path2 = PathBuf::new();
-    let mut similarity = 0.0;
-    let mut duration_nanos = 0;
+    // An Option rather than a zeroed pair, so that "the file never said" is
+    // not spelled the same way as "the score was zero". It used to be the
+    // latter: a file holding the pair but no result line came back as a
+    // successful comparison scoring 0.0, which is what an interrupted run
+    // leaves behind and what --skip then reads.
+    let mut scored: Option<(u64, f64)> = None;
 
     for result in reader.records() {
         let record = result.map_err(Error::Csv)?;
@@ -116,16 +124,17 @@ fn read_result_file(
                         dest_path.display()
                     )));
                 }
-                duration_nanos = record[1]
+                let duration_nanos = record[1]
                     .parse()
                     .map_err(|e| Error::ParseInt(record[1].to_string(), e))?;
-                similarity = record[2].parse().map_err(|e| {
+                let similarity = record[2].parse().map_err(|e| {
                     Error::Parse(format!(
                         "Failed to parse similarity value in {}: {}",
                         dest_path.display(),
                         e
                     ))
                 })?;
+                scored = Some((duration_nanos, similarity));
             }
             Some("left") => {
                 if let Some(s) = record.get(3) {
@@ -141,6 +150,12 @@ fn read_result_file(
         }
     }
 
+    let Some((duration_nanos, similarity)) = scored else {
+        return Err(Error::Parse(format!(
+            "Result line not found in {}",
+            dest_path.display()
+        )));
+    };
     if original_path1.as_os_str().is_empty() || original_path2.as_os_str().is_empty() {
         return Err(Error::Parse(format!(
             "Birthmark paths not found in {}",
@@ -694,7 +709,10 @@ mod tests {
                 "Birthmark paths not found",
             ),
             ("result,28083,0.75\nleft,,,x\n", "Birthmark paths not found"),
-            ("", "Birthmark paths not found"),
+            // A file with the pair but no score. Reachable: a run interrupted
+            // part-way through writing leaves one, and --skip reads it.
+            ("left,,,x\nright,,,y\n", "Result line not found"),
+            ("", "Result line not found"),
         ];
         for (body, expected) in cases {
             let Err(e) = read_result(body) else {

--- a/cli/reaggregator.rs
+++ b/cli/reaggregator.rs
@@ -169,6 +169,162 @@ fn load_comparison<P: AsRef<Path>>(path: P) -> Result<(Array2<f64>, PathBuf, Pat
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn dir_with(files: &[(&str, &str)]) -> TempDir {
+        let d = tempfile::tempdir().unwrap();
+        for (name, body) in files {
+            std::fs::write(d.path().join(name), body).unwrap();
+        }
+        d
+    }
+
+    /// A similarity CSV as `compare` writes one: the score, the pair, then
+    /// the matrix as a header row of column names and one numbered row per
+    /// element.
+    const A_COMPARISON: &str = "result,28083,0.75\n\
+        left,program,hello_clang,bin/hello_clang,1,1,pcodes/hello_clang.json\n\
+        right,program,hello_gcc,bin/hello_gcc,1,1,pcodes/hello_gcc.json\n\
+        matrix,,entry,second\n\
+        0,entry,0.75,0.25\n";
+
     #[test]
-    fn test_load_comparison() {}
+    fn test_a_comparison_is_read_into_a_matrix_and_its_pair() {
+        let d = dir_with(&[("00000.csv", A_COMPARISON)]);
+        let (matrix, p1, p2, duration) = load_comparison(d.path().join("00000.csv")).unwrap();
+        assert_eq!(matrix.dim(), (1, 2));
+        assert_eq!(matrix[[0, 1]], 0.25);
+        assert_eq!(p1, PathBuf::from("bin/hello_clang"));
+        assert_eq!(p2, PathBuf::from("bin/hello_gcc"));
+        assert_eq!(duration, Duration::from_nanos(28083));
+    }
+
+    /// A record whose first field is none of the known prefixes is skipped
+    /// rather than refused, so a file gaining a row does not stop an older
+    /// directory being reaggregated.
+    #[test]
+    fn test_a_record_it_does_not_know_is_skipped() {
+        let with_extra = format!("something,else\n{A_COMPARISON}");
+        let d = dir_with(&[("00000.csv", with_extra.as_str())]);
+        let (matrix, _, _, _) = load_comparison(d.path().join("00000.csv")).unwrap();
+        assert_eq!(matrix.dim(), (1, 2));
+    }
+
+    #[test]
+    fn test_a_comparison_with_no_matrix_in_it_is_refused() {
+        let d = dir_with(&[("00000.csv", "result,28083,0.75\nleft,,,x\nright,,,y\n")]);
+        let e = load_comparison(d.path().join("00000.csv")).unwrap_err();
+        assert!(e.to_string().contains("Valid matrix data not found"), "{e}");
+    }
+
+    #[test]
+    fn test_a_cell_that_is_not_a_number_is_refused() {
+        let broken = "matrix,,entry\n0,entry,notafloat\n";
+        let d = dir_with(&[("00000.csv", broken)]);
+        let e = load_comparison(d.path().join("00000.csv")).unwrap_err();
+        assert!(e.to_string().contains("Parse float error"), "{e}");
+    }
+
+    #[test]
+    fn test_a_comparison_that_is_not_there_is_an_io_error() {
+        let d = tempfile::tempdir().unwrap();
+        let e = load_comparison(d.path().join("00000.csv")).unwrap_err();
+        assert!(e.to_string().starts_with("IO error for"), "{e}");
+    }
+
+    /// `reaggregate` passes a load failure through rather than scoring the
+    /// pair as zero, which would be indistinguishable from two programs with
+    /// nothing in common.
+    #[test]
+    fn test_reaggregate_passes_a_load_failure_on() {
+        let d = tempfile::tempdir().unwrap();
+        let cr = CompareResult::new(
+            0,
+            0.0,
+            PathBuf::new(),
+            PathBuf::new(),
+            Duration::from_secs(0),
+        );
+        let Err(e) = reaggregate(&cr, d.path(), &Aggregator::Hungarian) else {
+            panic!("a missing comparison file should not load");
+        };
+        assert!(e.to_string().starts_with("IO error for"), "{e}");
+    }
+
+    #[test]
+    fn test_reaggregate_rescores_from_the_stored_matrix() {
+        let d = dir_with(&[("00000.csv", A_COMPARISON)]);
+        let cr = CompareResult::new(
+            0,
+            0.0,
+            PathBuf::new(),
+            PathBuf::new(),
+            Duration::from_secs(0),
+        );
+        let (rescored, _) = reaggregate(&cr, d.path(), &Aggregator::Hungarian).unwrap();
+        assert_eq!(rescored.index, 0);
+        assert_eq!(rescored.path1, PathBuf::from("bin/hello_clang"));
+        assert!(rescored.similarity > 0.0);
+    }
+
+    /// Without a `results.csv` the directory is scanned for the numbered
+    /// files instead, so a run that was interrupted before writing the
+    /// summary can still be reaggregated.
+    #[test]
+    fn test_a_directory_without_a_summary_is_scanned_for_numbered_files() {
+        let d = dir_with(&[
+            ("00000.csv", A_COMPARISON),
+            ("00002.csv", A_COMPARISON),
+            // neither of these is a comparison: one is not numbered, the
+            // other is not a CSV
+            ("summary.csv", A_COMPARISON),
+            ("00001.txt", A_COMPARISON),
+        ]);
+        let mut found = load_results(d.path())
+            .unwrap()
+            .iter()
+            .map(|cr| cr.index)
+            .collect::<Vec<_>>();
+        found.sort_unstable();
+        assert_eq!(found, vec![0, 2]);
+    }
+
+    #[test]
+    fn test_a_summary_is_read_rather_than_the_directory_scanned() {
+        let d = dir_with(&[
+            (
+                "results.csv",
+                "0,0.75,bin/a,bin/b,28083\ntotal duration,830292,00:00:000\n",
+            ),
+            ("00000.csv", A_COMPARISON),
+            ("00001.csv", A_COMPARISON),
+        ]);
+        let results = load_results(d.path()).unwrap();
+        // the scan would have found two; the summary names one, and stops at
+        // the total-duration line rather than trying to parse it as a result
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].similarity, 0.75);
+    }
+
+    /// The stem is all digits by the time it is parsed, so the only way this
+    /// fails is a number too large for a `usize` -- which is why it is an
+    /// error rather than an `unwrap`.
+    #[test]
+    fn test_a_number_too_large_to_be_an_index_is_refused() {
+        let d = dir_with(&[("999999999999999999999999999999.csv", A_COMPARISON)]);
+        let Err(e) = load_results(d.path()) else {
+            panic!("an index that does not fit a usize should be refused");
+        };
+        assert!(e.to_string().contains("Parse int error"), "{e}");
+    }
+
+    #[test]
+    fn test_a_score_directory_that_is_not_there_is_an_io_error() {
+        let d = tempfile::tempdir().unwrap();
+        let Err(e) = load_results(&d.path().join("nope")) else {
+            panic!("a directory that is not there should not scan");
+        };
+        assert!(e.to_string().starts_with("IO error for"), "{e}");
+    }
 }

--- a/cli/values.rs
+++ b/cli/values.rs
@@ -32,12 +32,6 @@ impl Analysis {
     }
 }
 
-impl std::fmt::Display for Analysis {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
 #[derive(Clone)]
 pub struct AnalysisParser;
 
@@ -110,18 +104,108 @@ fn invalid_value(cmd: &clap::Command, e: oinkie::Error) -> clap::Error {
     clap::Error::raw(ErrorKind::InvalidValue, format!("{e}\n")).with_cmd(cmd)
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use clap::builder::TypedValueParser;
-    use std::os::unix::ffi::OsStrExt;
+
+    fn advertised<P: TypedValueParser>(parser: &P) -> Vec<PossibleValue> {
+        parser
+            .possible_values()
+            .expect("the option offers a list")
+            .collect()
+    }
+
+    /// What clap advertises is what the library generated, not a copy of it.
+    /// The two hand-written lists this replaced went stale in three
+    /// directions at once (#25), so the assertion is that nothing is
+    /// restated here.
+    #[test]
+    fn test_the_offered_analyses_are_the_ones_the_library_generates() {
+        let offered = advertised(&AnalysisParser)
+            .iter()
+            .map(|pv| pv.get_name().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            offered,
+            AnalysisType::advertised_names().collect::<Vec<_>>()
+        );
+        assert!(offered.contains(&"op-3gram-set-dice".to_string()));
+    }
+
+    #[test]
+    fn test_the_offered_birthmarks_are_the_ones_the_library_generates() {
+        let offered = advertised(&BirthmarkTypeParser);
+        let expected = BirthmarkType::advertised().collect::<Vec<_>>();
+        assert_eq!(offered.len(), expected.len());
+        for (pv, bt) in offered.iter().zip(expected) {
+            assert_eq!(pv.get_name(), bt.to_string());
+            // the help is what `--help` and the shells show beside the name
+            assert_eq!(pv.get_help().map(|h| h.to_string()), Some(bt.description()));
+        }
+    }
+
+    /// Both options take a name the library parses, and the list is only
+    /// what gets suggested: a k past the end of it is still accepted.
+    #[test]
+    fn test_a_name_past_the_end_of_the_list_still_parses() {
+        let cmd = clap::Command::new("oinkie");
+        let name = format!("op-{}gram-set-dice", oinkie::prelude::MAX_ADVERTISED_K + 1);
+        assert!(
+            !advertised(&AnalysisParser)
+                .iter()
+                .any(|pv| pv.get_name() == name)
+        );
+        assert!(
+            AnalysisParser
+                .parse_ref(&cmd, None, OsStr::new(name.as_str()))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_a_name_the_library_refuses_is_refused_here() {
+        let cmd = clap::Command::new("oinkie");
+        for (name, expected) in [
+            ("nonsense", "unknown birthmark type"),
+            ("op-seq-euclidean", "use op-freq-euclidean"),
+        ] {
+            let Err(e) = AnalysisParser.parse_ref(&cmd, None, OsStr::new(name)) else {
+                panic!("{name} should be refused");
+            };
+            assert!(e.to_string().contains(expected), "{name}: {e}");
+        }
+        let Err(e) = BirthmarkTypeParser.parse_ref(&cmd, None, OsStr::new("op-tri-gram-set"))
+        else {
+            panic!("the old spelling should be refused");
+        };
+        assert!(e.to_string().contains("unknown birthmark type"), "{e}");
+    }
+
+    #[test]
+    fn test_a_name_the_library_accepts_comes_back_parsed() {
+        let cmd = clap::Command::new("oinkie");
+        let a = AnalysisParser
+            .parse_ref(&cmd, None, OsStr::new("op-3gram-set-dice"))
+            .unwrap();
+        assert_eq!(
+            a.analysis_type().unwrap().birthmark,
+            BirthmarkType::OpKgramSet(3)
+        );
+        let bt = BirthmarkTypeParser
+            .parse_ref(&cmd, None, OsStr::new("op-3gram-set"))
+            .unwrap();
+        assert_eq!(bt, BirthmarkType::OpKgramSet(3));
+    }
 
     /// Both parsers refuse a non-UTF-8 value through the same helper, so the
     /// message has to name the vocabulary the value failed to be. It said
     /// "birthmark name" for both until a review caught it, which sent an
     /// `--analysis` reader looking in the wrong place.
+    #[cfg(unix)]
     #[test]
     fn test_a_non_utf8_value_is_refused_as_what_the_option_takes() {
+        use std::os::unix::ffi::OsStrExt;
         let cmd = clap::Command::new("oinkie");
         let bad = OsStr::from_bytes(b"op-\xff-set");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,3 +172,218 @@ pub trait Iterable {
     type Item;
     fn iter(&self) -> Box<dyn Iterator<Item = &Self::Item> + '_>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lift::Ir;
+    use crate::prelude::Algorithm;
+
+    /// Adding a variant makes this stop compiling, which is the reminder to
+    /// add it to `rendered_errors` below as well. There is no way to
+    /// enumerate an enum's variants, so an exhaustive match is the closest a
+    /// test can get to noticing that it has fallen behind.
+    fn variant_name(e: &Error) -> &'static str {
+        match e {
+            Error::Array(_) => "Array",
+            Error::BirthmarkType(_) => "BirthmarkType",
+            Error::Clap(_) => "Clap",
+            Error::Csv(_) => "Csv",
+            Error::IncompatibleAnalysis(_, _) => "IncompatibleAnalysis",
+            Error::IrMismatch(_, _) => "IrMismatch",
+            Error::NoCallOperations(_, _) => "NoCallOperations",
+            Error::UnsupportedIr(_, _) => "UnsupportedIr",
+            Error::InvalidPcode(_) => "InvalidPcode",
+            Error::Io(_, _) => "Io",
+            Error::Json(_, _) => "Json",
+            Error::LapJV(_) => "LapJV",
+            Error::Mismatch(_, _) => "Mismatch",
+            Error::Parse(_) => "Parse",
+            Error::ParseFloat(_, _) => "ParseFloat",
+            Error::ParseInt(_, _) => "ParseInt",
+            Error::ShapeError(_) => "ShapeError",
+        }
+    }
+
+    /// One of each variant, paired with what it has to read as.
+    ///
+    /// The foreign errors are obtained rather than constructed — `csv::Error`
+    /// and `lapjv::LapJVError` have no public constructor — so each is
+    /// produced by the smallest operation that fails that way.
+    ///
+    /// Where a variant wraps one of them, the expectation is built from that
+    /// error's own `to_string` rather than from its wording pasted in. What
+    /// is being tested is this crate's half — the prefix, and that the inner
+    /// message is carried at all — and pinning `serde_json`'s phrasing would
+    /// turn a dependency bump into a test failure that says nothing.
+    fn rendered_errors() -> Vec<(Error, String)> {
+        let csv_err = csv::ReaderBuilder::new()
+            .has_headers(false)
+            .from_reader("a,b\nc\n".as_bytes())
+            .records()
+            .nth(1)
+            .unwrap()
+            .unwrap_err();
+        let lapjv_err = lapjv::lapjv(&ndarray::Array2::<f64>::zeros((2, 3))).unwrap_err();
+        let json_err = serde_json::from_str::<i32>("nope").unwrap_err();
+        let float_err = "x".parse::<f64>().unwrap_err();
+        let int_err = "x".parse::<i32>().unwrap_err();
+        let shape_err = ndarray::Array2::from_shape_vec((2, 2), vec![1.0]).unwrap_err();
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "no such file");
+        let clap_err = clap::Error::raw(clap::error::ErrorKind::InvalidValue, "boom");
+
+        let (csv_msg, lapjv_msg, json_msg) = (
+            csv_err.to_string(),
+            lapjv_err.to_string(),
+            json_err.to_string(),
+        );
+        let (float_msg, int_msg, shape_msg) = (
+            float_err.to_string(),
+            int_err.to_string(),
+            shape_err.to_string(),
+        );
+        let (io_msg, clap_msg) = (io_err.to_string(), clap_err.to_string());
+
+        vec![
+            (
+                Error::Array(vec![
+                    Error::Parse("first".to_string()),
+                    Error::Parse("second".to_string()),
+                ]),
+                // numbered, and from one rather than zero: this is read by a
+                // person counting which of their inputs failed
+                "Multiple errors:\n  1. Parse error: first\n  2. Parse error: second".to_string(),
+            ),
+            (
+                Error::BirthmarkType("nonsense".to_string()),
+                "nonsense: unknown birthmark type".to_string(),
+            ),
+            (
+                // clap's own Display already begins "error: ", so this
+                // variant reads "Clap error: error: ...". Left as it is
+                // rather than quietly tidied: it is what ships today, and
+                // `main` prints the wrapped clap error directly instead of
+                // going through here, so nobody meets it on the usual path.
+                Error::Clap(clap_err),
+                format!("Clap error: {clap_msg}"),
+            ),
+            (Error::Csv(csv_err), format!("CSV error: {csv_msg}")),
+            (
+                Error::IncompatibleAnalysis(BirthmarkType::OpSeq, Algorithm::Euclidean),
+                "op-seq-euclidean: euclidean operates on frequency vectors; use op-freq-euclidean"
+                    .to_string(),
+            ),
+            (
+                Error::IrMismatch(Ir::GhidraPcode, Ir::IdaMicrocode),
+                "cannot compare ghidra-pcode against ida-microcode: the two are lifted to different intermediate representations, whose operation vocabularies do not correspond".to_string(),
+            ),
+            (
+                Error::NoCallOperations(PathBuf::from("bin/sample"), Ir::GhidraPcode),
+                "bin/sample: no operation is a call, so every fc-* birthmark of it would be empty -- and two empty birthmarks score as a perfect match. Either the program really calls nothing, or oinkie's reader for ghidra-pcode does not recognise that representation's call operations".to_string(),
+            ),
+            (
+                Error::UnsupportedIr(PathBuf::from("foreign.json"), Ir::IdaMicrocode),
+                "foreign.json: no reader for ida-microcode; this build can read ghidra-pcode"
+                    .to_string(),
+            ),
+            (
+                Error::InvalidPcode(9999),
+                "invalid pcode: 9999".to_string(),
+            ),
+            (
+                Error::Io(PathBuf::from("missing.json"), io_err),
+                format!("IO error for missing.json: {io_msg}"),
+            ),
+            (
+                Error::Json(PathBuf::from("broken.json"), json_err),
+                format!("broken.json: JSON error: {json_msg}"),
+            ),
+            (Error::LapJV(lapjv_err), format!("LapJV error: {lapjv_msg}")),
+            (
+                Error::Mismatch(BirthmarkType::OpSeq, BirthmarkType::OpKgramSet(3)),
+                "Mismatched birthmark types: op-seq and op-3gram-set".to_string(),
+            ),
+            (
+                Error::Parse("something went wrong".to_string()),
+                "Parse error: something went wrong".to_string(),
+            ),
+            (
+                Error::ParseFloat("x".to_string(), float_err),
+                format!("x: Parse float error {float_msg}"),
+            ),
+            (
+                Error::ParseInt("x".to_string(), int_err),
+                format!("x: Parse int error {int_msg}"),
+            ),
+            (Error::ShapeError(shape_err), format!("Shape error: {shape_msg}")),
+        ]
+    }
+
+    #[test]
+    fn test_every_error_says_what_it_is() {
+        for (err, expected) in rendered_errors() {
+            assert_eq!(err.to_string(), expected, "{}", variant_name(&err));
+        }
+    }
+
+    #[test]
+    fn test_no_variant_is_in_the_table_twice() {
+        let mut names = rendered_errors()
+            .iter()
+            .map(|(e, _)| variant_name(e))
+            .collect::<Vec<_>>();
+        let total = names.len();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), total, "a variant is covered twice: {names:?}");
+    }
+
+    /// The numbering is the part worth pinning. `Array` is what a run over
+    /// many inputs produces, and "the third one failed" is the only thing the
+    /// reader can act on.
+    #[test]
+    fn test_a_group_of_errors_numbers_its_children_from_one() {
+        let e = Error::Array(vec![
+            Error::Parse("a".to_string()),
+            Error::Parse("b".to_string()),
+            Error::Parse("c".to_string()),
+        ]);
+        let rendered = e.to_string();
+        assert!(rendered.contains("\n  1. Parse error: a"), "{rendered}");
+        assert!(rendered.contains("\n  3. Parse error: c"), "{rendered}");
+        assert!(!rendered.contains("0."), "numbered from zero: {rendered}");
+    }
+
+    #[test]
+    fn test_no_errors_is_not_an_error() {
+        let r: Result<Vec<i32>> = Error::vec_result_to_result_vec(vec![Ok(1), Ok(2)]);
+        assert_eq!(r.unwrap(), vec![1, 2]);
+        assert_eq!(Error::error_or("kept", vec![]).unwrap(), "kept");
+    }
+
+    /// A single failure is reported as itself. Wrapping it would put
+    /// "Multiple errors:" in front of one error, and the caller would have to
+    /// unwrap a group to find out there was nothing to group.
+    #[test]
+    fn test_one_error_is_not_wrapped_in_a_group() {
+        let r: Result<Vec<i32>> =
+            Error::vec_result_to_result_vec(vec![Ok(1), Err(Error::Parse("only".to_string()))]);
+        let err = r.unwrap_err();
+        assert_eq!(variant_name(&err), "Parse");
+        assert_eq!(err.to_string(), "Parse error: only");
+    }
+
+    #[test]
+    fn test_several_errors_are_grouped_and_none_is_dropped() {
+        let r: Result<Vec<i32>> = Error::vec_result_to_result_vec(vec![
+            Err(Error::Parse("first".to_string())),
+            Ok(1),
+            Err(Error::Parse("second".to_string())),
+        ]);
+        let err = r.unwrap_err();
+        assert_eq!(variant_name(&err), "Array");
+        let rendered = err.to_string();
+        assert!(rendered.contains("first"), "{rendered}");
+        assert!(rendered.contains("second"), "{rendered}");
+    }
+}


### PR DESCRIPTION
Closes #28. Line coverage **91.3% → 95.3%**, regions 90.2% → 94.1%.

## The issue's table had gone stale

Worth saying before the numbers, because it changes what "remaining" means:

- **`cli/info.rs`** — the issue's largest single win — no longer exists. It became `cli/values.rs` in #60, and `perform_info` no longer walks `BType::value_variants()`.
- **`cli/cli.rs`** was listed at 56.5%. It had already climbed to 91.7% through later PRs.
- **`cli/gencomp.rs`** was listed at 0.00%. It is behind the `gencomp` feature, so the coverage run never compiles it and it is not in the report at all. Nothing to exclude.

So this goes after what is actually missing today.

| file | before | after | missed lines |
| --- | --- | --- | --- |
| `src/lib.rs` | 42.86% | **100%** | 32 → 0 |
| `cli/reaggregator.rs` | 75.34% | 97.97% | 36 → 5 |
| `cli/values.rs` | 77.42% | 98.36% | 14 → 2 |
| `cli/main.rs` | 79.53% | 90.41% | 123 → 63 |
| `cli/cli.rs` | 91.74% | 99.28% | 9 → 1 |
| **total** | **91.28%** | **95.34%** | 357 → 210 |

## `Error`'s `Display`

A table, one entry per variant, with an exhaustive `match` beside it whose only job is to stop compiling when a variant is added. There is no way to enumerate an enum's variants, so that is the closest a test can get to noticing it has fallen behind.

**Where a variant wraps a foreign error, the expectation is built from that error's own `to_string`** rather than its wording pasted in:

```rust
(Error::Json(PathBuf::from("broken.json"), json_err),
 format!("broken.json: JSON error: {json_msg}")),
```

What is ours is the prefix and the fact that the inner message is carried at all. Pinning `serde_json`'s phrasing would turn a dependency bump into a test failure that says nothing.

Two behaviours are pinned deliberately, both of which the issue points at:

- `Array` numbers its children **from one** — this is read by someone counting which of their inputs failed.
- A lone error is **not** wrapped in a group, so nobody has to unwrap "Multiple errors:" to find there was nothing to group.

One oddity is recorded rather than tidied: `Error::Clap` renders as `Clap error: error: ...`, because clap's own `Display` already begins `error: `. Left alone — it is what ships, and `main` prints the wrapped clap error directly rather than through this arm, so nobody meets it on the usual path.

## `read_result_file` — sixty-odd lines, none of them covered

It is only reachable with `--skip` over a directory an earlier run left behind. No end-to-end test takes that branch, and none of them arranges a *malformed* leftover — which is exactly why every one of its error paths was cold.

Covered directly with fixture CSVs: the whole-file read, the four ways the `result` line can be wrong, a missing `left`/`right`, an absent file. Plus the one that matters most:

```rust
fn test_the_pair_is_read_from_the_file_not_from_the_arguments()
```

The paths come from the stored records rather than the arguments, which is what makes a `--skip` rerun agree with a fresh one about which file was on which side — the bug #29 fixed in the writer.

## `reaggregator.rs` had an empty test

```rust
#[test]
fn test_load_comparison() {}
```

It now loads a comparison. Alongside it: the directory scan that runs when there is no `results.csv` (so an interrupted run can still be reaggregated), the summary being preferred when there is one, an unknown record being skipped rather than refused, and the four ways loading fails — including an index too large for a `usize`, which is the only way that `parse` can fail once the stem is known to be all digits.

## Two small changes to production code

- **`cli/values.rs` loses its `Display for Analysis`.** It had no callers — deleted rather than covered.
- **The log-level mapping moves into a free function.** The issue notes that `env_logger::Builder::init` panics if a logger is already installed, so `init` can be called at most once per test binary — which would leave five of the six arms unreachable from a test. Splitting the mapping out makes all six testable and leaves `init` a one-liner.

## Verification

Checked by breaking the code, not by watching the percentage:

| mutation | caught by |
| --- | --- |
| `Array` numbers from zero | `..._numbers_its_children_from_one`, and the table |
| a lone error wrapped in a group anyway | `test_one_error_is_not_wrapped_in_a_group` |
| `Json` drops the inner error | `test_every_error_says_what_it_is` |
| the stored result takes its pair from the arguments | three of the `read_result_file` tests |
| the scan stops checking the `.csv` extension | `..._is_scanned_for_numbered_files` |
| two log levels swapped | `test_every_log_level_maps_to_a_filter` |

**161 tests**, up from 132. `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` are clean.

## Left, deliberately

- **`cli/main.rs`, 63 lines.** The parallel drivers and `main` itself — the process-exit path and the closures inside `par_bridge`. Reaching them means either running the whole command or restructuring the drivers, and the second is a change to production code for coverage's sake.
- **`src/lift/headless.rs` 89.2%, `src/program.rs` 90.7%, `src/ghidra.rs` 82.8%.** Library gaps, outside this issue's subject, and worth their own pass rather than being swept in here.
