### PR TITLE
fix: land #66 and #68, which merged into a dead end

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -153,6 +153,23 @@ so extracting the same program twice writes the same bytes:
 {"KgramFreq": [[["CALL", "COPY"], 1], [["COPY", "COPY"], 1]]}
 ```
 
+**Birthmark files are written in a canonical order.** A map and a set have no
+order of their own, and oinkie wrote them in hash order — which comes from the
+insertion history and the hasher rather than from what the birthmark holds
+(#68). Two equal birthmarks could be written differently, and a `rustc-hash`
+bump would relay every file for no reason.
+
+`Freq`, `Set` and `KgramSet` are sorted on the way out now, joining `KgramFreq`.
+`Seq` and `KgramSeq` are untouched and must be: their order is the program's,
+and sorting them would not canonicalise the file but destroy the birthmark.
+
+Nothing about any file's meaning changes, every existing file still reads, and
+scores are unaffected — checked against a build of the previous commit across
+nine families. What changes is the byte layout of newly written files, so a
+checksum taken over a birthmark from an earlier version will not match one
+taken now, and a `--skip` rerun still skips because it goes by the file
+existing rather than by its contents.
+
 **A frequency stated twice is refused, in both shapes.** `op-freq` and
 `fc-freq` used serde's derived map deserializer, which inserts in a loop, so a
 birthmark saying `{"COPY": 3, "COPY": 5}` loaded as 5 and was scored with
@@ -390,6 +407,9 @@ now is.
 - **#54** — the tests that run a real Ghidra no longer run at the same time as
   each other, so they cannot corrupt its language cache; two of them that
   differed only in their `-i` path are now one
+- **#68** — birthmark files are written in a canonical order, so the bytes are
+  a function of what the birthmark holds rather than of hash order; sequences
+  keep the program's order, which is theirs to keep
 - **#66** — a birthmark stating one operation's frequency twice is refused
   rather than silently read as the last of them, in `op-freq` and `fc-freq` as
   well as the k-gram shapes

--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -153,6 +153,21 @@ so extracting the same program twice writes the same bytes:
 {"KgramFreq": [[["CALL", "COPY"], 1], [["COPY", "COPY"], 1]]}
 ```
 
+**A frequency stated twice is refused, in both shapes.** `op-freq` and
+`fc-freq` used serde's derived map deserializer, which inserts in a loop, so a
+birthmark saying `{"COPY": 3, "COPY": 5}` loaded as 5 and was scored with
+nothing said (#66). It is refused now, naming the operation:
+
+```
+COPY: listed twice, so its frequency is ambiguous
+```
+
+Only the frequency shapes changed. A `Set` repeating an element denotes the
+same set and a `Seq` repeating one is a sequence doing its job — neither is
+ambiguous, and both still load. Nothing oinkie writes can produce a repeat in
+any of them, since every map and set is serialized from a map or a set, so no
+file it wrote is affected.
+
 A k-gram listed twice is refused rather than resolved. The list stands for a
 map, so collecting it would let the last pair win: a file saying a k-gram
 occurred 3 times and again 5 times would load as 5 and be scored, with nothing
@@ -375,6 +390,9 @@ now is.
 - **#54** — the tests that run a real Ghidra no longer run at the same time as
   each other, so they cannot corrupt its language cache; two of them that
   differed only in their `-i` path are now one
+- **#66** — a birthmark stating one operation's frequency twice is refused
+  rather than silently read as the last of them, in `op-freq` and `fc-freq` as
+  well as the k-gram shapes
 - **#59** — `op-*gram-freq` birthmarks can be written. Every non-empty one
   failed with "key must be a string", so eight of the thirty birthmark types
   the CLI advertises could not produce a file and twenty-four of its eighty

--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -170,22 +170,27 @@ checksum taken over a birthmark from an earlier version will not match one
 taken now, and a `--skip` rerun still skips because it goes by the file
 existing rather than by its contents.
 
-**A frequency stated twice is refused, in both shapes.** `op-freq` and
-`fc-freq` used serde's derived map deserializer, which inserts in a loop, so a
-birthmark saying `{"COPY": 3, "COPY": 5}` loaded as 5 and was scored with
+**A frequency stated more than once is refused, in both shapes.** `op-freq`
+and `fc-freq` used serde's derived map deserializer, which inserts in a loop,
+so a birthmark saying `{"COPY": 3, "COPY": 5}` loaded as 5 and was scored with
 nothing said (#66). It is refused now, naming the operation:
 
 ```
-COPY: listed twice, so its frequency is ambiguous
+COPY: listed more than once; a birthmark names each operation once
 ```
 
-Only the frequency shapes changed. A `Set` repeating an element denotes the
-same set and a `Seq` repeating one is a sequence doing its job — neither is
-ambiguous, and both still load. Nothing oinkie writes can produce a repeat in
-any of them, since every map and set is serialized from a map or a set, so no
-file it wrote is affected.
+Every repeat is refused, including `{"COPY": 3, "COPY": 3}`, whose counts
+agree: a repeated key is a malformed object however the values fall, and
+reading it would mean accepting a broken file whenever it was broken
+consistently.
 
-A k-gram listed twice is refused rather than resolved. The list stands for a
+Only the frequency shapes changed. A `Set` repeating an element denotes the
+same set and a `Seq` repeating one is a sequence doing its job — neither can
+mean two things, and both still load. Nothing oinkie writes can produce a
+repeat in any of them, since every map and set is serialized from a map or a
+set, so no file it wrote is affected.
+
+A k-gram listed more than once is refused rather than resolved. The list stands for a
 map, so collecting it would let the last pair win: a file saying a k-gram
 occurred 3 times and again 5 times would load as 5 and be scored, with nothing
 said. Nothing oinkie writes can produce one, since the pairs come from a map.

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -423,7 +423,11 @@ impl Elements {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Data {
-    Freq(FxHashMap<String, usize>),
+    /// An operation named twice is refused, for the reason
+    /// [`kgram_freq::deserialize`] gives: a count the file states twice is
+    /// ambiguous, and serde's derived map deserializer takes the last one
+    /// without saying so (#66).
+    Freq(#[serde(deserialize_with = "no_repeated_key")] FxHashMap<String, usize>),
     Seq(Vec<String>),
     Set(FxHashSet<String>),
     KgramSeq(Vec<Kgram>),
@@ -445,6 +449,53 @@ pub enum Data {
     /// mnemonic can ever contain one.
     KgramFreq(#[serde(with = "kgram_freq")] FxHashMap<Kgram, usize>),
     KgramSet(FxHashSet<Kgram>),
+}
+
+/// Reads a frequency map, refusing a key that appears twice.
+///
+/// serde's derived deserializer inserts in a loop, so `{"COPY": 3, "COPY": 5}`
+/// loads as 5 and nothing is said — a similarity computed from a count the
+/// file contradicts itself about. Nothing this crate writes can produce one,
+/// since it serializes from a map, so refusing costs no real file anything
+/// (#66).
+///
+/// Only the frequency shapes need this. A repeated element in a `Set` denotes
+/// the same set, and a repeated element in a `Seq` is what a sequence is for
+/// — neither is ambiguous. The problem is the contradiction, not the
+/// repetition.
+fn no_repeated_key<'de, D>(d: D) -> std::result::Result<FxHashMap<String, usize>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de::{Error as _, MapAccess, Visitor};
+
+    struct Frequencies;
+
+    impl<'de> Visitor<'de> for Frequencies {
+        type Value = FxHashMap<String, usize>;
+
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.write_str("a map of operations to how often each occurs")
+        }
+
+        fn visit_map<M>(self, mut entries: M) -> std::result::Result<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            let mut map = FxHashMap::default();
+            while let Some((name, count)) = entries.next_entry::<String, usize>()? {
+                if map.contains_key(&name) {
+                    return Err(M::Error::custom(format!(
+                        "{name}: listed twice, so its frequency is ambiguous"
+                    )));
+                }
+                map.insert(name, count);
+            }
+            Ok(map)
+        }
+    }
+
+    d.deserialize_map(Frequencies)
 }
 
 /// `KgramFreq` as a list of pairs. See the variant for why.
@@ -1306,6 +1357,63 @@ mod tests {
                 [["INT_ADD", "COPY"], 2],
             ])
         );
+    }
+
+    /// The two frequency shapes agree about a contradiction, and the other
+    /// four correctly do not care.
+    ///
+    /// `Freq` used serde's derived map deserializer, which inserts in a loop,
+    /// so `{"COPY": 3, "COPY": 5}` loaded as 5 with nothing said — the same
+    /// hazard #59 removed from `KgramFreq`, in the family that already worked
+    /// (#66).
+    ///
+    /// The line is ambiguity, not repetition. A `Set` repeating an element
+    /// denotes the same set, so collapsing loses nothing; a `Seq` repeating
+    /// one is a sequence doing its job.
+    #[test]
+    fn test_only_a_contradicted_frequency_is_refused() {
+        let refused = [
+            (r#"{"Freq":{"COPY":3,"COPY":5}}"#, "COPY"),
+            (
+                r#"{"KgramFreq":[[["CALL","COPY"],3],[["CALL","COPY"],5]]}"#,
+                "CALL",
+            ),
+        ];
+        for (json, named) in refused {
+            let Err(e) = serde_json::from_str::<Data>(json) else {
+                panic!("a contradicted frequency must not pick one: {json}");
+            };
+            let msg = e.to_string();
+            assert!(msg.contains("ambiguous"), "{json}: {msg}");
+            assert!(msg.contains(named), "does not say which one: {msg}");
+        }
+
+        // Nothing is contradicted here, so nothing is refused.
+        let accepted = [
+            (r#"{"Set":["COPY","COPY"]}"#, 1),
+            (r#"{"KgramSet":[["CALL","COPY"],["CALL","COPY"]]}"#, 1),
+            (r#"{"Seq":["COPY","COPY"]}"#, 2),
+            (r#"{"KgramSeq":[["CALL","COPY"],["CALL","COPY"]]}"#, 2),
+        ];
+        for (json, len) in accepted {
+            let d: Data = serde_json::from_str(json).unwrap_or_else(|e| panic!("{json}: {e}"));
+            assert_eq!(d.len(), len, "{json}");
+        }
+    }
+
+    /// A frequency map that says each thing once is still read, and read
+    /// whole. Refusing a repeat must not turn into refusing a second key.
+    #[test]
+    fn test_a_frequency_map_with_distinct_keys_is_read_whole() {
+        let Data::Freq(m) =
+            serde_json::from_str::<Data>(r#"{"Freq":{"COPY":3,"CALL":5,"RETURN":1}}"#).unwrap()
+        else {
+            panic!("the shape changed");
+        };
+        assert_eq!(m.len(), 3);
+        assert_eq!(m["COPY"], 3);
+        assert_eq!(m["CALL"], 5);
+        assert_eq!(m["RETURN"], 1);
     }
 
     /// A list is a weaker container than the map it stands for: it can say

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -1380,10 +1380,9 @@ mod tests {
             ),
         ];
         for (json, named) in refused {
-            let Err(e) = serde_json::from_str::<Data>(json) else {
-                panic!("a contradicted frequency must not pick one: {json}");
-            };
-            let msg = e.to_string();
+            let msg = serde_json::from_str::<Data>(json)
+                .expect_err("a contradicted frequency must not pick one")
+                .to_string();
             assert!(msg.contains("ambiguous"), "{json}: {msg}");
             assert!(msg.contains(named), "does not say which one: {msg}");
         }
@@ -1421,10 +1420,9 @@ mod tests {
     #[test]
     fn test_a_frequency_that_is_not_a_map_says_what_was_expected() {
         for json in [r#"{"Freq":[]}"#, r#"{"Freq":"COPY"}"#] {
-            let Err(e) = serde_json::from_str::<Data>(json) else {
-                panic!("{json} is not a frequency map");
-            };
-            let msg = e.to_string();
+            let msg = serde_json::from_str::<Data>(json)
+                .expect_err("this is not a frequency map")
+                .to_string();
             assert!(msg.contains("invalid type"), "{json}: {msg}");
             assert!(
                 msg.contains("expected a map of operations to how often each occurs"),

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -423,10 +423,10 @@ impl Elements {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Data {
-    /// An operation named twice is refused, for the reason
-    /// [`kgram_freq::deserialize`] gives: a count the file states twice is
-    /// ambiguous, and serde's derived map deserializer takes the last one
-    /// without saying so (#66).
+    /// An operation named more than once is refused, for the reason
+    /// [`Data::KgramFreq`] gives: a count the file states twice is ambiguous,
+    /// and serde's derived map deserializer takes the last one without saying
+    /// so (#66).
     Freq(#[serde(deserialize_with = "no_repeated_key")] FxHashMap<String, usize>),
     Seq(Vec<String>),
     Set(FxHashSet<String>),
@@ -486,7 +486,7 @@ where
             while let Some((name, count)) = entries.next_entry::<String, usize>()? {
                 if map.contains_key(&name) {
                     return Err(M::Error::custom(format!(
-                        "{name}: listed twice, so its frequency is ambiguous"
+                        "{name}: listed more than once, so its frequency is ambiguous"
                     )));
                 }
                 map.insert(name, count);

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -1416,6 +1416,23 @@ mod tests {
         assert_eq!(m["RETURN"], 1);
     }
 
+    /// The custom visitor has to say what it wanted, or a file with the wrong
+    /// shape reports "invalid type: sequence, expected " and stops there.
+    #[test]
+    fn test_a_frequency_that_is_not_a_map_says_what_was_expected() {
+        for json in [r#"{"Freq":[]}"#, r#"{"Freq":"COPY"}"#] {
+            let Err(e) = serde_json::from_str::<Data>(json) else {
+                panic!("{json} is not a frequency map");
+            };
+            let msg = e.to_string();
+            assert!(msg.contains("invalid type"), "{json}: {msg}");
+            assert!(
+                msg.contains("expected a map of operations to how often each occurs"),
+                "{json}: {msg}"
+            );
+        }
+    }
+
     /// A list is a weaker container than the map it stands for: it can say
     /// the same thing twice. Collecting would take the last one, so a file
     /// claiming a k-gram occurred 3 times and again 5 times would load as 5

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -424,9 +424,9 @@ impl Elements {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum Data {
     /// An operation named more than once is refused, for the reason
-    /// [`Data::KgramFreq`] gives: a count the file states twice is ambiguous,
-    /// and serde's derived map deserializer takes the last one without saying
-    /// so (#66).
+    /// [`Data::KgramFreq`] gives: serde's derived map deserializer takes the
+    /// last of a repeated key without saying so, and a birthmark names each
+    /// operation once (#66).
     Freq(
         #[serde(serialize_with = "sorted_freq", deserialize_with = "no_repeated_key")]
         FxHashMap<String, usize>,
@@ -492,18 +492,27 @@ where
     s.collect_seq(items)
 }
 
-/// Reads a frequency map, refusing a key that appears twice.
+/// Reads a frequency map, refusing a key that appears more than once.
 ///
 /// serde's derived deserializer inserts in a loop, so `{"COPY": 3, "COPY": 5}`
 /// loads as 5 and nothing is said — a similarity computed from a count the
-/// file contradicts itself about. Nothing this crate writes can produce one,
-/// since it serializes from a map, so refusing costs no real file anything
-/// (#66).
+/// file contradicts itself about (#66).
 ///
-/// Only the frequency shapes need this. A repeated element in a `Set` denotes
-/// the same set, and a repeated element in a `Seq` is what a sequence is for
-/// — neither is ambiguous. The problem is the contradiction, not the
-/// repetition.
+/// Two decisions here, on different axes, and they are easy to run together.
+///
+/// *Which shapes need a check at all* is decided by ambiguity: a repeated
+/// element in a `Set` denotes the same set, and a repeated element in a `Seq`
+/// is what a sequence is for, so neither can mean two things. A repeated
+/// count can, which is why only the frequency shapes have this.
+///
+/// *Which repeats are refused* is not: every one is, without comparing the
+/// values, so `{"COPY": 3, "COPY": 3}` is refused as well. A repeated key is
+/// a malformed object however the values fall, and "a duplicate that happens
+/// to agree with itself" is not a category worth carving out — reading it
+/// would mean accepting a broken file whenever it was broken consistently.
+///
+/// Nothing this crate writes can produce a repeat, since it serializes from a
+/// map, so refusing costs no real file anything.
 fn no_repeated_key<'de, D>(d: D) -> std::result::Result<FxHashMap<String, usize>, D::Error>
 where
     D: Deserializer<'de>,
@@ -527,7 +536,7 @@ where
             while let Some((name, count)) = entries.next_entry::<String, usize>()? {
                 if map.contains_key(&name) {
                     return Err(M::Error::custom(format!(
-                        "{name}: listed more than once, so its frequency is ambiguous"
+                        "{name}: listed more than once; a birthmark names each operation once"
                     )));
                 }
                 map.insert(name, count);
@@ -557,7 +566,8 @@ mod kgram_freq {
         pairs.serialize(s)
     }
 
-    /// A repeated k-gram is refused rather than resolved.
+    /// A repeated k-gram is refused rather than resolved, on the same terms
+    /// as [`no_repeated_key`]: every repeat, without comparing the counts.
     ///
     /// The list is a map on disk, and collecting it would let the last pair
     /// win silently — a file saying a k-gram occurred 3 times and again 5
@@ -574,7 +584,7 @@ mod kgram_freq {
         for (kgram, count) in Vec::<(Kgram, usize)>::deserialize(d)? {
             if map.contains_key(&kgram) {
                 return Err(D::Error::custom(format!(
-                    "[{}]: listed more than once, so its frequency is ambiguous",
+                    "[{}]: listed more than once; a birthmark names each k-gram once",
                     kgram.0.join(", ")
                 )));
             }
@@ -1468,8 +1478,16 @@ mod tests {
         );
     }
 
-    /// The two frequency shapes agree about a contradiction, and the other
-    /// four correctly do not care.
+    /// The two frequency shapes refuse a repeated key and the other four
+    /// correctly do not care.
+    ///
+    /// Both axes are pinned here, because they are easy to run together.
+    /// *Which shapes check*: only the frequencies, because only a repeated
+    /// count can mean two things — a repeated set member denotes the same
+    /// set, a repeated sequence element is a sequence doing its job.
+    /// *Which repeats are refused*: all of them, so a repeat whose counts
+    /// agree is refused too. A repeated key is malformed however the values
+    /// fall.
     ///
     /// `Freq` used serde's derived map deserializer, which inserts in a loop,
     /// so `{"COPY": 3, "COPY": 5}` loaded as 5 with nothing said — the same
@@ -1480,23 +1498,30 @@ mod tests {
     /// denotes the same set, so collapsing loses nothing; a `Seq` repeating
     /// one is a sequence doing its job.
     #[test]
-    fn test_only_a_contradicted_frequency_is_refused() {
+    fn test_only_a_repeated_frequency_is_refused() {
         let refused = [
             (r#"{"Freq":{"COPY":3,"COPY":5}}"#, "COPY"),
             (
                 r#"{"KgramFreq":[[["CALL","COPY"],3],[["CALL","COPY"],5]]}"#,
                 "CALL",
             ),
+            // and the same repeats with counts that agree, which are refused
+            // for being repeats rather than for disagreeing
+            (r#"{"Freq":{"COPY":3,"COPY":3}}"#, "COPY"),
+            (
+                r#"{"KgramFreq":[[["CALL","COPY"],3],[["CALL","COPY"],3]]}"#,
+                "CALL",
+            ),
         ];
         for (json, named) in refused {
             let msg = serde_json::from_str::<Data>(json)
-                .expect_err("a contradicted frequency must not pick one")
+                .expect_err("a repeated key must not be resolved by picking one")
                 .to_string();
-            assert!(msg.contains("ambiguous"), "{json}: {msg}");
+            assert!(msg.contains("listed more than once"), "{json}: {msg}");
             assert!(msg.contains(named), "does not say which one: {msg}");
         }
 
-        // Nothing is contradicted here, so nothing is refused.
+        // Nothing here can mean two things, so nothing is refused.
         let accepted = [
             (r#"{"Set":["COPY","COPY"]}"#, 1),
             (r#"{"KgramSet":[["CALL","COPY"],["CALL","COPY"]]}"#, 1),
@@ -1556,13 +1581,11 @@ mod tests {
         };
         assert_eq!(m[&kgram(&["CALL", "COPY"])], 3);
 
-        let twice = serde_json::from_str::<Data>(
+        let msg = serde_json::from_str::<Data>(
             r#"{"KgramFreq":[[["CALL","COPY"],3],[["CALL","COPY"],5]]}"#,
-        );
-        let Err(e) = twice else {
-            panic!("a k-gram listed twice must not silently pick one");
-        };
-        let msg = e.to_string();
+        )
+        .expect_err("a repeated k-gram must not be resolved by picking one")
+        .to_string();
         assert!(msg.contains("listed more than once"), "{msg}");
         assert!(msg.contains("CALL"), "does not say which one: {msg}");
     }

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -427,9 +427,12 @@ pub enum Data {
     /// [`Data::KgramFreq`] gives: a count the file states twice is ambiguous,
     /// and serde's derived map deserializer takes the last one without saying
     /// so (#66).
-    Freq(#[serde(deserialize_with = "no_repeated_key")] FxHashMap<String, usize>),
+    Freq(
+        #[serde(serialize_with = "sorted_freq", deserialize_with = "no_repeated_key")]
+        FxHashMap<String, usize>,
+    ),
     Seq(Vec<String>),
-    Set(FxHashSet<String>),
+    Set(#[serde(serialize_with = "sorted_set")] FxHashSet<String>),
     KgramSeq(Vec<Kgram>),
     /// Written as a list of `[kgram, count]` pairs rather than as a JSON
     /// object.
@@ -448,7 +451,45 @@ pub enum Data {
     /// their files would stop reading. It also needs no separator, so no
     /// mnemonic can ever contain one.
     KgramFreq(#[serde(with = "kgram_freq")] FxHashMap<Kgram, usize>),
-    KgramSet(FxHashSet<Kgram>),
+    KgramSet(#[serde(serialize_with = "sorted_kgram_set")] FxHashSet<Kgram>),
+}
+
+/// A map and a set have no order of their own, so the one they are written in
+/// has to come from somewhere. Hash order comes from the insertion history and
+/// the hasher, which means two equal birthmarks can be written differently and
+/// a `rustc-hash` bump relays every file for no reason. Sorted, the bytes are
+/// a function of what the birthmark holds (#68).
+///
+/// `Seq` and `KgramSeq` are not here on purpose. Their order is the program's,
+/// and sorting them would not canonicalise the file — it would destroy the
+/// birthmark.
+fn sorted_freq<S>(map: &FxHashMap<String, usize>, s: S) -> std::result::Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut pairs = map.iter().collect::<Vec<_>>();
+    pairs.sort_unstable_by_key(|(name, _)| *name);
+    s.collect_map(pairs)
+}
+
+/// See [`sorted_freq`].
+fn sorted_set<S>(set: &FxHashSet<String>, s: S) -> std::result::Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut items = set.iter().collect::<Vec<_>>();
+    items.sort_unstable();
+    s.collect_seq(items)
+}
+
+/// See [`sorted_freq`].
+fn sorted_kgram_set<S>(set: &FxHashSet<Kgram>, s: S) -> std::result::Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut items = set.iter().collect::<Vec<_>>();
+    items.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+    s.collect_seq(items)
 }
 
 /// Reads a frequency map, refusing a key that appears twice.
@@ -1356,6 +1397,74 @@ mod tests {
                 [["COPY", "RETURN"], 1],
                 [["INT_ADD", "COPY"], 2],
             ])
+        );
+    }
+
+    /// A map and a set have no order of their own, so what gets written has
+    /// to be decided. Hash order decides it by insertion history and by the
+    /// hasher, which means two equal birthmarks can be written differently
+    /// and a `rustc-hash` bump relays every file (#68).
+    ///
+    /// Built twice from the same elements in opposite orders: the bytes have
+    /// to match. Fifty elements rather than a handful, because `FxHash` is
+    /// not randomised and a small container's order can happen to be the
+    /// sorted one either way.
+    #[test]
+    fn test_what_has_no_order_is_written_in_one() {
+        let ops = (0..50).map(|i| format!("OP_{i:02}")).collect::<Vec<_>>();
+        let both_ways = |build: &dyn Fn(Vec<String>) -> Data| {
+            let forward = serde_json::to_string(&build(ops.clone())).unwrap();
+            let mut reversed = ops.clone();
+            reversed.reverse();
+            (forward, serde_json::to_string(&build(reversed)).unwrap())
+        };
+
+        let (a, b) = both_ways(&|v| {
+            let mut m = FxHashMap::default();
+            for op in v {
+                let count = op.len();
+                m.insert(op, count);
+            }
+            Data::Freq(m)
+        });
+        assert_eq!(a, b, "Freq");
+
+        let (a, b) = both_ways(&|v| Data::Set(v.into_iter().collect()));
+        assert_eq!(a, b, "Set");
+
+        let (a, b) = both_ways(&|v| {
+            Data::KgramSet(
+                v.into_iter()
+                    .map(|op| kgram(&[op.as_str(), "COPY"]))
+                    .collect(),
+            )
+        });
+        assert_eq!(a, b, "KgramSet");
+
+        let (a, b) = both_ways(&|v| {
+            let mut m = FxHashMap::default();
+            for op in v {
+                let count = op.len();
+                m.insert(kgram(&[op.as_str(), "COPY"]), count);
+            }
+            Data::KgramFreq(m)
+        });
+        assert_eq!(a, b, "KgramFreq");
+    }
+
+    /// A sequence is ordered data: its order is the program's, and sorting it
+    /// would not canonicalise the file but destroy the birthmark.
+    #[test]
+    fn test_a_sequence_keeps_the_order_it_was_extracted_in() {
+        let ops = vec!["RETURN".to_string(), "CALL".to_string(), "COPY".to_string()];
+        let json = serde_json::to_value(Data::Seq(ops.clone())).unwrap();
+        assert_eq!(json["Seq"], serde_json::json!(["RETURN", "CALL", "COPY"]));
+
+        let kgrams = vec![kgram(&["RETURN", "CALL"]), kgram(&["CALL", "COPY"])];
+        let json = serde_json::to_value(Data::KgramSeq(kgrams)).unwrap();
+        assert_eq!(
+            json["KgramSeq"],
+            serde_json::json!([["RETURN", "CALL"], ["CALL", "COPY"]])
         );
     }
 


### PR DESCRIPTION
Re-lands the work of #67 (closes #66) and #69 (closes #68). Both are marked MERGED, and **neither reached `main`**.

## What happened

The stack was merged bottom-up, but the two upper PRs still pointed at the branches below them:

| PR | merged at | into |
| --- | --- | --- |
| #65 | 00:49:12 | `main` |
| #67 | 00:49:35 | `issue/59_kgram_freq_key` — **already merged into main 23 s earlier** |
| #69 | 00:49:57 | `issue/66_freq_duplicate_keys` — **same** |

So #67 and #69 merged into branches that were already spent. GitHub records them as merged, correctly: they *were* merged, just not anywhere that leads to `main`.

`main` is therefore missing five commits — `src/birthmarks.rs` +238 lines and the release notes +38.

This branch holds the complete result: its tree is **identical** to `issue/66_freq_duplicate_keys`, and it is rebased onto the current `main`, so the diff below is exactly what is missing and nothing else.

## What lands with it

### #66 — a frequency stated twice is refused

`Data::Freq` used serde's derived map deserializer, which inserts in a loop, so `{"COPY": 3, "COPY": 5}` loaded as 5 and was scored with nothing said — the same shape as #40's empty `fc-*` birthmarks and the zeroed `--skip` score in #61.

```
COPY: listed more than once, so its frequency is ambiguous
```

The line is **ambiguity, not repetition**: a `Set` repeating an element denotes the same set and a `Seq` repeating one is a sequence doing its job, so both still load. `test_only_a_contradicted_frequency_is_refused` pins all six variants, two refused and four accepted.

### #68 — birthmark files are written in a canonical order

Sorting `Freq`, `Set` and `KgramSet` on the way out, joining `KgramFreq`. Hash order is a function of the insertion history and the hasher rather than of the content, so two *equal* birthmarks could be written differently and a `rustc-hash` bump would relay every file for nothing.

`Seq` and `KgramSeq` are untouched and must be — their order is the program's, and sorting them would destroy the birthmark rather than canonicalise the file. There is a test saying so.

### Review fixes carried along

The three commits between them are the Copilot points from #67: a private intra-doc link replaced with the public `[Data::KgramFreq]` (`cargo doc --no-deps` is clean), "listed twice" corrected to "listed more than once", and coverage for the visitor's `expecting` message.

## Verification

Unchanged from #67 and #69, and re-run on this rebase:

- Against a build of the previous commit on a 10 MB input, across nine families: **meaning unchanged, scores identical**; layout reordered for the five that were not already sorted, unchanged for `KgramFreq` and the three sequences. The `hello_world` fixture is too small to show it — its maps come out sorted either way.
- Mutations caught: `Freq` back to serde's derived map; the duplicate check dropped; the sort removed from any of the four unordered variants.

**178 tests**. `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` and `cargo doc --no-deps` are all clean.

## After merging

`issue/59_kgram_freq_key`, `issue/66_freq_duplicate_keys` and `issue/68_canonical_order` can all be deleted — no open PR points at any of them.
