### PR TITLE
fix: find where an analysis name splits, rather than assume it

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -219,6 +219,26 @@ which has read whole files since #45, and neither of them loads a birthmark
 from disk. The other half of the fix is for library callers: `Program::try_from`
 and `Birthmark::try_from` were both slow, and both are public.
 
+**An analysis name built from what `oinkie info` prints now parses.** `info`
+lists the algorithms as `weighted-jaccard`, but `run --analysis` only accepted
+`op-freq-weightedjaccard` — a name assembled from what the tool itself showed
+you was refused (#71). Both spellings work now, and so does
+`compare --algorithm weighted-jaccard`, which was always the only one it took.
+
+The other seven algorithms are single words and were already spelled the same
+in both places.
+
+The two halves of an analysis name are no longer split on the last hyphen.
+Each hyphen is tried, rightmost first, and the split whose tail names an
+algorithm and whose head is a birthmark type wins — so an algorithm added
+later may be two words without breaking anything. Every name that parsed
+before still parses, and a name whose birthmark half is wrong still reports
+that half:
+
+```
+op-nonsense-jaccard  ->  op-nonsense: unknown birthmark type
+```
+
 ## Library API
 
 These affect code using oinkie as a crate. The command-line interface is
@@ -412,6 +432,10 @@ now is.
 - **#54** — the tests that run a real Ghidra no longer run at the same time as
   each other, so they cannot corrupt its language cache; two of them that
   differed only in their `-i` path are now one
+- **#71** — an analysis name built from what `oinkie info` prints parses;
+  the split between the two halves is searched for rather than assumed to be
+  the last hyphen, so `weighted-jaccard` works inside a name and a two-word
+  algorithm added later needs no special care
 - **#68** — birthmark files are written in a canonical order, so the bytes are
   a function of what the birthmark holds rather than of hash order; sequences
   keep the program's order, which is theirs to keep

--- a/src/birthmarks.rs
+++ b/src/birthmarks.rs
@@ -701,17 +701,42 @@ impl TryFrom<String> for AnalysisType {
     ///
     /// Only the algorithm name is read here; everything before it is handed to
     /// [`BirthmarkType::try_from`], which is the parser that owns that half.
-    /// Splitting on the last hyphen is safe because no algorithm name contains
-    /// one — `weightedjaccard` is deliberately a single word.
+    ///
+    /// Where the two halves meet is found rather than assumed. Each hyphen is
+    /// tried as the split, rightmost first, and the first one whose tail names
+    /// an algorithm and whose head is a birthmark type wins:
+    ///
+    /// ```text
+    /// op-freq-weighted-jaccard
+    ///         ^ "jaccard" is an algorithm, but "op-freq-weighted" is not a
+    ///           birthmark -- keep looking
+    ///    ^ "weighted-jaccard" is an algorithm and "op-freq" is a birthmark
+    /// ```
+    ///
+    /// It used to split on the last hyphen, which made an algorithm name
+    /// containing one unrepresentable — so `weightedjaccard` was spelled
+    /// without one while `compare --algorithm` and `oinkie info` showed
+    /// clap's `weighted-jaccard`, and a name built from what `info` printed
+    /// was refused (#71). Searching for the split costs a few string
+    /// comparisons on a name a person typed, and removes the rule that a
+    /// future algorithm must not be two words.
     fn try_from(name: String) -> Result<Self> {
         let lowered = name.to_lowercase();
-        let (birthmark, algorithm) = lowered
-            .rsplit_once('-')
-            .ok_or_else(|| Error::BirthmarkType(name.clone()))?;
-        let birthmark = BirthmarkType::try_from(birthmark)?;
-        let algorithm =
-            parse_algorithm(algorithm).ok_or_else(|| Error::BirthmarkType(name.clone()))?;
-        AnalysisType::new(birthmark, algorithm)
+        // The rightmost split that got as far as naming an algorithm, so that
+        // a bad birthmark half is still reported as itself rather than the
+        // whole string being blamed.
+        let mut birthmark_error = None;
+        for (at, _) in lowered.rmatch_indices('-') {
+            let (birthmark, algorithm) = (&lowered[..at], &lowered[at + 1..]);
+            let Some(algorithm) = parse_algorithm(algorithm) else {
+                continue;
+            };
+            match BirthmarkType::try_from(birthmark) {
+                Ok(birthmark) => return AnalysisType::new(birthmark, algorithm),
+                Err(e) => birthmark_error = birthmark_error.or(Some(e)),
+            }
+        }
+        Err(birthmark_error.unwrap_or(Error::BirthmarkType(name)))
     }
 }
 
@@ -736,11 +761,21 @@ impl Shape {
     }
 }
 
+/// An algorithm by either of the names it goes by: the one an analysis name
+/// uses, and clap's kebab-case, which is what `compare --algorithm` takes and
+/// what `oinkie info` prints (#71).
+///
+/// They differ for `weightedjaccard` / `weighted-jaccard` alone; the other
+/// seven are single words and spell the same either way.
 fn parse_algorithm(name: &str) -> Option<Algorithm> {
     use clap::ValueEnum;
     Algorithm::value_variants()
         .iter()
-        .find(|a| a.cli_name() == name)
+        .find(|a| {
+            a.cli_name() == name
+                || a.to_possible_value()
+                    .is_some_and(|value| value.get_name() == name)
+        })
         .cloned()
 }
 
@@ -1034,6 +1069,83 @@ mod tests {
             let at = AnalysisType::try_from(name).unwrap_or_else(|e| panic!("{name}: {e}"));
             assert_eq!(at.birthmark, expected, "name: {name}");
         }
+    }
+
+    /// `compare --algorithm` takes clap's kebab-case and `oinkie info` prints
+    /// it, so an analysis name has to accept it as well or the two halves of
+    /// the CLI disagree about what an algorithm is called (#71).
+    #[test]
+    fn test_an_algorithm_answers_to_both_of_its_spellings() {
+        use clap::ValueEnum;
+        let mut differing = 0;
+        for algorithm in Algorithm::value_variants() {
+            let own = algorithm.cli_name();
+            let kebab = algorithm.to_possible_value().unwrap();
+            let kebab = kebab.get_name();
+            assert_eq!(parse_algorithm(own).unwrap().cli_name(), own);
+            assert_eq!(parse_algorithm(kebab).unwrap().cli_name(), own, "{kebab}");
+            if own != kebab {
+                differing += 1;
+            }
+        }
+        // `weighted-jaccard` is the only one that is spelled two ways; if a
+        // second multi-word algorithm arrives this still holds, and the count
+        // is here so that going to zero is noticed rather than assumed.
+        assert_eq!(differing, 1);
+    }
+
+    /// The property the issue was really about: every name a person can build
+    /// out of what `oinkie info` shows them has to parse.
+    ///
+    /// Generated from the two lists rather than written out, so a two-word
+    /// algorithm added later is covered without anyone remembering to.
+    #[test]
+    fn test_a_name_built_from_what_info_prints_parses() {
+        use clap::ValueEnum;
+        for birthmark in BirthmarkType::advertised() {
+            for algorithm in Algorithm::value_variants() {
+                if !birthmark.pairs_with(algorithm) {
+                    continue;
+                }
+                let shown = algorithm.to_possible_value().unwrap();
+                let name = format!("{birthmark}-{}", shown.get_name());
+                let parsed =
+                    AnalysisType::try_from(name.as_str()).unwrap_or_else(|e| panic!("{name}: {e}"));
+                assert_eq!(parsed.birthmark, birthmark, "{name}");
+            }
+        }
+    }
+
+    /// Where the halves meet is searched for, rightmost hyphen first, rather
+    /// than assumed to be the last one. Both spellings therefore mean the
+    /// same analysis.
+    #[test]
+    fn test_the_split_is_found_rather_than_assumed() {
+        for name in ["op-freq-weighted-jaccard", "op-freq-weightedjaccard"] {
+            let at = AnalysisType::try_from(name).unwrap_or_else(|e| panic!("{name}: {e}"));
+            assert_eq!(at.birthmark, BirthmarkType::OpFreq, "{name}");
+        }
+        let at = AnalysisType::try_from("op-3gram-freq-weighted-jaccard").unwrap();
+        assert_eq!(at.birthmark, BirthmarkType::OpKgramFreq(3));
+    }
+
+    /// Searching must not cost the message. A split that names an algorithm
+    /// but not a birthmark reports the birthmark half, not the whole string.
+    #[test]
+    fn test_a_bad_birthmark_half_is_still_reported_as_itself() {
+        let Err(e) = AnalysisType::try_from("op-nonsense-jaccard") else {
+            panic!("op-nonsense is not a birthmark type");
+        };
+        assert_eq!(e.to_string(), "op-nonsense: unknown birthmark type");
+
+        // nothing names an algorithm here, so there is no half to blame
+        let Err(e) = AnalysisType::try_from("fc-set-jaccard-extra") else {
+            panic!("nothing in this names an algorithm");
+        };
+        assert_eq!(
+            e.to_string(),
+            "fc-set-jaccard-extra: unknown birthmark type"
+        );
     }
 
     #[test]

--- a/src/compare.rs
+++ b/src/compare.rs
@@ -384,9 +384,16 @@ impl std::fmt::Display for Algorithm {
 impl Algorithm {
     /// The CLI spelling of this algorithm and the shape it operates on, in one
     /// table so that the parser, the validation and the error message cannot
-    /// drift apart. Written out rather than derived from `ValueEnum`, whose
-    /// kebab-case would render `WeightedJaccard` as `weighted-jaccard` and put
-    /// a hyphen inside a name that has to be split off by its last one.
+    /// drift apart.
+    ///
+    /// Written out rather than derived from `ValueEnum`, whose kebab-case
+    /// renders `WeightedJaccard` as `weighted-jaccard`. This is the canonical
+    /// spelling inside an analysis name and the one the completion list is
+    /// built from; the kebab-case is accepted there too, since it is what
+    /// `compare --algorithm` takes and what `oinkie info` prints (#71).
+    ///
+    /// A hyphen here is no longer forbidden. It was, while an analysis name
+    /// was split on its last one.
     fn spec(&self) -> (&'static str, Shape) {
         match self {
             Algorithm::Cosine => ("cosine", Shape::Freq),


### PR DESCRIPTION
Closes #71. Not stacked — branches from `main`.

## A name built from what the tool prints was refused

| | accepts | rejects |
| --- | --- | --- |
| `compare -a` | `weighted-jaccard` | `weightedjaccard` |
| `run -a` | `op-freq-weightedjaccard` | `op-freq-weighted-jaccard` |
| what `oinkie info` lists | `weighted-jaccard` | — |

Read `oinkie info`, see `weighted-jaccard`, build an analysis name from it, and it is refused. The spelling that worked appears nowhere in `info`.

Seven of the eight algorithms are single words and spell the same in both places. This is `weighted-jaccard` alone.

## It was not an oversight

`AnalysisType::try_from` split on the **last** hyphen:

```rust
let (birthmark, algorithm) = lowered.rsplit_once('-')?;
```

so an algorithm whose own name contained one could not be represented. `Algorithm::cli_name` said exactly that in a comment, and `weightedjaccard` was deliberately a single word.

The constraint was real. The split was the wrong tool for it.

## Searching for the split

Each hyphen is tried, rightmost first, and the split whose tail names an algorithm **and** whose head parses as a birthmark type wins:

```
op-freq-weighted-jaccard
        ^ "jaccard" is an algorithm, but "op-freq-weighted" is not a
          birthmark -- keep looking
   ^ "weighted-jaccard" is an algorithm and "op-freq" is a birthmark
```

`parse_algorithm` accepts clap's kebab-case beside `cli_name`, so both spellings mean the same analysis.

**Nothing that parsed before stops parsing** — the rightmost split is still tried first, so every existing name resolves on the first attempt exactly as it used to.

**The message is preserved.** Searching would otherwise cost it: a split that names an algorithm but not a birthmark used to propagate the birthmark error, and now has to be remembered instead. It is:

```
op-nonsense-jaccard  ->  op-nonsense: unknown birthmark type
```

not the whole string being blamed.

And the rule that a future algorithm must not be two words goes away, which is the part worth having beyond the immediate fix.

## Verification

The test that matters is **generated from the two lists** rather than written out — for every advertised birthmark and every algorithm that pairs with its shape, the name built from what `info` prints must parse. A two-word algorithm added later is covered without anyone remembering to.

Mutations, each caught:

| mutation | caught by |
| --- | --- |
| back to splitting on the last hyphen | `..._built_from_what_info_prints_parses`, `..._split_is_found_rather_than_assumed` |
| kebab-case no longer accepted | those two, plus `..._answers_to_both_of_its_spellings` |
| the bad-birthmark error is discarded | `..._still_reported_as_itself` |

End to end, on the real binary: `op-freq-weighted-jaccard`, `op-freq-weightedjaccard` and `op-3gram-freq-weighted-jaccard` all run; `op-seq-euclidean` still names the canonical pairing; `op-nonsense-jaccard` and `fc-set-jaccard-extra` are still refused.

**182 tests**, up from 178. `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` and `cargo doc --no-deps` are clean.
