### PR TITLE
fix: write a k-gram frequency as pairs, not as object keys

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -128,6 +128,37 @@ Error: IO error for no-such-file.json: No such file or directory (os error 2)
 Scripts matching on the old `Error: error:` text need updating. The exit codes
 are unchanged: 1 for a usage error, 2 for anything else.
 
+**`op-*gram-freq` birthmarks can be extracted at all.** Every non-empty one
+failed at write time with
+
+```
+Error: hello_clang_3380b9841726541e.json: JSON error: key must be a string
+```
+
+A k-gram is a list of operations and a JSON object's keys are strings, so
+`serde_json` refused the map outright (#59). Three of the thirty birthmark
+types the CLI offers — `op-1gram-freq` through `op-8gram-freq` and their
+siblings — could not produce a file, and the eight `op-Kgram-freq-*` analyses
+could not be reached through `extract` + `compare`.
+
+It looked as though only small k were affected. It was not: a program with
+fewer than k operations yields an empty map, and an empty map has no key to
+refuse. Any k fails on any program long enough to produce a k-gram.
+
+The frequency map is now written as a list of `[kgram, count]` pairs, sorted,
+so extracting the same program twice writes the same bytes:
+
+```json
+{"KgramFreq": [[["CALL", "COPY"], 1], [["COPY", "COPY"], 1]]}
+```
+
+No existing file changes. `op-*gram-seq` and `op-*gram-set` already wrote a
+k-gram as a plain list and still do — which is why the map was changed rather
+than the k-gram, since making `Kgram` itself serialize as a string would have
+rewritten the two families that work. `run -a op-Kgram-freq-*` was never
+affected: it compares in memory and never writes a birthmark, which is why the
+whole thing went unnoticed.
+
 **`compare` stopped making one syscall per byte.** `Birthmark::try_from` and
 `Program::try_from` handed `serde_json::from_reader` a bare `std::fs::File`.
 serde_json's `IoRead` takes one byte at a time, so an unbuffered file meant one
@@ -338,6 +369,10 @@ now is.
 - **#54** — the tests that run a real Ghidra no longer run at the same time as
   each other, so they cannot corrupt its language cache; two of them that
   differed only in their `-i` path are now one
+- **#59** — `op-*gram-freq` birthmarks can be written. Every non-empty one
+  failed with "key must be a string", so three of the birthmark families the
+  CLI offers could not produce a file; the frequency map is a list of
+  `[kgram, count]` pairs now, and no existing file changes
 - **#51** — birthmark and program files are read whole and parsed from the
   bytes, rather than through `serde_json::from_reader` on an unbuffered
   `File`, which cost one syscall per byte. A 9 MB birthmark loads in 15 ms

--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -136,10 +136,11 @@ Error: hello_clang_3380b9841726541e.json: JSON error: key must be a string
 ```
 
 A k-gram is a list of operations and a JSON object's keys are strings, so
-`serde_json` refused the map outright (#59). Three of the thirty birthmark
-types the CLI offers — `op-1gram-freq` through `op-8gram-freq` and their
-siblings — could not produce a file, and the eight `op-Kgram-freq-*` analyses
-could not be reached through `extract` + `compare`.
+`serde_json` refused the map outright (#59). `op-1gram-freq` through
+`op-8gram-freq` — **eight of the thirty birthmark types** the CLI advertises,
+and one of the three shapes a k-gram comes in — could not produce a file, and
+with them **twenty-four of its eighty analyses** could not be reached through
+`extract` + `compare`.
 
 It looked as though only small k were affected. It was not: a program with
 fewer than k operations yields an empty map, and an empty map has no key to
@@ -151,6 +152,11 @@ so extracting the same program twice writes the same bytes:
 ```json
 {"KgramFreq": [[["CALL", "COPY"], 1], [["COPY", "COPY"], 1]]}
 ```
+
+A k-gram listed twice is refused rather than resolved. The list stands for a
+map, so collecting it would let the last pair win: a file saying a k-gram
+occurred 3 times and again 5 times would load as 5 and be scored, with nothing
+said. Nothing oinkie writes can produce one, since the pairs come from a map.
 
 No existing file changes. `op-*gram-seq` and `op-*gram-set` already wrote a
 k-gram as a plain list and still do — which is why the map was changed rather
@@ -370,9 +376,10 @@ now is.
   each other, so they cannot corrupt its language cache; two of them that
   differed only in their `-i` path are now one
 - **#59** — `op-*gram-freq` birthmarks can be written. Every non-empty one
-  failed with "key must be a string", so three of the birthmark families the
-  CLI offers could not produce a file; the frequency map is a list of
-  `[kgram, count]` pairs now, and no existing file changes
+  failed with "key must be a string", so eight of the thirty birthmark types
+  the CLI advertises could not produce a file and twenty-four of its eighty
+  analyses were unreachable; the frequency map is a list of `[kgram, count]`
+  pairs now, and no existing file changes
 - **#51** — birthmark and program files are read whole and parsed from the
   bytes, rather than through `serde_json::from_reader` on an unbuffered
   `File`, which cost one syscall per byte. A 9 MB birthmark loads in 15 ms

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -427,8 +427,49 @@ pub enum Data {
     Seq(Vec<String>),
     Set(FxHashSet<String>),
     KgramSeq(Vec<Kgram>),
-    KgramFreq(FxHashMap<Kgram, usize>),
+    /// Written as a list of `[kgram, count]` pairs rather than as a JSON
+    /// object.
+    ///
+    /// A JSON object's keys are strings, and a k-gram is a list of
+    /// operations. `serde_json` refuses it — "key must be a string" — so
+    /// every non-empty `op-*gram-freq` birthmark failed at write time and
+    /// three of the families the CLI offers could not produce a file at all
+    /// (#59). It looked k-dependent only because a program with fewer than k
+    /// operations yields an empty map, and an empty map has no key to refuse.
+    ///
+    /// A list of pairs rather than a stringified key, because the alternative
+    /// is to make `Kgram` serialize as a string, and `KgramSeq` and
+    /// `KgramSet` already write it as a list — those two families work, and
+    /// their files would stop reading. It also needs no separator, so no
+    /// mnemonic can ever contain one.
+    KgramFreq(#[serde(with = "kgram_freq")] FxHashMap<Kgram, usize>),
     KgramSet(FxHashSet<Kgram>),
+}
+
+/// `KgramFreq` as a list of pairs. See the variant for why.
+mod kgram_freq {
+    use super::Kgram;
+    use rustc_hash::FxHashMap;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    pub(super) fn serialize<S>(map: &FxHashMap<Kgram, usize>, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Sorted, so that extracting the same program twice writes the same
+        // bytes. A hash map's order is not stable across runs, and a
+        // birthmark file is something people diff and cache.
+        let mut pairs = map.iter().collect::<Vec<_>>();
+        pairs.sort_unstable_by(|(a, _), (b, _)| a.0.cmp(&b.0));
+        pairs.serialize(s)
+    }
+
+    pub(super) fn deserialize<'de, D>(d: D) -> Result<FxHashMap<Kgram, usize>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Vec::<(Kgram, usize)>::deserialize(d)?.into_iter().collect())
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
@@ -1156,6 +1197,110 @@ mod tests {
         assert_eq!(loaded.name(), b.name());
         assert_eq!(loaded.len(), b.len());
         assert!(Birthmark::try_from(path.clone()).is_ok());
+    }
+
+    fn kgram(ops: &[&str]) -> Kgram {
+        Kgram::new(ops.iter().map(|s| s.to_string()).collect())
+    }
+
+    fn kgram_freq_birthmark() -> Birthmark {
+        let mut freq = FxHashMap::default();
+        freq.insert(kgram(&["COPY", "RETURN"]), 1);
+        freq.insert(kgram(&["CALL", "COPY"]), 3);
+        freq.insert(kgram(&["INT_ADD", "COPY"]), 2);
+        Birthmark {
+            metadata: Metadata {
+                birthmark_type: BirthmarkType::OpKgramFreq(2),
+                ..sample_birthmark().metadata
+            },
+            elements: vec![Elements {
+                name: "main".to_string(),
+                data: Data::KgramFreq(freq),
+            }],
+            json_path: None,
+        }
+    }
+
+    /// A k-gram is a list of operations, and a JSON object's keys are
+    /// strings, so `serde_json` refused the map outright — every non-empty
+    /// `op-*gram-freq` birthmark failed at write time and three of the CLI's
+    /// families could not produce a file at all (#59).
+    ///
+    /// A non-empty map is what makes this a test. An empty one has no key to
+    /// refuse, which is why the bug looked as though it only affected small
+    /// k: the fixture yields nothing for k >= 5.
+    #[test]
+    fn test_a_kgram_frequency_birthmark_survives_a_round_trip() {
+        let b = kgram_freq_birthmark();
+        let json = serde_json::to_string(&b).expect("a k-gram frequency must be writable");
+        let back: Birthmark = serde_json::from_str(&json).expect("and readable again");
+
+        let (Data::KgramFreq(before), Data::KgramFreq(after)) =
+            (&b.elements[0].data, &back.elements[0].data)
+        else {
+            panic!("the shape changed");
+        };
+        assert_eq!(before, after);
+        assert_eq!(after[&kgram(&["CALL", "COPY"])], 3);
+    }
+
+    /// Extracting the same program twice should write the same bytes. A hash
+    /// map's iteration order is not stable across runs, so the pairs are
+    /// sorted on the way out.
+    #[test]
+    fn test_a_kgram_frequency_is_written_in_a_stable_order() {
+        // Enough keys, inserted both ways round. Three would not discriminate:
+        // FxHash is not randomised, so a small map's iteration order is
+        // whatever it is and happens to come out sorted. At fifty the order
+        // is neither sorted nor the same for both insertion orders, so this
+        // fails if the sort is removed.
+        let build = |reverse: bool| {
+            let mut ops = (0..50).map(|i| format!("OP_{i:02}")).collect::<Vec<_>>();
+            if reverse {
+                ops.reverse();
+            }
+            let mut freq = FxHashMap::default();
+            for op in ops {
+                // The count comes from the key, not from when it was
+                // inserted, or the two maps would not hold the same thing.
+                let count = op.len();
+                freq.insert(kgram(&[op.as_str(), "COPY"]), count);
+            }
+            serde_json::to_string(&Data::KgramFreq(freq)).unwrap()
+        };
+        assert_eq!(build(false), build(true));
+
+        // The data alone: `sample_birthmark` stamps `Utc::now()` into the
+        // metadata, which is not what this is about.
+        let once = serde_json::to_string(&kgram_freq_birthmark().elements[0].data).unwrap();
+        for _ in 0..8 {
+            let again = serde_json::to_string(&kgram_freq_birthmark().elements[0].data).unwrap();
+            assert_eq!(again, once);
+        }
+        let data = serde_json::to_value(&kgram_freq_birthmark().elements[0].data).unwrap();
+        assert_eq!(
+            data["KgramFreq"],
+            serde_json::json!([
+                [["CALL", "COPY"], 3],
+                [["COPY", "RETURN"], 1],
+                [["INT_ADD", "COPY"], 2],
+            ])
+        );
+    }
+
+    /// Only `KgramFreq` changed. The fix could have been to make `Kgram`
+    /// itself serialize as a string, and that would have rewritten the two
+    /// k-gram families that already work — whose files are readable today.
+    #[test]
+    fn test_the_other_kgram_families_still_write_a_plain_list() {
+        let k = kgram(&["CALL", "COPY"]);
+        let expected = serde_json::json!(["CALL", "COPY"]);
+
+        let seq = serde_json::to_value(Data::KgramSeq(vec![k.clone()])).unwrap();
+        assert_eq!(seq["KgramSeq"][0], expected);
+
+        let set = serde_json::to_value(Data::KgramSet(FxHashSet::from_iter([k]))).unwrap();
+        assert_eq!(set["KgramSet"][0], expected);
     }
 
     #[test]

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -432,9 +432,10 @@ pub enum Data {
     ///
     /// A JSON object's keys are strings, and a k-gram is a list of
     /// operations. `serde_json` refuses it — "key must be a string" — so
-    /// every non-empty `op-*gram-freq` birthmark failed at write time and
-    /// three of the families the CLI offers could not produce a file at all
-    /// (#59). It looked k-dependent only because a program with fewer than k
+    /// every non-empty `op-*gram-freq` birthmark failed at write time.
+    /// `op-1gram-freq` through `op-8gram-freq` — eight of the thirty
+    /// birthmark types the CLI advertises, and one of the three shapes a
+    /// k-gram comes in — could not produce a file at all (#59). It looked k-dependent only because a program with fewer than k
     /// operations yields an empty map, and an empty map has no key to refuse.
     ///
     /// A list of pairs rather than a stringified key, because the alternative
@@ -464,11 +465,30 @@ mod kgram_freq {
         pairs.serialize(s)
     }
 
+    /// A repeated k-gram is refused rather than resolved.
+    ///
+    /// The list is a map on disk, and collecting it would let the last pair
+    /// win silently — a file saying a k-gram occurred 3 times and again 5
+    /// times would load as 5, with a similarity computed from it and nothing
+    /// said. Nothing this crate writes can produce a duplicate, since it
+    /// serializes from a map, so a file holding one has been hand-edited or
+    /// corrupted, and guessing which count was meant is worse than stopping.
     pub(super) fn deserialize<'de, D>(d: D) -> Result<FxHashMap<Kgram, usize>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        Ok(Vec::<(Kgram, usize)>::deserialize(d)?.into_iter().collect())
+        use serde::de::Error as _;
+        let mut map = FxHashMap::default();
+        for (kgram, count) in Vec::<(Kgram, usize)>::deserialize(d)? {
+            if map.contains_key(&kgram) {
+                return Err(D::Error::custom(format!(
+                    "[{}]: the same k-gram is listed twice, so its frequency is ambiguous",
+                    kgram.0.join(", ")
+                )));
+            }
+            map.insert(kgram, count);
+        }
+        Ok(map)
     }
 }
 
@@ -1223,8 +1243,8 @@ mod tests {
 
     /// A k-gram is a list of operations, and a JSON object's keys are
     /// strings, so `serde_json` refused the map outright — every non-empty
-    /// `op-*gram-freq` birthmark failed at write time and three of the CLI's
-    /// families could not produce a file at all (#59).
+    /// `op-*gram-freq` birthmark failed at write time, so eight of the thirty
+    /// birthmark types the CLI advertises could not produce a file (#59).
     ///
     /// A non-empty map is what makes this a test. An empty one has no key to
     /// refuse, which is why the bug looked as though it only affected small
@@ -1286,6 +1306,33 @@ mod tests {
                 [["INT_ADD", "COPY"], 2],
             ])
         );
+    }
+
+    /// A list is a weaker container than the map it stands for: it can say
+    /// the same thing twice. Collecting would take the last one, so a file
+    /// claiming a k-gram occurred 3 times and again 5 times would load as 5
+    /// and be scored, with nothing said about it.
+    ///
+    /// Nothing this crate writes can produce one — the pairs come from a map
+    /// — so refusing costs no real file anything.
+    #[test]
+    fn test_a_kgram_listed_twice_is_refused_rather_than_resolved() {
+        let once: Data =
+            serde_json::from_str(r#"{"KgramFreq":[[["CALL","COPY"],3]]}"#).expect("one is fine");
+        let Data::KgramFreq(m) = once else {
+            panic!("the shape changed");
+        };
+        assert_eq!(m[&kgram(&["CALL", "COPY"])], 3);
+
+        let twice = serde_json::from_str::<Data>(
+            r#"{"KgramFreq":[[["CALL","COPY"],3],[["CALL","COPY"],5]]}"#,
+        );
+        let Err(e) = twice else {
+            panic!("a k-gram listed twice must not silently pick one");
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("listed twice"), "{msg}");
+        assert!(msg.contains("CALL"), "does not say which one: {msg}");
     }
 
     /// Only `KgramFreq` changed. The fix could have been to make `Kgram`

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -482,7 +482,7 @@ mod kgram_freq {
         for (kgram, count) in Vec::<(Kgram, usize)>::deserialize(d)? {
             if map.contains_key(&kgram) {
                 return Err(D::Error::custom(format!(
-                    "[{}]: the same k-gram is listed twice, so its frequency is ambiguous",
+                    "[{}]: listed more than once, so its frequency is ambiguous",
                     kgram.0.join(", ")
                 )));
             }
@@ -1331,7 +1331,7 @@ mod tests {
             panic!("a k-gram listed twice must not silently pick one");
         };
         let msg = e.to_string();
-        assert!(msg.contains("listed twice"), "{msg}");
+        assert!(msg.contains("listed more than once"), "{msg}");
         assert!(msg.contains("CALL"), "does not say which one: {msg}");
     }
 

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -243,14 +243,25 @@ fn test_a_kgram_frequency_birthmark_can_be_written_and_read_back() {
         .assert()
         .success();
 
-    let score = |dir: &std::path::Path| {
+    // Every row, sorted. The rows are written from a parallel iteration, so
+    // which one lands first is not part of the output's meaning -- reading
+    // only the first line made this test depend on a race, and it lost.
+    //
+    // Each row is `index, similarity, left, right, duration`; the duration is
+    // wall clock and the only field that differs between two runs of the same
+    // analysis, so it is dropped.
+    let scores = |dir: &std::path::Path| {
         let csv = fs::read_to_string(dir.join("results.csv")).unwrap();
-        let line = csv.lines().next().unwrap().to_string();
-        // index, similarity, left, right, duration -- the duration is the
-        // only field that differs between two runs of the same analysis
-        line.rsplit_once(',').unwrap().0.to_string()
+        let mut rows: Vec<String> = csv
+            .lines()
+            .filter(|l| !l.starts_with("total duration,"))
+            .map(|l| l.rsplit_once(',').unwrap().0.to_string())
+            .collect();
+        rows.sort();
+        assert!(!rows.is_empty(), "no scores in {}", dir.display());
+        rows
     };
-    assert_eq!(score(&through_a_file), score(&in_memory));
+    assert_eq!(scores(&through_a_file), scores(&in_memory));
 }
 
 #[test]

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -183,6 +183,75 @@ fn test_extract_names_a_kgram_the_way_the_library_does() {
         .stderr(predicate::str::contains("unknown birthmark type"));
 }
 
+/// `op-*gram-freq` birthmarks could not be written at all: a k-gram is a list
+/// of operations, a JSON object's keys are strings, and `serde_json` refused
+/// the map outright (#59). Three of the families the CLI offers could not
+/// produce a file.
+///
+/// `op-2gram-freq` on this fixture rather than a larger k, because the bug
+/// hid behind emptiness: the fixture's one function has four operations, so
+/// k >= 5 yields an empty map and an empty map has no key to refuse. A test
+/// that happened to pick k = 5 would have passed against the bug.
+///
+/// The score is checked against `run`, which computes the same analysis
+/// without ever writing a birthmark. Equal scores say the file round trip is
+/// faithful, not merely that it completed.
+#[test]
+fn test_a_kgram_frequency_birthmark_can_be_written_and_read_back() {
+    let temp_dir = tempdir().unwrap();
+    let birthmarks = temp_dir.path().join("birthmarks");
+    let through_a_file = temp_dir.path().join("through-a-file");
+    let in_memory = temp_dir.path().join("in-memory");
+    let inputs = [
+        "testdata/hello_world/pcodes/hello_clang.json",
+        "testdata/hello_world/pcodes/hello_gcc.json",
+    ];
+
+    Command::cargo_bin("oinkie")
+        .unwrap()
+        .args(["extract", "-b", "op-2gram-freq", "-d"])
+        .arg(&birthmarks)
+        .args(inputs)
+        .assert()
+        .success();
+    let written: Vec<_> = fs::read_dir(&birthmarks)
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .collect();
+    assert_eq!(written.len(), 2, "the birthmarks were not written");
+    assert!(
+        fs::read_to_string(&written[0])
+            .unwrap()
+            .contains("KgramFreq"),
+        "the file does not hold what was asked for"
+    );
+
+    Command::cargo_bin("oinkie")
+        .unwrap()
+        .args(["compare", "-a", "cosine", "-d"])
+        .arg(&through_a_file)
+        .args(&written)
+        .assert()
+        .success();
+
+    Command::cargo_bin("oinkie")
+        .unwrap()
+        .args(["run", "-a", "op-2gram-freq-cosine", "-d"])
+        .arg(&in_memory)
+        .args(inputs)
+        .assert()
+        .success();
+
+    let score = |dir: &std::path::Path| {
+        let csv = fs::read_to_string(dir.join("results.csv")).unwrap();
+        let line = csv.lines().next().unwrap().to_string();
+        // index, similarity, left, right, duration -- the duration is the
+        // only field that differs between two runs of the same analysis
+        line.rsplit_once(',').unwrap().0.to_string()
+    };
+    assert_eq!(score(&through_a_file), score(&in_memory));
+}
+
 #[test]
 fn test_compare_command() {
     let temp_dir = tempdir().unwrap();

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -185,8 +185,9 @@ fn test_extract_names_a_kgram_the_way_the_library_does() {
 
 /// `op-*gram-freq` birthmarks could not be written at all: a k-gram is a list
 /// of operations, a JSON object's keys are strings, and `serde_json` refused
-/// the map outright (#59). Three of the families the CLI offers could not
-/// produce a file.
+/// the map outright (#59). Eight of the thirty birthmark types the CLI
+/// advertises — `op-1gram-freq` through `op-8gram-freq` — could not produce a
+/// file, and with them twenty-four of its eighty analyses.
 ///
 /// `op-2gram-freq` on this fixture rather than a larger k, because the bug
 /// hid behind emptiness: the fixture's one function has four operations, so


### PR DESCRIPTION
Closes #59. **Stacked on #64** (`issue/51_read_json_whole`) — retarget to `main` once that merges.

## Three birthmark families could not produce a file

```
$ oinkie extract -b op-2gram-freq -d /tmp/bm testdata/hello_world/pcodes/hello_clang.json
Extraction completed in 271875 nsec (00:00:000)
Error: /tmp/bm/hello_clang_3380b9841726541e.json: JSON error: key must be a string
```

`Data::KgramFreq` is a map keyed by `Kgram`, a `Kgram` is a list of operations, and a JSON object's keys are strings. `serde_json` refuses it. The extraction succeeds; the *write* fails.

So **eight of the thirty birthmark types** the CLI advertises — `op-1gram-freq` through `op-8gram-freq`, one of the three shapes a k-gram comes in — could not produce a file, and with them **twenty-four of its eighty analyses** could not be reached through `extract` + `compare`. (Counted with `BirthmarkType::advertised()` and `AnalysisType::advertised_names()`; an earlier revision of this PR said "three" and "eight", which was the shape count leaking in.)

**It is not k-dependent, though it looks it.** A program with fewer than k operations yields an empty map, and an empty map has no key to refuse. The `hello_world` fixture has one function of four operations:

| k | before |
| --- | --- |
| 1–4 | `key must be a string` |
| 5+ | "ok" — and an **empty** birthmark |

That is also why nothing caught it: the k that appeared to work was writing an empty file and reading it back successfully.

## Only the map changes, not the k-gram

The issue offered two repairs. The first — make `Kgram` serialize as a string with a separator — is the one to avoid, and checking the format says why:

```json
{"KgramSet": [["COPY", "COPY", "RETURN"], ["CALL", "COPY", "COPY"]]}
```

`KgramSeq` and `KgramSet` already write a k-gram as a plain list. **Those two families work, and their files are readable today** — changing `Kgram`'s own `Serialize` would rewrite both formats to fix a third that has never written anything. Pairs also need no separator, so no mnemonic can ever contain one.

```json
{"KgramFreq": [[["CALL", "COPY"], 1], [["COPY", "COPY"], 1]]}
```

**Sorted on the way out**, so extracting the same program twice writes the same bytes. A hash map's iteration order is not stable across runs, and a birthmark file is something people diff and cache.

**A k-gram listed twice is refused**, not resolved. The list stands for a map, so collecting it would let the last pair win: a file saying a k-gram occurred 3 times and again 5 times would load as 5 and be scored, with nothing said. Nothing oinkie writes can produce one, since the pairs come from a map, so no real file loses anything.

## Verification

**Against a build of the parent commit.** The fourteen families that could write a file — `op-seq/set/freq`, `fc-seq/set/freq`, and `op-{1,2,3,4}gram-{seq,set}` — produce **byte-identical data**. Nothing but `KgramFreq` moved.

k = 1 through 8 now write, read back through `compare`, and the file round trip is checked against `run`, which computes the same analysis **without ever writing a birthmark**. Equal scores say the round trip is faithful, not merely that it completed.

Mutations, each caught:

| mutation | caught by |
| --- | --- |
| the map is written as a JSON object again | the round-trip test, the format test, and the end-to-end test |
| the pairs are not sorted | `..._is_written_in_a_stable_order` |
| duplicates are silently collected | `..._listed_twice_is_refused_rather_than_resolved` |

**The sort took two attempts to test honestly.** Three keys did not discriminate: `FxHash` is not randomised, so a small map's iteration order is whatever it is and happened to come out sorted — the test passed with the sort removed. It now builds fifty keys in both insertion orders, where the order is neither sorted nor the same for both, and removing the sort fails it.

There is also a test asserting `KgramSeq` and `KgramSet` still write a bare list, so nobody unifies the three representations later and breaks the two that work.

**172 tests**, up from 167. `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` are clean.

