### PR TITLE
fix: write what has no order of its own in a canonical one

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -153,6 +153,23 @@ so extracting the same program twice writes the same bytes:
 {"KgramFreq": [[["CALL", "COPY"], 1], [["COPY", "COPY"], 1]]}
 ```
 
+**Birthmark files are written in a canonical order.** A map and a set have no
+order of their own, and oinkie wrote them in hash order — which comes from the
+insertion history and the hasher rather than from what the birthmark holds
+(#68). Two equal birthmarks could be written differently, and a `rustc-hash`
+bump would relay every file for no reason.
+
+`Freq`, `Set` and `KgramSet` are sorted on the way out now, joining `KgramFreq`.
+`Seq` and `KgramSeq` are untouched and must be: their order is the program's,
+and sorting them would not canonicalise the file but destroy the birthmark.
+
+Nothing about any file's meaning changes, every existing file still reads, and
+scores are unaffected — checked against a build of the previous commit across
+nine families. What changes is the byte layout of newly written files, so a
+checksum taken over a birthmark from an earlier version will not match one
+taken now, and a `--skip` rerun still skips because it goes by the file
+existing rather than by its contents.
+
 **A frequency stated twice is refused, in both shapes.** `op-freq` and
 `fc-freq` used serde's derived map deserializer, which inserts in a loop, so a
 birthmark saying `{"COPY": 3, "COPY": 5}` loaded as 5 and was scored with
@@ -390,6 +407,9 @@ now is.
 - **#54** — the tests that run a real Ghidra no longer run at the same time as
   each other, so they cannot corrupt its language cache; two of them that
   differed only in their `-i` path are now one
+- **#68** — birthmark files are written in a canonical order, so the bytes are
+  a function of what the birthmark holds rather than of hash order; sequences
+  keep the program's order, which is theirs to keep
 - **#66** — a birthmark stating one operation's frequency twice is refused
   rather than silently read as the last of them, in `op-freq` and `fc-freq` as
   well as the k-gram shapes

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -427,9 +427,12 @@ pub enum Data {
     /// [`Data::KgramFreq`] gives: a count the file states twice is ambiguous,
     /// and serde's derived map deserializer takes the last one without saying
     /// so (#66).
-    Freq(#[serde(deserialize_with = "no_repeated_key")] FxHashMap<String, usize>),
+    Freq(
+        #[serde(serialize_with = "sorted_freq", deserialize_with = "no_repeated_key")]
+        FxHashMap<String, usize>,
+    ),
     Seq(Vec<String>),
-    Set(FxHashSet<String>),
+    Set(#[serde(serialize_with = "sorted_set")] FxHashSet<String>),
     KgramSeq(Vec<Kgram>),
     /// Written as a list of `[kgram, count]` pairs rather than as a JSON
     /// object.
@@ -448,7 +451,45 @@ pub enum Data {
     /// their files would stop reading. It also needs no separator, so no
     /// mnemonic can ever contain one.
     KgramFreq(#[serde(with = "kgram_freq")] FxHashMap<Kgram, usize>),
-    KgramSet(FxHashSet<Kgram>),
+    KgramSet(#[serde(serialize_with = "sorted_kgram_set")] FxHashSet<Kgram>),
+}
+
+/// A map and a set have no order of their own, so the one they are written in
+/// has to come from somewhere. Hash order comes from the insertion history and
+/// the hasher, which means two equal birthmarks can be written differently and
+/// a `rustc-hash` bump relays every file for no reason. Sorted, the bytes are
+/// a function of what the birthmark holds (#68).
+///
+/// `Seq` and `KgramSeq` are not here on purpose. Their order is the program's,
+/// and sorting them would not canonicalise the file — it would destroy the
+/// birthmark.
+fn sorted_freq<S>(map: &FxHashMap<String, usize>, s: S) -> std::result::Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut pairs = map.iter().collect::<Vec<_>>();
+    pairs.sort_unstable_by_key(|(name, _)| *name);
+    s.collect_map(pairs)
+}
+
+/// See [`sorted_freq`].
+fn sorted_set<S>(set: &FxHashSet<String>, s: S) -> std::result::Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut items = set.iter().collect::<Vec<_>>();
+    items.sort_unstable();
+    s.collect_seq(items)
+}
+
+/// See [`sorted_freq`].
+fn sorted_kgram_set<S>(set: &FxHashSet<Kgram>, s: S) -> std::result::Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut items = set.iter().collect::<Vec<_>>();
+    items.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    s.collect_seq(items)
 }
 
 /// Reads a frequency map, refusing a key that appears twice.
@@ -1356,6 +1397,74 @@ mod tests {
                 [["COPY", "RETURN"], 1],
                 [["INT_ADD", "COPY"], 2],
             ])
+        );
+    }
+
+    /// A map and a set have no order of their own, so what gets written has
+    /// to be decided. Hash order decides it by insertion history and by the
+    /// hasher, which means two equal birthmarks can be written differently
+    /// and a `rustc-hash` bump relays every file (#68).
+    ///
+    /// Built twice from the same elements in opposite orders: the bytes have
+    /// to match. Fifty elements rather than a handful, because `FxHash` is
+    /// not randomised and a small container's order can happen to be the
+    /// sorted one either way.
+    #[test]
+    fn test_what_has_no_order_is_written_in_one() {
+        let ops = (0..50).map(|i| format!("OP_{i:02}")).collect::<Vec<_>>();
+        let both_ways = |build: &dyn Fn(Vec<String>) -> Data| {
+            let forward = serde_json::to_string(&build(ops.clone())).unwrap();
+            let mut reversed = ops.clone();
+            reversed.reverse();
+            (forward, serde_json::to_string(&build(reversed)).unwrap())
+        };
+
+        let (a, b) = both_ways(&|v| {
+            let mut m = FxHashMap::default();
+            for op in v {
+                let count = op.len();
+                m.insert(op, count);
+            }
+            Data::Freq(m)
+        });
+        assert_eq!(a, b, "Freq");
+
+        let (a, b) = both_ways(&|v| Data::Set(v.into_iter().collect()));
+        assert_eq!(a, b, "Set");
+
+        let (a, b) = both_ways(&|v| {
+            Data::KgramSet(
+                v.into_iter()
+                    .map(|op| kgram(&[op.as_str(), "COPY"]))
+                    .collect(),
+            )
+        });
+        assert_eq!(a, b, "KgramSet");
+
+        let (a, b) = both_ways(&|v| {
+            let mut m = FxHashMap::default();
+            for op in v {
+                let count = op.len();
+                m.insert(kgram(&[op.as_str(), "COPY"]), count);
+            }
+            Data::KgramFreq(m)
+        });
+        assert_eq!(a, b, "KgramFreq");
+    }
+
+    /// A sequence is ordered data: its order is the program's, and sorting it
+    /// would not canonicalise the file but destroy the birthmark.
+    #[test]
+    fn test_a_sequence_keeps_the_order_it_was_extracted_in() {
+        let ops = vec!["RETURN".to_string(), "CALL".to_string(), "COPY".to_string()];
+        let json = serde_json::to_value(Data::Seq(ops.clone())).unwrap();
+        assert_eq!(json["Seq"], serde_json::json!(["RETURN", "CALL", "COPY"]));
+
+        let kgrams = vec![kgram(&["RETURN", "CALL"]), kgram(&["CALL", "COPY"])];
+        let json = serde_json::to_value(Data::KgramSeq(kgrams)).unwrap();
+        assert_eq!(
+            json["KgramSeq"],
+            serde_json::json!([["RETURN", "CALL"], ["CALL", "COPY"]])
         );
     }
 


### PR DESCRIPTION
Closes #68. **Stacked on #67**, which is stacked on #65 and #64 — retarget as each merges.

This closes the inconsistency #65 introduced: it sorted `KgramFreq`'s pairs and left every other unordered container in hash order.

## What is actually wrong — not what it first looks like

Not "the output changes between runs". `FxHash` is not randomised, so six extractions of the same input produce identical bytes for every family today. That measurement is what makes the real problem visible:

**the order is a function of the insertion history and the hasher, not of the content.**

```
Freq: same bytes for both insertion orders?  false
Set:  same bytes for both insertion orders?  false
```

So two *equal* birthmarks can serialize differently, and a `rustc-hash` or `hashbrown` bump relays every birthmark file for no semantic reason.

## What changed, and what deliberately did not

| variant | before | after |
| --- | --- | --- |
| `Freq` | hash order | **sorted** |
| `Set` | hash order | **sorted** |
| `KgramSet` | hash order | **sorted** |
| `KgramFreq` | sorted (#65) | unchanged |
| `Seq`, `KgramSeq` | the program's order | **unchanged, and must be** |

Fixing only `Freq` would have answered the inconsistency by name and left the same defect in `Set` and `KgramSet` — so all three go together.

**`Seq` and `KgramSeq` are untouched, and `test_a_sequence_keeps_the_order_it_was_extracted_in` says so.** The line is between a container that has *no* order and one whose order *is* the content: sorting a sequence would not canonicalise the file, it would destroy the birthmark.

## Verification

**Against a build of the parent commit, on a 10 MB input** — the `hello_world` fixture is useless here, because its maps are small enough that hash order already comes out sorted and nothing appears to change:

| family | meaning | data layout |
| --- | --- | --- |
| `op-freq`, `fc-freq`, `op-set`, `fc-set`, `op-3gram-set` | unchanged | reordered |
| `op-3gram-freq` | unchanged | unchanged (already sorted) |
| `op-seq`, `fc-seq`, `op-3gram-seq` | unchanged | unchanged |

Scores identical across six family/algorithm pairs, three pairs each.

Two false alarms on the way, both mine and both worth naming: comparing whole files reported the sequence families as relaid, because the metadata carries a timestamp; and `json.dumps(sort_keys=True)` reported the set families as changed in *meaning*, because it sorts object keys and not array elements. The table above is from a variant-aware normalisation — an unordered container compared as a sorted list of its members, an ordered one compared as-is.

The new test builds fifty elements in both insertion orders and requires the bytes to match, for all four unordered variants. Fifty rather than a handful for the same reason the fixture was no good: a small `FxHashMap` can happen to iterate in sorted order and the test would pass with the sort removed.

## Compatibility

Every existing file still reads, and scores are unaffected. What changes is the byte layout of newly written files, so a checksum taken over a birthmark from an earlier version will not match one taken now. `--skip` is unaffected — it goes by the file existing, not by its contents.

**176 tests**, up from 174. `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` and `cargo doc --no-deps` are all clean.
