### PR TITLE
fix: refuse a frequency the file states twice

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -153,6 +153,21 @@ so extracting the same program twice writes the same bytes:
 {"KgramFreq": [[["CALL", "COPY"], 1], [["COPY", "COPY"], 1]]}
 ```
 
+**A frequency stated twice is refused, in both shapes.** `op-freq` and
+`fc-freq` used serde's derived map deserializer, which inserts in a loop, so a
+birthmark saying `{"COPY": 3, "COPY": 5}` loaded as 5 and was scored with
+nothing said (#66). It is refused now, naming the operation:
+
+```
+COPY: listed twice, so its frequency is ambiguous
+```
+
+Only the frequency shapes changed. A `Set` repeating an element denotes the
+same set and a `Seq` repeating one is a sequence doing its job — neither is
+ambiguous, and both still load. Nothing oinkie writes can produce a repeat in
+any of them, since every map and set is serialized from a map or a set, so no
+file it wrote is affected.
+
 A k-gram listed twice is refused rather than resolved. The list stands for a
 map, so collecting it would let the last pair win: a file saying a k-gram
 occurred 3 times and again 5 times would load as 5 and be scored, with nothing
@@ -375,6 +390,9 @@ now is.
 - **#54** — the tests that run a real Ghidra no longer run at the same time as
   each other, so they cannot corrupt its language cache; two of them that
   differed only in their `-i` path are now one
+- **#66** — a birthmark stating one operation's frequency twice is refused
+  rather than silently read as the last of them, in `op-freq` and `fc-freq` as
+  well as the k-gram shapes
 - **#59** — `op-*gram-freq` birthmarks can be written. Every non-empty one
   failed with "key must be a string", so eight of the thirty birthmark types
   the CLI advertises could not produce a file and twenty-four of its eighty

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -423,7 +423,11 @@ impl Elements {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Data {
-    Freq(FxHashMap<String, usize>),
+    /// An operation named twice is refused, for the reason
+    /// [`kgram_freq::deserialize`] gives: a count the file states twice is
+    /// ambiguous, and serde's derived map deserializer takes the last one
+    /// without saying so (#66).
+    Freq(#[serde(deserialize_with = "no_repeated_key")] FxHashMap<String, usize>),
     Seq(Vec<String>),
     Set(FxHashSet<String>),
     KgramSeq(Vec<Kgram>),
@@ -445,6 +449,53 @@ pub enum Data {
     /// mnemonic can ever contain one.
     KgramFreq(#[serde(with = "kgram_freq")] FxHashMap<Kgram, usize>),
     KgramSet(FxHashSet<Kgram>),
+}
+
+/// Reads a frequency map, refusing a key that appears twice.
+///
+/// serde's derived deserializer inserts in a loop, so `{"COPY": 3, "COPY": 5}`
+/// loads as 5 and nothing is said — a similarity computed from a count the
+/// file contradicts itself about. Nothing this crate writes can produce one,
+/// since it serializes from a map, so refusing costs no real file anything
+/// (#66).
+///
+/// Only the frequency shapes need this. A repeated element in a `Set` denotes
+/// the same set, and a repeated element in a `Seq` is what a sequence is for
+/// — neither is ambiguous. The problem is the contradiction, not the
+/// repetition.
+fn no_repeated_key<'de, D>(d: D) -> std::result::Result<FxHashMap<String, usize>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::{Error as _, MapAccess, Visitor};
+
+    struct Frequencies;
+
+    impl<'de> Visitor<'de> for Frequencies {
+        type Value = FxHashMap<String, usize>;
+
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.write_str("a map of operations to how often each occurs")
+        }
+
+        fn visit_map<M>(self, mut entries: M) -> std::result::Result<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            let mut map = FxHashMap::default();
+            while let Some((name, count)) = entries.next_entry::<String, usize>()? {
+                if map.contains_key(&name) {
+                    return Err(M::Error::custom(format!(
+                        "{name}: listed twice, so its frequency is ambiguous"
+                    )));
+                }
+                map.insert(name, count);
+            }
+            Ok(map)
+        }
+    }
+
+    d.deserialize_map(Frequencies)
 }
 
 /// `KgramFreq` as a list of pairs. See the variant for why.
@@ -1306,6 +1357,63 @@ mod tests {
                 [["INT_ADD", "COPY"], 2],
             ])
         );
+    }
+
+    /// The two frequency shapes agree about a contradiction, and the other
+    /// four correctly do not care.
+    ///
+    /// `Freq` used serde's derived map deserializer, which inserts in a loop,
+    /// so `{"COPY": 3, "COPY": 5}` loaded as 5 with nothing said — the same
+    /// hazard #59 removed from `KgramFreq`, in the family that already worked
+    /// (#66).
+    ///
+    /// The line is ambiguity, not repetition. A `Set` repeating an element
+    /// denotes the same set, so collapsing loses nothing; a `Seq` repeating
+    /// one is a sequence doing its job.
+    #[test]
+    fn test_only_a_contradicted_frequency_is_refused() {
+        let refused = [
+            (r#"{"Freq":{"COPY":3,"COPY":5}}"#, "COPY"),
+            (
+                r#"{"KgramFreq":[[["CALL","COPY"],3],[["CALL","COPY"],5]]}"#,
+                "CALL",
+            ),
+        ];
+        for (json, named) in refused {
+            let Err(e) = serde_json::from_str::<Data>(json) else {
+                panic!("a contradicted frequency must not pick one: {json}");
+            };
+            let msg = e.to_string();
+            assert!(msg.contains("ambiguous"), "{json}: {msg}");
+            assert!(msg.contains(named), "does not say which one: {msg}");
+        }
+
+        // Nothing is contradicted here, so nothing is refused.
+        let accepted = [
+            (r#"{"Set":["COPY","COPY"]}"#, 1),
+            (r#"{"KgramSet":[["CALL","COPY"],["CALL","COPY"]]}"#, 1),
+            (r#"{"Seq":["COPY","COPY"]}"#, 2),
+            (r#"{"KgramSeq":[["CALL","COPY"],["CALL","COPY"]]}"#, 2),
+        ];
+        for (json, len) in accepted {
+            let d: Data = serde_json::from_str(json).unwrap_or_else(|e| panic!("{json}: {e}"));
+            assert_eq!(d.len(), len, "{json}");
+        }
+    }
+
+    /// A frequency map that says each thing once is still read, and read
+    /// whole. Refusing a repeat must not turn into refusing a second key.
+    #[test]
+    fn test_a_frequency_map_with_distinct_keys_is_read_whole() {
+        let Data::Freq(m) =
+            serde_json::from_str::<Data>(r#"{"Freq":{"COPY":3,"CALL":5,"RETURN":1}}"#).unwrap()
+        else {
+            panic!("the shape changed");
+        };
+        assert_eq!(m.len(), 3);
+        assert_eq!(m["COPY"], 3);
+        assert_eq!(m["CALL"], 5);
+        assert_eq!(m["RETURN"], 1);
     }
 
     /// A list is a weaker container than the map it stands for: it can say

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -1380,10 +1380,9 @@ mod tests {
             ),
         ];
         for (json, named) in refused {
-            let Err(e) = serde_json::from_str::<Data>(json) else {
-                panic!("a contradicted frequency must not pick one: {json}");
-            };
-            let msg = e.to_string();
+            let msg = serde_json::from_str::<Data>(json)
+                .expect_err("a contradicted frequency must not pick one")
+                .to_string();
             assert!(msg.contains("ambiguous"), "{json}: {msg}");
             assert!(msg.contains(named), "does not say which one: {msg}");
         }
@@ -1421,10 +1420,9 @@ mod tests {
     #[test]
     fn test_a_frequency_that_is_not_a_map_says_what_was_expected() {
         for json in [r#"{"Freq":[]}"#, r#"{"Freq":"COPY"}"#] {
-            let Err(e) = serde_json::from_str::<Data>(json) else {
-                panic!("{json} is not a frequency map");
-            };
-            let msg = e.to_string();
+            let msg = serde_json::from_str::<Data>(json)
+                .expect_err("this is not a frequency map")
+                .to_string();
             assert!(msg.contains("invalid type"), "{json}: {msg}");
             assert!(
                 msg.contains("expected a map of operations to how often each occurs"),

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -423,10 +423,10 @@ impl Elements {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Data {
-    /// An operation named twice is refused, for the reason
-    /// [`kgram_freq::deserialize`] gives: a count the file states twice is
-    /// ambiguous, and serde's derived map deserializer takes the last one
-    /// without saying so (#66).
+    /// An operation named more than once is refused, for the reason
+    /// [`Data::KgramFreq`] gives: a count the file states twice is ambiguous,
+    /// and serde's derived map deserializer takes the last one without saying
+    /// so (#66).
     Freq(#[serde(deserialize_with = "no_repeated_key")] FxHashMap<String, usize>),
     Seq(Vec<String>),
     Set(FxHashSet<String>),
@@ -486,7 +486,7 @@ where
             while let Some((name, count)) = entries.next_entry::<String, usize>()? {
                 if map.contains_key(&name) {
                     return Err(M::Error::custom(format!(
-                        "{name}: listed twice, so its frequency is ambiguous"
+                        "{name}: listed more than once, so its frequency is ambiguous"
                     )));
                 }
                 map.insert(name, count);

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -1416,6 +1416,23 @@ mod tests {
         assert_eq!(m["RETURN"], 1);
     }
 
+    /// The custom visitor has to say what it wanted, or a file with the wrong
+    /// shape reports "invalid type: sequence, expected " and stops there.
+    #[test]
+    fn test_a_frequency_that_is_not_a_map_says_what_was_expected() {
+        for json in [r#"{"Freq":[]}"#, r#"{"Freq":"COPY"}"#] {
+            let Err(e) = serde_json::from_str::<Data>(json) else {
+                panic!("{json} is not a frequency map");
+            };
+            let msg = e.to_string();
+            assert!(msg.contains("invalid type"), "{json}: {msg}");
+            assert!(
+                msg.contains("expected a map of operations to how often each occurs"),
+                "{json}: {msg}"
+            );
+        }
+    }
+
     /// A list is a weaker container than the map it stands for: it can say
     /// the same thing twice. Collecting would take the last one, so a file
     /// claiming a k-gram occurred 3 times and again 5 times would load as 5


### PR DESCRIPTION
Closes #66. **Stacked on #65** (`issue/59_kgram_freq_key`), which is stacked on #64 — retarget as each merges.

This is the half deliberately left out of #65, split off because fixing it needs new code in a family that already works.

## The behaviour, measured

| variant | duplicate input | before | after |
| --- | --- | --- | --- |
| `Freq` | `{"COPY":3,"COPY":5}` | accepted → `{"COPY":5}` | **refused** |
| `KgramFreq` | the same k-gram twice | refused (#65) | refused |
| `Set` | `["COPY","COPY"]` | accepted → one entry | unchanged |
| `KgramSet` | the same k-gram twice | accepted → one entry | unchanged |
| `Seq` / `KgramSeq` | repeated element | accepted | unchanged |

`Freq` used serde's derived map deserializer, whose visitor inserts in a loop, so the last entry won and nothing was reported. The similarity was then computed from a count the file contradicts itself about — the same shape as #40's empty `fc-*` birthmarks and the zeroed `--skip` score fixed in #61.

```
COPY: listed twice, so its frequency is ambiguous
```

## The line is ambiguity, not repetition

This is why `Set` and `Seq` are untouched, and it is worth stating because "reject duplicates everywhere" is the tempting generalisation:

- A duplicate in a **frequency** is ambiguous: the file states two different counts and there is no way to decide which was meant.
- A duplicate in a **set** is not: whatever the file repeats, the set it denotes is the same one. Collapsing loses nothing.
- A duplicate in a **sequence** is not a duplicate at all — a program repeating an operation is the normal case.

`test_only_a_contradicted_frequency_is_refused` pins all six variants, two refused and four accepted, so the distinction cannot be tidied into a blanket rule later.

## Verification

Nothing oinkie writes can produce a repeat in any variant, since every map and set is serialized from a map or a set — so refusing costs no real file anything.

Checked against a build of the parent commit: `op-freq`, `fc-freq`, `op-seq`, `op-set` and `fc-set` all extract **byte-identical data** and compare to **identical scores**.

Mutations, each caught by `test_only_a_contradicted_frequency_is_refused`:

| mutation | result |
| --- | --- |
| `Freq` goes back to serde's derived map | CAUGHT |
| the visitor stays but the duplicate check is dropped | CAUGHT |

**174 tests**, up from 172. `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` are clean.

## Not done here

`KgramFreq` writes its pairs sorted, so extracting the same program twice produces the same bytes; `Freq` writes a JSON object in hash order and does not. That inconsistency arrived with #65 and is recorded in #66's description rather than fixed here — sorting `Freq` would change the bytes of files that are currently written correctly, which is a decision of its own.
