### PR TITLE
refactor: derive Error, and let it report its cause

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -112,6 +112,22 @@ there is indistinguishable from a real one.
 rather than reading it, and a truncated file has no matrix either — which it
 already refuses.
 
+**A usage error is no longer announced twice.** clap's own message begins
+`error: `, and oinkie printed it behind `Error: `, so a mistyped flag came back
+as `Error: error: unexpected argument ...` (#62). The prefix is gone from that
+path. oinkie's own errors carry no prefix of their own and keep theirs:
+
+```
+$ oinkie run --bogus-flag
+error: unexpected argument '--bogus-flag' found
+
+$ oinkie extract no-such-file.json
+Error: IO error for no-such-file.json: No such file or directory (os error 2)
+```
+
+Scripts matching on the old `Error: error:` text need updating. The exit codes
+are unchanged: 1 for a usage error, 2 for anything else.
+
 ## Library API
 
 These affect code using oinkie as a crate. The command-line interface is
@@ -226,6 +242,18 @@ Python library and has no installation directory to point at.
 `Shape`, `BirthmarkType::shape`, `BirthmarkType::with_shape`,
 `BirthmarkType::pairs_with` and `Algorithm::shape`.
 
+**`Error` reports its cause.** `impl std::error::Error for Error` was empty, so
+`source()` returned `None` even for the seven variants holding a wrapped error
+(#62). Each now returns it, and an error chain has the depth it should. Nothing
+called `source()` before, because there was nothing to get.
+
+`Error` is derived with `thiserror` rather than hand-writing `Display`, so the
+message sits on the variant it belongs to. Every variant renders exactly as it
+did, with one deliberate exception: `Error::Clap` no longer prefixes clap's
+message with `Clap error: `, since clap's already begins `error: `. No `#[from]`
+impls were added, so nothing converts implicitly through `?` that did not
+before.
+
 **New public items for listing the vocabulary rather than hand-writing it**:
 `BirthmarkType::advertised`, `BirthmarkType::description`,
 `AnalysisType::advertised_names` and `MAX_ADVERTISED_K`; `Algorithm::cli_name`
@@ -297,6 +325,11 @@ now is.
   zero.** Found by covering the parser it lives in: the score defaulted when
   the `result,` line was absent, so an interrupted run's leftovers came back
   as a successful comparison finding nothing in common
+
+- **#62** — `Error` is derived rather than hand-written, and reports its
+  cause: `source()` was `None` for every variant, including the seven wrapping
+  a foreign error. A usage error is also no longer printed as
+  `Error: error: ...`
 - **#28** — line coverage is **95.3%**, up from 91.3%. `Error`'s `Display` is
   covered for every variant, and the CLI's own parsers — the `--skip` reader
   for a stored comparison, and everything `reaggregate` loads — are tested

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,7 @@ dependencies = [
  "serial_test",
  "sha2",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]
@@ -1098,22 +1099,22 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde = { version = "1.0.228", features = [ "derive" ] }
 serde_json = "1.0.150"
 sha2 = "0.10.9"
 tempfile = "3.10.1"
+thiserror = "2.0.20"
 
 [[bin]]
 name = "oinkie"

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -604,7 +604,14 @@ fn main() {
                 println!("{}", e.render().ansi());
                 0
             } else {
-                eprintln!("Error: {}", e);
+                // No "Error: " in front: clap's own message already begins
+                // "error: ", and prefixing it gave "Error: error: ..." (#62).
+                // The other arm keeps its prefix, since oinkie's own errors
+                // carry none.
+                //
+                // Display rather than `render().ansi()`, which would put
+                // colour codes into a redirected stderr.
+                eprintln!("{e}");
                 1
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,85 +14,94 @@ mod program;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-impl std::error::Error for Error {}
-
-#[derive(Debug)]
+/// The messages live on the variants rather than in a `Display` match, so
+/// that adding a variant and deciding how it reads are the same edit.
+///
+/// The wrapped errors are `#[source]` but not `#[from]`. `Io` and `Json`
+/// carry the path beside the error — which path failed is the useful half —
+/// so they could not be `#[from]` anyway, and for the rest an explicit
+/// `map_err(Error::Csv)` at the call site says more than a conversion hidden
+/// inside a `?`.
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("{}", render_group(.0))]
     Array(Vec<Self>),
+    #[error("{0}: unknown birthmark type")]
     BirthmarkType(String),
-    Clap(clap::Error),
-    Csv(csv::Error),
+    /// clap's own message already begins `error: `, so this adds no prefix of
+    /// its own. It used to read `Clap error: error: ...` (#62).
+    #[error("{0}")]
+    Clap(#[source] clap::Error),
+    #[error("CSV error: {0}")]
+    Csv(#[source] csv::Error),
     /// A birthmark shape paired with an algorithm that does not operate on it.
+    #[error("{}", render_incompatible(.0, .1))]
     IncompatibleAnalysis(BirthmarkType, crate::prelude::Algorithm),
     /// Two birthmarks lifted to different intermediate representations.
+    #[error(
+        "cannot compare {0} against {1}: the two are lifted to different intermediate representations, whose operation vocabularies do not correspond"
+    )]
     IrMismatch(crate::lift::Ir, crate::lift::Ir),
     /// An `fc-*` birthmark was asked of a program holding no call at all.
+    #[error(
+        "{path}: no operation is a call, so every fc-* birthmark of it would be empty -- and two empty birthmarks score as a perfect match. Either the program really calls nothing, or oinkie's reader for {ir} does not recognise that representation's call operations",
+        path = .0.display(),
+        ir = .1
+    )]
     NoCallOperations(PathBuf, crate::lift::Ir),
     /// A lifted file naming a representation this build cannot read.
+    #[error(
+        "{path}: no reader for {ir}; this build can read {readable}",
+        path = .0.display(),
+        ir = .1,
+        readable = render_readable()
+    )]
     UnsupportedIr(PathBuf, crate::lift::Ir),
+    #[error("invalid pcode: {0}")]
     InvalidPcode(u32),
-    Io(PathBuf, std::io::Error),
-    Json(PathBuf, serde_json::Error),
-    LapJV(lapjv::LapJVError),
+    #[error("IO error for {path}: {cause}", path = .0.display(), cause = .1)]
+    Io(PathBuf, #[source] std::io::Error),
+    #[error("{path}: JSON error: {cause}", path = .0.display(), cause = .1)]
+    Json(PathBuf, #[source] serde_json::Error),
+    #[error("LapJV error: {0}")]
+    LapJV(#[source] lapjv::LapJVError),
+    #[error("Mismatched birthmark types: {0} and {1}")]
     Mismatch(BirthmarkType, BirthmarkType),
+    #[error("Parse error: {0}")]
     Parse(String),
-    ParseFloat(String, std::num::ParseFloatError),
-    ParseInt(String, std::num::ParseIntError),
-    ShapeError(ShapeError),
+    #[error("{0}: Parse float error {1}")]
+    ParseFloat(String, #[source] std::num::ParseFloatError),
+    #[error("{0}: Parse int error {1}")]
+    ParseInt(String, #[source] std::num::ParseIntError),
+    #[error("Shape error: {0}")]
+    ShapeError(#[source] ShapeError),
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Error::Array(errs) => {
-                let _ = write!(f, "Multiple errors:");
-                for (i, err) in errs.iter().enumerate() {
-                    write!(f, "\n  {}. {}", i + 1, err)?;
-                }
-                Ok(())
-            }
-            Error::BirthmarkType(t) => write!(f, "{t}: unknown birthmark type"),
-            Error::Csv(e) => write!(f, "CSV error: {}", e),
-            Error::IncompatibleAnalysis(bt, algorithm) => {
-                let name = algorithm.cli_name();
-                write!(
-                    f,
-                    "{bt}-{name}: {name} operates on {}; use {}-{name}",
-                    algorithm.shape().description(),
-                    bt.with_shape(algorithm.shape())
-                )
-            }
-            Error::IrMismatch(a, b) => write!(
-                f,
-                "cannot compare {a} against {b}: the two are lifted to different intermediate representations, whose operation vocabularies do not correspond"
-            ),
-            Error::InvalidPcode(code) => write!(f, "invalid pcode: {code}"),
-            Error::NoCallOperations(path, ir) => write!(
-                f,
-                "{}: no operation is a call, so every fc-* birthmark of it would be empty -- and two empty birthmarks score as a perfect match. Either the program really calls nothing, or oinkie's reader for {ir} does not recognise that representation's call operations",
-                path.display()
-            ),
-            Error::Io(path, e) => write!(f, "IO error for {}: {}", path.display(), e),
-            Error::Json(file, e) => write!(f, "{}: JSON error: {}", file.display(), e),
-            Error::LapJV(e) => write!(f, "LapJV error: {}", e),
-            Error::Mismatch(t1, t2) => write!(f, "Mismatched birthmark types: {} and {}", t1, t2),
-            Error::ParseFloat(s, e) => write!(f, "{s}: Parse float error {e}"),
-            Error::Parse(s) => write!(f, "Parse error: {}", s),
-            Error::ParseInt(s, e) => write!(f, "{s}: Parse int error {e}"),
-            Error::UnsupportedIr(path, ir) => write!(
-                f,
-                "{}: no reader for {ir}; this build can read {}",
-                path.display(),
-                crate::lift::Ir::readable()
-                    .iter()
-                    .map(|ir| ir.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            ),
-            Error::Clap(e) => write!(f, "Clap error: {}", e),
-            Error::ShapeError(e) => write!(f, "Shape error: {}", e),
-        }
+/// Numbered from one, because this is read by someone counting which of their
+/// inputs failed.
+fn render_group(errs: &[Error]) -> String {
+    let mut s = String::from("Multiple errors:");
+    for (i, err) in errs.iter().enumerate() {
+        s.push_str(&format!("\n  {}. {}", i + 1, err));
     }
+    s
+}
+
+fn render_incompatible(bt: &BirthmarkType, algorithm: &crate::prelude::Algorithm) -> String {
+    let name = algorithm.cli_name();
+    format!(
+        "{bt}-{name}: {name} operates on {}; use {}-{name}",
+        algorithm.shape().description(),
+        bt.with_shape(algorithm.shape())
+    )
+}
+
+fn render_readable() -> String {
+    crate::lift::Ir::readable()
+        .iter()
+        .map(|ir| ir.to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 impl Error {
@@ -259,13 +268,11 @@ mod tests {
                 "nonsense: unknown birthmark type".to_string(),
             ),
             (
-                // clap's own Display already begins "error: ", so this
-                // variant reads "Clap error: error: ...". Left as it is
-                // rather than quietly tidied: it is what ships today, and
-                // `main` prints the wrapped clap error directly instead of
-                // going through here, so nobody meets it on the usual path.
+                // No prefix of its own: clap's message already begins
+                // "error: ", and this used to put "Clap error: " in front of
+                // that (#62).
                 Error::Clap(clap_err),
-                format!("Clap error: {clap_msg}"),
+                clap_msg.clone(),
             ),
             (Error::Csv(csv_err), format!("CSV error: {csv_msg}")),
             (
@@ -352,6 +359,70 @@ mod tests {
         assert!(rendered.contains("\n  1. Parse error: a"), "{rendered}");
         assert!(rendered.contains("\n  3. Parse error: c"), "{rendered}");
         assert!(!rendered.contains("0."), "numbered from zero: {rendered}");
+    }
+
+    /// The message has to name every representation this build can read, and
+    /// separate them.
+    ///
+    /// Honest about its reach: `Ir::readable()` holds one entry today, so the
+    /// separator half cannot fail yet — `join("")` and `join(", ")` produce
+    /// the same string for one item. It is here for the build that adds a
+    /// second reader, which is exactly when a broken join would ship
+    /// unnoticed.
+    #[test]
+    fn test_an_unreadable_representation_lists_what_can_be_read() {
+        let rendered =
+            Error::UnsupportedIr(PathBuf::from("foreign.json"), crate::lift::Ir::IdaMicrocode)
+                .to_string();
+        for ir in crate::lift::Ir::readable() {
+            assert!(
+                rendered.contains(&ir.to_string()),
+                "{ir} missing: {rendered}"
+            );
+        }
+        let separators = rendered.matches(", ").count();
+        assert_eq!(
+            separators,
+            crate::lift::Ir::readable().len() - 1,
+            "{} readable representations should be separated {} times: {rendered}",
+            crate::lift::Ir::readable().len(),
+            crate::lift::Ir::readable().len() - 1
+        );
+    }
+
+    /// `impl std::error::Error for Error {}` was empty, so `source()` was
+    /// `None` even for the variants holding a cause. Nothing called it —
+    /// there was nothing to get (#62).
+    #[test]
+    fn test_a_wrapped_error_is_reachable_as_a_source() {
+        use std::error::Error as _;
+
+        let inner = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
+        let inner_msg = inner.to_string();
+        let e = Error::Io(PathBuf::from("locked.json"), inner);
+        let source = e.source().expect("the io::Error is the cause");
+        assert_eq!(source.to_string(), inner_msg);
+
+        let e = Error::Json(
+            PathBuf::from("broken.json"),
+            serde_json::from_str::<i32>("nope").unwrap_err(),
+        );
+        assert!(e.source().is_some(), "the serde_json::Error is the cause");
+    }
+
+    /// A variant that is not wrapping anything has no cause to report, and
+    /// saying otherwise would make a chain look deeper than it is.
+    #[test]
+    fn test_an_error_of_our_own_has_no_source() {
+        use std::error::Error as _;
+
+        assert!(Error::Parse("ours".to_string()).source().is_none());
+        assert!(Error::InvalidPcode(1).source().is_none());
+        assert!(
+            Error::Array(vec![Error::Parse("child".to_string())])
+                .source()
+                .is_none()
+        );
     }
 
     #[test]

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -86,6 +86,37 @@ fn test_the_lifter_home_is_read_from_the_environment() {
         ));
 }
 
+/// clap's own message begins "error: ", and `main` used to print it behind
+/// "Error: " -- so a mistyped flag came back as "Error: error: ..." (#62).
+/// oinkie's own errors carry no prefix of their own and keep theirs.
+///
+/// End to end because the doubling was in `main`, which no unit test reaches:
+/// fixing only the `Display` arm of `Error::Clap` would have changed nothing
+/// a user sees.
+#[test]
+fn test_a_usage_error_is_not_prefixed_twice() {
+    Command::cargo_bin("oinkie")
+        .unwrap()
+        .arg("run")
+        .arg("--bogus-flag")
+        .assert()
+        .failure()
+        .stderr(predicate::str::starts_with("error: "))
+        .stderr(predicate::str::contains("Error: error:").not());
+
+    // and the other arm still says whose error it is
+    let temp_dir = tempdir().unwrap();
+    Command::cargo_bin("oinkie")
+        .unwrap()
+        .arg("extract")
+        .arg("-d")
+        .arg(temp_dir.path().join("birthmarks"))
+        .arg("no-such-file.json")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Error: IO error for"));
+}
+
 #[test]
 fn test_extract_command() {
     let temp_dir = tempdir().unwrap();


### PR DESCRIPTION
Closes #62. **Stacked on #61** (`issue/28_cover_the_cli_layer`) — retarget to `main` once that merges.

## Two things were wrong, and only one of them was the boilerplate

`Display` was a fifty-line match sitting thirty lines away from the variants it described. That is the visible half. The other half:

```rust
impl std::error::Error for Error {}
```

An empty impl, so **`source()` returned `None` for all seventeen variants** — including the seven holding a wrapped error (`Csv`, `Json`, `Io`, `LapJV`, `ShapeError`, `ParseFloat`, `ParseInt`). Nothing in the crate called `source()`, but that is because there was nothing to get. A downstream crate using oinkie as a library got a flat string where it should get a chain.

`#[source]` fixes it, and that is the actual reason to do this.

## Three messages need more than a format string

| variant | why |
| --- | --- |
| `Array(Vec<Self>)` | loops over the children, numbering from 1 |
| `UnsupportedIr` | joins `Ir::readable()` |
| `IncompatibleAnalysis` | calls `cli_name()` twice and `with_shape()` once |

Each is an attribute plus a small helper (`render_group`, `render_readable`, `render_incompatible`). Four variants also needed **named** format arguments — thiserror rejects mixing `{1}` with a positional expression like `.0.display()` as ambiguous, which is a good error to have hit.

## No `#[from]`

- `Io` and `Json` carry the `PathBuf` beside the error, so they could not be `#[from]` anyway — and should not be, since which path failed is the useful half.
- For the rest, the eight explicit `map_err(Error::Csv)` call sites say more than a conversion hidden inside a `?`.

**Nothing converts implicitly through `?` that did not before.**

## The doubled prefix, on both paths

`Error::Clap` rendered as `Clap error: error: ...`, because clap's own message already begins `error: `.

But that arm is **unreachable from the CLI** — `main` prints the wrapped clap error directly rather than through `Display`. So fixing only the variant would have changed nothing a user sees, which is the shape of a half-fix. `main`'s prefix goes too:

```
$ oinkie run --bogus-flag
error: unexpected argument '--bogus-flag' found     # was "Error: error: ..."

$ oinkie extract no-such-file.json
Error: IO error for no-such-file.json: No such file or directory (os error 2)
```

oinkie's own errors carry no prefix of their own, so that arm keeps `Error: `. Exit codes unchanged — 1 for a usage error, 2 for anything else.

`Display` rather than `render().ansi()` there, deliberately: `.ansi()` would have put colour codes into a redirected stderr.

## Verification

**The table from #61 is what makes this checkable.** Sixteen of the seventeen expected strings passed untouched; the seventeenth is the `Clap` line being changed on purpose. That is the whole argument for doing #28 first — before it, `src/lib.rs` was 42.9% covered and this conversion would have been a leap.

Also checked by breaking it:

| mutation | caught by |
| --- | --- |
| `#[source]` dropped from `Io` | `test_a_wrapped_error_is_reachable_as_a_source` |
| `#[source]` dropped from `Json` | same |
| the `Clap error: ` prefix restored | `test_every_error_says_what_it_is` |
| `render_group` numbers from zero | `..._numbers_its_children_from_one`, and the table |
| `main` puts its prefix back | `test_a_usage_error_is_not_prefixed_twice` |

New tests: `source()` is reachable for the wrapped variants and absent for the ones wrapping nothing (`Array` included — its children are the message, not a cause), and the end-to-end check that a usage error is not prefixed twice.

**One blind spot, named rather than papered over.** `UnsupportedIr`'s separator cannot be tested while `Ir::readable()` holds a single entry — `join("")` and `join(", ")` produce the same string for one item, and a mutation of it is *not* caught. The test asserts the invariant instead (every readable representation named, separated `len - 1` times), so it starts biting when a second reader lands, which is exactly when a broken join would otherwise ship unnoticed.

**164 tests**, up from 161. `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` are clean.
