### PR TITLE
perf: read a JSON file whole instead of one syscall per byte

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -128,21 +128,22 @@ Error: IO error for no-such-file.json: No such file or directory (os error 2)
 Scripts matching on the old `Error: error:` text need updating. The exit codes
 are unchanged: 1 for a usage error, 2 for anything else.
 
-**`compare` and `run` stopped making one syscall per byte.** Both loaders
-handed `serde_json::from_reader` a bare `std::fs::File`. serde_json's `IoRead`
-takes one byte at a time, so an unbuffered file meant one `read` syscall per
-byte of JSON (#51). Loading a 9 MB birthmark took **2.7 s**; it now takes
-15 ms.
+**`compare` stopped making one syscall per byte.** `Birthmark::try_from` and
+`Program::try_from` handed `serde_json::from_reader` a bare `std::fs::File`.
+serde_json's `IoRead` takes one byte at a time, so an unbuffered file meant one
+`read` syscall per byte of JSON (#51). Loading a 9 MB birthmark took **2.7 s**;
+it now takes 15 ms.
 
 `compare` loads its inputs once per *pair*, so the loader runs O(n²) times.
 Over three pairs of 9 MB birthmarks the whole command went from **22.0 s to
 7.8 s**, and the kernel time in it from **37.5 s to 0.08 s** — the parsing was
 never the cost. Output is byte-identical.
 
-Nothing to change on your side. `extract` and `run`'s program loading were
-already reading whole files, so the gain is concentrated where birthmarks are
-read: `compare`, `run`, and any code using `Program::try_from` or
-`Birthmark::try_from` as a library.
+Nothing to change on your side, and **`compare` is the only subcommand
+affected**. `extract` and `run` read their programs through `AnyProgram::load`,
+which has read whole files since #45, and neither of them loads a birthmark
+from disk. The other half of the fix is for library callers: `Program::try_from`
+and `Birthmark::try_from` were both slow, and both are public.
 
 ## Library API
 

--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -128,6 +128,22 @@ Error: IO error for no-such-file.json: No such file or directory (os error 2)
 Scripts matching on the old `Error: error:` text need updating. The exit codes
 are unchanged: 1 for a usage error, 2 for anything else.
 
+**`compare` and `run` stopped making one syscall per byte.** Both loaders
+handed `serde_json::from_reader` a bare `std::fs::File`. serde_json's `IoRead`
+takes one byte at a time, so an unbuffered file meant one `read` syscall per
+byte of JSON (#51). Loading a 9 MB birthmark took **2.7 s**; it now takes
+15 ms.
+
+`compare` loads its inputs once per *pair*, so the loader runs O(n²) times.
+Over three pairs of 9 MB birthmarks the whole command went from **22.0 s to
+7.8 s**, and the kernel time in it from **37.5 s to 0.08 s** — the parsing was
+never the cost. Output is byte-identical.
+
+Nothing to change on your side. `extract` and `run`'s program loading were
+already reading whole files, so the gain is concentrated where birthmarks are
+read: `compare`, `run`, and any code using `Program::try_from` or
+`Birthmark::try_from` as a library.
+
 ## Library API
 
 These affect code using oinkie as a crate. The command-line interface is
@@ -321,6 +337,11 @@ now is.
 - **#54** — the tests that run a real Ghidra no longer run at the same time as
   each other, so they cannot corrupt its language cache; two of them that
   differed only in their `-i` path are now one
+- **#51** — birthmark and program files are read whole and parsed from the
+  bytes, rather than through `serde_json::from_reader` on an unbuffered
+  `File`, which cost one syscall per byte. A 9 MB birthmark loads in 15 ms
+  where it took 2.7 s, and a `compare` over three such pairs went from 22.0 s
+  to 7.8 s
 - **`--skip` no longer reads a half-written similarity file as a score of
   zero.** Found by covering the parser it lives in: the score defaulted when
   the `result,` line was absent, so an interrupted run's leftovers came back

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -162,9 +162,20 @@ impl Display for BirthmarkType {
 impl TryFrom<PathBuf> for Birthmark {
     type Error = Error;
 
+    /// Read whole, then parsed from the bytes.
+    ///
+    /// `from_reader` on a bare `File` looks like the obvious thing and is a
+    /// trap: serde_json's `IoRead` takes one byte at a time, so an unbuffered
+    /// file is one `read` syscall per byte. On a 9 MB birthmark that is 2.7 s
+    /// against 15 ms here, and `compare` loads its inputs once per *pair*, so
+    /// the loader runs O(n²) times (#51).
+    ///
+    /// `from_slice` rather than `read_to_string` + `from_str`: bytes that are
+    /// not UTF-8 are the file's content being wrong, and stay a JSON error
+    /// rather than becoming an IO one.
     fn try_from(path: PathBuf) -> Result<Self> {
-        let file = std::fs::File::open(&path).map_err(|e| Error::Io(path.clone(), e))?;
-        serde_json::from_reader(file).map_err(|e| Error::Json(path, e))
+        let bytes = std::fs::read(&path).map_err(|e| Error::Io(path.clone(), e))?;
+        serde_json::from_slice(&bytes).map_err(|e| Error::Json(path, e))
     }
 }
 
@@ -1160,6 +1171,17 @@ mod tests {
         std::fs::write(&broken, b"{ not json").unwrap();
         assert!(matches!(
             Birthmark::try_from(broken).unwrap_err(),
+            Error::Json(..)
+        ));
+
+        // Bytes that are not UTF-8 are the file's content being wrong, not
+        // the read failing, so they come back as a JSON error. This is the
+        // difference between reading to bytes and reading to a String:
+        // `read_to_string` would report `Error::Io` here (#51).
+        let not_utf8 = dir.path().join("not-utf8.json");
+        std::fs::write(&not_utf8, b"{\"name\": \"\xff\xfe\"}").unwrap();
+        assert!(matches!(
+            Birthmark::try_from(not_utf8).unwrap_err(),
             Error::Json(..)
         ));
     }

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -162,7 +162,7 @@ impl Display for BirthmarkType {
 impl TryFrom<PathBuf> for Birthmark {
     type Error = Error;
 
-    /// Read whole, then parsed from the bytes.
+    /// Reads the file whole, then parses the bytes.
     ///
     /// `from_reader` on a bare `File` looks like the obvious thing and is a
     /// trap: serde_json's `IoRead` takes one byte at a time, so an unbuffered

--- a/src/ghidra.rs
+++ b/src/ghidra.rs
@@ -174,9 +174,10 @@ mod tests {
 
     #[test]
     fn parse_pcode_json() {
-        let file = std::fs::File::open("testdata/hello_world/pcodes/hello_clang.json")
-            .expect("Failed to open JSON file");
-        let r: Program<super::Op> = serde_json::from_reader(file).expect("Failed to parse JSON");
+        // Through the loader rather than `from_reader` on a bare `File`, so
+        // that the pattern #51 removed is not left here to be copied.
+        let path = std::path::PathBuf::from("testdata/hello_world/pcodes/hello_clang.json");
+        let r: Program<super::Op> = path.try_into().expect("Failed to parse JSON");
         assert_eq!(r.name(), "hello_clang");
         assert_eq!(
             r.path(),
@@ -232,8 +233,9 @@ mod tests {
 
     #[test]
     fn parse_pcode_json2() {
-        let file = std::fs::File::open("testdata/hello_world/pcodes/hello_gcc.json")
-            .expect("Failed to open JSON file");
-        let _r: Program<super::Op> = serde_json::from_reader(file).expect("Failed to parse JSON");
+        // Through the loader rather than `from_reader` on a bare `File`, so
+        // that the pattern #51 removed is not left here to be copied.
+        let path = std::path::PathBuf::from("testdata/hello_world/pcodes/hello_gcc.json");
+        let _r: Program<super::Op> = path.try_into().expect("Failed to parse JSON");
     }
 }

--- a/src/program.rs
+++ b/src/program.rs
@@ -37,7 +37,7 @@ where
 {
     type Error = Error;
 
-    /// Read whole, then parsed from the bytes, for the reason
+    /// Reads the file whole and parses the bytes, for the reason
     /// [`AnyProgram::load`] already did it that way: serde_json's `IoRead`
     /// takes one byte at a time, so `from_reader` on an unbuffered `File` is
     /// one `read` syscall per byte — 3.3 s against 25 ms on a 10 MB lifted

--- a/src/program.rs
+++ b/src/program.rs
@@ -37,10 +37,14 @@ where
 {
     type Error = Error;
 
+    /// Read whole, then parsed from the bytes, for the reason
+    /// [`AnyProgram::load`] already did it that way: serde_json's `IoRead`
+    /// takes one byte at a time, so `from_reader` on an unbuffered `File` is
+    /// one `read` syscall per byte — 3.3 s against 25 ms on a 10 MB lifted
+    /// file (#51).
     fn try_from(path: PathBuf) -> Result<Self> {
-        std::fs::File::open(&path)
-            .map_err(|e| Error::Io(path.clone(), e))
-            .and_then(|f| serde_json::from_reader(f).map_err(|e| Error::Json(path, e)))
+        let bytes = std::fs::read(&path).map_err(|e| Error::Io(path.clone(), e))?;
+        serde_json::from_slice(&bytes).map_err(|e| Error::Json(path, e))
     }
 }
 
@@ -393,6 +397,55 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(AnyProgram::load(&path), Err(Error::Json(_, _))));
+    }
+
+    /// The loader reads the file whole and parses the bytes (#51). Reading it
+    /// whole is where a change of error semantics could hide, so the three
+    /// ways it fails are pinned: the file not being there is an IO error, and
+    /// both ways its *content* can be wrong are JSON errors.
+    ///
+    /// The last of the three is the one worth having. `read_to_string` +
+    /// `from_str` would look like the same thing and report `Error::Io` for
+    /// bytes that are not UTF-8, moving a fact about the file's content into
+    /// the category for the read failing.
+    #[test]
+    fn test_loading_a_program_reports_the_right_kind_of_failure() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let missing = dir.path().join("missing.json");
+        assert!(matches!(
+            Program::<crate::ghidra::Op>::try_from(missing),
+            Err(Error::Io(..))
+        ));
+
+        let broken = dir.path().join("broken.json");
+        std::fs::write(&broken, b"{ not json").unwrap();
+        assert!(matches!(
+            Program::<crate::ghidra::Op>::try_from(broken),
+            Err(Error::Json(..))
+        ));
+
+        let not_utf8 = dir.path().join("not-utf8.json");
+        std::fs::write(&not_utf8, b"{\"program\": \"\xff\xfe\"}").unwrap();
+        assert!(matches!(
+            Program::<crate::ghidra::Op>::try_from(not_utf8),
+            Err(Error::Json(..))
+        ));
+    }
+
+    /// Reading the file whole must not change what is parsed out of it. The
+    /// fixture is real lifter output, so this compares the loader against
+    /// parsing the same text directly.
+    #[test]
+    fn test_reading_the_file_whole_parses_what_the_text_says() {
+        let fixture = Path::new("testdata/hello_world/pcodes/hello_clang.json");
+        let loaded: Program<crate::ghidra::Op> = fixture.try_into().unwrap();
+        let parsed: Program<crate::ghidra::Op> =
+            serde_json::from_str(&std::fs::read_to_string(fixture).unwrap()).unwrap();
+        assert_eq!(loaded.name(), parsed.name());
+        assert_eq!(loaded.ir(), parsed.ir());
+        assert_eq!(loaded.len(), parsed.len());
+        assert_eq!(loaded.path(), parsed.path());
     }
 
     /// The fixtures are real lifter output, so they must carry what the


### PR DESCRIPTION
Closes #51.

## One `read` syscall per byte

`Birthmark::try_from` and `Program::try_from` handed `serde_json::from_reader` a bare `std::fs::File`. serde_json's `IoRead` takes **one byte at a time**, so an unbuffered file means one `read` syscall per byte of JSON. "Unbuffered" undersells it — that is what turns a missing buffer into a 120x problem rather than a 2x one.

Measured on a 9.1 MB birthmark and a 10.7 MB lifted program, release build:

| | before | after |
| --- | --- | --- |
| `Birthmark::try_from` | 2658 ms | **22 ms** |
| `Program::try_from` | 3259 ms | **21 ms** |

A `BufReader` alone would have reached 26 ms and 32 ms, so the syscalls were the whole of it.

## Where it was actually costing

`compare` loads its inputs once per *pair*, so the loader runs O(n²) times. The same command over three pairs of those birthmarks:

```
before   20.46s user   37.50s system   22.017 total
after    21.94s user    0.08s system    7.754 total
```

User time is unchanged within noise. **37.4 seconds of kernel time is gone** — the parsing was never the cost. Output compared against a build of the parent commit, durations normalised: byte-identical, 2.4 MB of CSV.

## Why `extract` was already fine

`AnyProgram::load` reads to bytes and deserializes twice from them, because it has to probe the `ir` field before it can choose a reader (#45). That fixed program loading for the CLI **incidentally**, which is why `extract` was fast while `compare` was not, and why the issue's "already done" note is narrower than it looks: the library's `Program::try_from` was still slow for anyone using oinkie as a crate, and for the tests.

**`compare` is the only subcommand this speeds up.** `run` and `extract` both go through `AnyProgram::load`, and neither loads a birthmark from disk — `run` extracts and compares in memory. The other half of the fix is for library callers: `Program::try_from` and `Birthmark::try_from` are both public and were both slow.

## `from_slice`, not `read_to_string` + `from_str`

The second looks like the same thing and quietly moves a fact about the file's *content* into the category for the *read* failing: bytes that are not UTF-8 would come back as `Error::Io` instead of `Error::Json`.

That is pinned by a test **written before the change**, which passed against the old reader as well — so it says the semantics are preserved, rather than merely describing the new ones:

```rust
std::fs::write(&not_utf8, b"{\"name\": \"\xff\xfe\"}").unwrap();
assert!(matches!(Birthmark::try_from(not_utf8).unwrap_err(), Error::Json(..)));
```

`Program::try_from` had no error-path tests at all; it now has the same three (missing file → `Error::Io`, malformed JSON → `Error::Json`, invalid UTF-8 → `Error::Json`), plus one asserting the loader parses what parsing the text directly gives.

## No regression test for the timing

Deliberately, and as the issue says. A wall-clock assertion is a poor one to leave in CI. What is left instead is that **no `serde_json::from_reader` on a `File` remains anywhere in the crate** — the two tests in `ghidra.rs` that used the pattern now go through the loader, so it is not sitting there to be copied back.

The `csv` readers are untouched: `csv::Reader` keeps its own internal buffer, so passing it a `File` is not the same mistake.

**167 tests**, up from 165. `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` are clean.

