### PR TITLE
docs: regenerate the CLI reference from the CLI

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -436,6 +436,11 @@ now is.
   the split between the two halves is searched for rather than assumed to be
   the last hyphen, so `weighted-jaccard` works inside a name and a two-word
   algorithm added later needs no special care
+- **LLVM IR/BC is no longer named as a target.** The tagline and the site
+  described oinkie as a toolkit for "Ghidra Pcode, LLVM IR/BC, and Binary
+  Ninja", but LLVM is in neither `Ir` nor `LifterType` and is not in the
+  multi-lifter design work, which is about Binary Ninja and IDA Pro. The
+  documentation says what is there and what is planned
 - **The CLI reference matches the CLI.** `cli/README.md` documented
   `-B/--binary-type`, which this release removes, and was missing `lift -j`
   and `run -A`; `lift`'s lifter list still read `ghidra, llvm, binary-ninja`

--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -436,6 +436,12 @@ now is.
   the split between the two halves is searched for rather than assumed to be
   the last hyphen, so `weighted-jaccard` works inside a name and a two-word
   algorithm added later needs no special care
+- **The CLI reference matches the CLI.** `cli/README.md` documented
+  `-B/--binary-type`, which this release removes, and was missing `lift -j`
+  and `run -A`; `lift`'s lifter list still read `ghidra, llvm, binary-ninja`
+  where it is `ghidra, angr, ida-pro, binary-ninja`; and the `oinkie info`
+  sample in the site docs was from v0.2.0 and showed a section the command
+  does not print. All of it is regenerated from the real output
 - **#68** — birthmark files are written in a canonical order, so the bytes are
   a function of what the birthmark holds rather than of hash order; sequences
   keep the program's order, which is theirs to keep

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Docker](https://img.shields.io/badge/Container-quay.io/tama5/oinkie:0.3.0-blue?logo=docker)](https://quay.io/repository/tama5/oinkie)
 
-Detecting software theft, the birthmark toolkit for Ghidra Pcode, LLVM IR/BC, and Binary Ninja.
+Detecting software theft, the birthmark toolkit for Ghidra P-code, with Binary Ninja and IDA Pro planned.
 
 ![Logo of oinkie](.github/assets/oinkie.png)
 
@@ -37,7 +37,7 @@ It is derived from the binary code of the software and can be used to detect sof
 To examine the birthmarks, we apply the following steps:
 
 1. Collects the binary files to be examined.
-2. Lifts binary files to an intermediate representation (IR), such as Ghidra PCODE or LLVM IR/BC.
+2. Lifts binary files to an intermediate representation (IR), such as Ghidra's P-code.
 3. Extracts the birthmarks from the lifted IR files.
 4. Compares the birthmarks to calculate the similarities.
 5. Analyze the results to determine if software theft is suspected.
@@ -112,7 +112,7 @@ Note that the birthmark method just detects potential copies; it does not prove 
 
 The previous version of this tool is [`pochi`](https://github.com/tamada/pochi), which is the birthmark toolkit for the JVM platform. The `pochi` is a dog that said "dig dig, here" and finds the treasures in the Japanese old tale "The old man who made flowers bloom." The tool finds clues of piracy from the binary code, as illustrated by the example of the dog above.
 
-The purpose of `oinkie` is the same as `pochi`'s on the other platform: LLVM IR/BC. Hence, another tool name is wanted, such as an animal, a concept, or a famous person. From this background, I came up with the idea of a pig finding a truffle. However, truffle is already used in [GraalVM](https://www.graalvm.org/latest/graalvm-as-a-platform/language-implementation-framework/). Then I asked Microsoft Copilot, "What is the famous name of the truffle pig?" The name `oinkie` is one answer to the question.
+The purpose of `oinkie` is the same as `pochi`'s, on the other platform: native binaries rather than the JVM. Hence, another tool name is wanted, such as an animal, a concept, or a famous person. From this background, I came up with the idea of a pig finding a truffle. However, truffle is already used in [GraalVM](https://www.graalvm.org/latest/graalvm-as-a-platform/language-implementation-framework/). Then I asked Microsoft Copilot, "What is the famous name of the truffle pig?" The name `oinkie` is one answer to the question.
 
 ### 🎃 The logo of `oinkie`
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -11,7 +11,7 @@ Usage: oinkie [OPTIONS] <COMMAND>
 
 Commands:
   info         Display information about the application
-  lift         Lift binary files to P-code JSON files using a specified lifter
+  lift         Lift binary files to JSON files of an intermediate representation, using a specified lifter
   extract      Extract birthmarks from a lifted binary file (JSON format)
   compare      Compare birthmarks and output the similarity score
   reaggregate  Reaggregate the element-wise similarity scores and recalculate the birthmark-wise similarity score
@@ -19,8 +19,7 @@ Commands:
   help         Print this message or the help of the given subcommand(s)
 
 Options:
-  -l, --level <LEVEL>  Log level for the application [default: warn]
-                       [possible values: error, warn, info, debug, trace, off]
+  -l, --level <LEVEL>  Log level for the application [default: warn] [possible values: error, warn, info, debug, trace, off]
   -h, --help           Print help
   -V, --version        Print version
 ```
@@ -30,7 +29,7 @@ Options:
 This command lifts binary files into Oinkie-IR files (P-code JSON format), which are used as inputs for the `extract` command.
 
 ```sh
-Lift binary files to P-code JSON files using a specified lifter
+Lift binary files to JSON files of an intermediate representation, using a specified lifter
 
 Usage: oinkie lift [OPTIONS] [FILES]...
 
@@ -38,25 +37,14 @@ Arguments:
   [FILES]...  Path to the binary or intermediate files to lift
 
 Options:
-  -d, --dest <DIRECTORY>
-          Specify the directory for putting the resultant JSON files for the lifted P-code
-          (default: './pcodes' directory) [default: pcodes]
-  -l, --lifter-type <LIFTER_TYPE>
-          Specify the lifter type [default: ghidra]
-          [possible values: ghidra, llvm, binary-ninja]
-  -H, --home <HOME>
-          Specify the path to the home directory of the lifter (e.g., GHIDRA_HOME for Ghidra).
-          If not specified, the environment variable (e.g., GHIDRA_HOME) or default paths are searched.
-  -i, --intermediate <DIRECTORY>
-          Directory to keep intermediate files like Ghidra project directories.
-          If not specified, a temporary directory is used and deleted.
-      --script <SCRIPT>
-          Path to a custom lifting script. Interpretation depends on the lifter type.
-          For Ghidra, it's the path to a Java script.
-  -S, --skip
-          Skip if the resultant JSON file already exists
-  -h, --help
-          Print help
+  -d, --dest <DIRECTORY>           Specify the directory for putting the resultant JSON files of the lifted programs (default: './pcodes' directory) [default: pcodes]
+  -l, --lifter-type <LIFTER_TYPE>  Specify the lifter type [default: ghidra] [possible values: ghidra, angr, ida-pro, binary-ninja]
+  -H, --home <HOME>                Path to the lifter's installation directory. If not specified, the lifter's own environment variable (GHIDRA_HOME for Ghidra) is read, then the usual install locations are searched. The error names which variable to set.
+  -i, --intermediate <DIRECTORY>   Directory for the lifter to work in, kept rather than discarded. Every lifter runs in one, since that is where its script writes; Ghidra also keeps its project there. If not specified, a temporary directory is used and deleted.
+      --script <SCRIPT>            Path to a custom lifting script, replacing the built-in one. The language is the lifter's own: Java for Ghidra. It must write {input file name}.json into its working directory.
+  -j, --jobs <N>                   Lift up to N files at a time (default: 1, one after another). Lifting runs a whole decompiler process per file, and several of them against a Ghidra installation whose language cache has not been built yet can corrupt it, so parallelism is opt-in. [default: 1]
+  -S, --skip                       Skip if the resultant JSON file already exists
+  -h, --help                       Print help
 ```
 
 ### `extract` command
@@ -67,15 +55,14 @@ The lifted binary files are obtained by [`lift` command](#lift-command)
 ```sh
 Extract birthmarks from a lifted binary file (JSON format)
 
-Usage: oinkie extract [OPTIONS] [FILES]...
+Usage: oinkie extract [OPTIONS] [JSON_FILES]...
 
 Arguments:
-  [FILES]...  Path to the JSON files to extract birthmarks from
+  [JSON_FILES]...  Path to the JSON files to extract birthmarks from
 
 Options:
-  -d, --dest <DEST>
-          Specify the directory for putting the resultant JSON files for the extracted birthmarks
-          (default: './birthmarks' directory) [default: birthmarks]
+  -d, --dest <DIRECTORY>
+          Specify the directory for putting the resultant JSON files for the extracted birthmarks (default: './birthmarks' directory) [default: birthmarks]
   -b, --birthmark-type <BIRTHMARK_TYPE>
           Type of birthmark to extract.
           fc (Function Calls) and op (Opcode) with set, seq, and freq variants are supported.
@@ -86,9 +73,6 @@ Options:
           The full birthmark types can be found by running 'oinkie info'. [default: op-seq]
   -S, --skip
           Skip the resultant birthmark file is already exists
-  -B, --binary-type <BINARY_TYPE>
-          Type of binary. Current version only supports Ghidra JSON format [default: ghidra]
-          [possible values: ghidra, llvm, binary-ninja]
   -h, --help
           Print help
 ```
@@ -101,29 +85,59 @@ Compare birthmarks and output the similarity score
 Usage: oinkie compare [OPTIONS] [JSON_FILES]...
 
 Arguments:
-  [JSON_FILES]...  Path to the birthmark JSON files to compare
+  [JSON_FILES]...
+          Path to the birthmark JSON files to compare
 
 Options:
   -a, --algorithm <ALGORITHM>
-      Specify the similarity calculation algorithm. [default: jaccard]
-      [possible values: cosine, dice, euclidean, jaccard, levenshtein, lcs, simpson, weighted-jaccard]
+          Specify the similarity calculation algorithm.
+
+          Possible values:
+          - cosine:           Cosine similarity based on term frequency vectors. Available: seq and freq
+          - dice:             Dice coefficient. Available: seq, set and freq
+          - euclidean:        Euclidean distance between term frequency vectors. Available: seq and freq
+          - jaccard:          Jaccard index. Available: seq, set and freq
+          - levenshtein:      Levenshtein distance. Available: seq
+          - lcs:              Longest Common Subsequence (LCS). Available: seq
+          - simpson:          Simpson's coefficient. Available: seq, set and freq
+          - weighted-jaccard: Weighted Jaccard index based on term frequency vectors. Available: seq and freq
+          
+          [default: jaccard]
+
   -A, --aggregator <METHOD>
-      Specify the aggregator for combining element-wise similarity scores into a birthmark-wise similarity score.
-      Available:
-      - hungarian  Use the Hungarian algorithm to find the optimal matching between elements of two birthmarks,
-                   maximizing the total similarity score.
-      - topn:N     For each element in the first birthmark, consider only the top N most similar elements in the
-                   second birthmark when calculating the overall similarity score. This can reduce noise from less
-                   relevant matches and focus on the most significant similarities. [default: hungarian]
+          Specify the aggregator for combining element-wise similarity scores into a birthmark-wise similarity score.
+          Available:
+          - hungarian  Use the Hungarian algorithm to find the optimal matching between elements of two birthmarks,
+                       maximizing the total similarity score.
+          - topn:N     For each element in the first birthmark, consider only the top N most similar elements in the
+                       second birthmark when calculating the overall similarity score. This can reduce noise from less
+                       relevant matches and focus on the most significant similarities.
+          
+          [default: hungarian]
+
   -s, --strategy <STRATEGY>
-      Specify the pairing strategy for comparing files. [default: all-and-self]
-      [possible values: all-and-self, all, self-coverage, adjacent, first-vs-others]
+          Specify the pairing strategy for comparing files.
+
+          Possible values:
+          - all-and-self:    All possible combinations including self-comparisons ($_nC_2 + n$). Used for full matrix visualization or comprehensive heatmaps
+          - all:             Compares all possible combinations ($_nC_2$). Used for comprehensive validation of accuracy (False Positive / True Positive)
+          - self-coverage:   Compares each file with itself ($n$). Used for sanity checks to ensure identical files yield a similarity score of 1.0
+          - adjacent:        Compares only adjacent pairs in the list ($n-1$). Useful for comparing sequential versions (e.g., v1.0 vs v1.1, v1.1 vs v1.2)
+          - first-vs-others: Compares a specific reference file against all other files ($n-1$). Compares first item and all other items. Useful for comparing a baseline version against multiple variants
+          - last-vs-others:  Compares a specific reference file against all other files ($n-1$). Compares the last item and all other items. Useful for comparing a baseline version against multiple variants
+          
+          [default: all-and-self]
+
   -d, --dest <DIRECTORY>
-      Specify the destination directory for the comparing results [default: similarities]
+          Specify the destination directory for the comparing results
+          
+          [default: similarities]
+
   -S, --skip
-      Skip if the similarity file already exists for the pair of birthmarks
+          Skip if the similarity file already exists for the pair of birthmarks
+
   -h, --help
-      Print help (see more with '--help')
+          Print help (see a summary with '-h')
 ```
 
 ### `reaggregate` command
@@ -139,19 +153,16 @@ Arguments:
   <SCORE_DIRECTORY>  Path to the directory containing the element-wise similarity scores
 
 Options:
-  -A, --aggregator <METHOD>
-          Specify the aggregator for combining element-wise similarity scores into a birthmark-wise similarity score.
-          Available:
-          - hungarian  Use the Hungarian algorithm to find the optimal matching between elements of two birthmarks,
-                       maximizing the total similarity score.
-          - topn:N     For each element in the first birthmark, consider only the top N most similar elements in the
-                       second birthmark when calculating the overall similarity score. This can reduce noise from less
-                       relevant matches and focus on the most significant similarities. [default: hungarian]
-  -d, --dest-file <RESULT.CSV>
-          Specify the result CSV file of the comparing results to reaggregate.
-          The file contains the birthmark-wise similarity score list. [default: reaggregate.csv]
-  -h, --help
-          Print help
+  -A, --aggregator <METHOD>     Specify the aggregator for combining element-wise similarity scores into a birthmark-wise similarity score.
+                                Available:
+                                - hungarian  Use the Hungarian algorithm to find the optimal matching between elements of two birthmarks,
+                                             maximizing the total similarity score.
+                                - topn:N     For each element in the first birthmark, consider only the top N most similar elements in the
+                                             second birthmark when calculating the overall similarity score. This can reduce noise from less
+                                             relevant matches and focus on the most significant similarities. [default: hungarian]
+  -d, --dest-file <RESULT.CSV>  Specify the result CSV file of the comparing results to reaggregate.
+                                The file contains the birthmark-wise similarity score list. [default: reaggregate.csv]
+  -h, --help                    Print help
 ```
 
 ### `run` command
@@ -162,20 +173,49 @@ Extract birthmarks and compare them in one command
 Usage: oinkie run [OPTIONS] [FILES]...
 
 Arguments:
-  [FILES]...  Path to the JSON files
+  [FILES]...
+          Path to the JSON files
 
 Options:
   -a, --analysis <ANALYSIS>
           Analysis to run, as '{birthmark}-{algorithm}' -- for example 'op-set-jaccard' or 'op-3gram-freq-cosine'.
           Run 'oinkie info' for the birthmarks and the algorithms they pair with. Any k
-          parses in a k-gram name, not only the ones listed. [default: op-set-jaccard]
+          parses in a k-gram name, not only the ones listed.
+          
+          [default: op-set-jaccard]
+
   -s, --strategy <STRATEGY>
-          Pairing strategy for file comparisons [default: all-and-self]
-          [possible values: all-and-self, all, self-coverage, adjacent, first-vs-others]
+          Pairing strategy for file comparisons
+
+          Possible values:
+          - all-and-self:    All possible combinations including self-comparisons ($_nC_2 + n$). Used for full matrix visualization or comprehensive heatmaps
+          - all:             Compares all possible combinations ($_nC_2$). Used for comprehensive validation of accuracy (False Positive / True Positive)
+          - self-coverage:   Compares each file with itself ($n$). Used for sanity checks to ensure identical files yield a similarity score of 1.0
+          - adjacent:        Compares only adjacent pairs in the list ($n-1$). Useful for comparing sequential versions (e.g., v1.0 vs v1.1, v1.1 vs v1.2)
+          - first-vs-others: Compares a specific reference file against all other files ($n-1$). Compares first item and all other items. Useful for comparing a baseline version against multiple variants
+          - last-vs-others:  Compares a specific reference file against all other files ($n-1$). Compares the last item and all other items. Useful for comparing a baseline version against multiple variants
+          
+          [default: all-and-self]
+
   -d, --dest <DEST>
-          Destination path for the output CSV file (default: 'similarities' directory [default: similarities]
+          Destination path for the output CSV file (default: 'similarities' directory
+          
+          [default: similarities]
+
+  -A, --aggregator <METHOD>
+          Specify the aggregator for combining element-wise similarity scores into a birthmark-wise similarity score.
+          Available:
+          - hungarian  Use the Hungarian algorithm to find the optimal matching between elements of two birthmarks,
+                       maximizing the total similarity score.
+          - topn:N     For each element in the first birthmark, consider only the top N most similar elements in the
+                       second birthmark when calculating the overall similarity score. This can reduce noise from less
+                       relevant matches and focus on the most significant similarities. available topn:N or topn:all (same as topn).
+          
+          [default: hungarian]
+
   -S, --skip
           Skip if the similarity file already exists for the pair of birthmarks
+
   -h, --help
-          Print help (see more with '--help')
+          Print help (see a summary with '-h')
 ```

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "oinkie 🐽🐷🐖"
-description: "Detecting software theft, the birthmark toolkit for Ghidra Pcode, LLVM IR/BC, and Binary Ninja."
+description: "Detecting software theft, the birthmark toolkit for Ghidra P-code, with Binary Ninja and IDA Pro planned."
 date: 2026-06-22
 draft: false
 outputs:
@@ -21,7 +21,7 @@ outputs:
 
 **oinkie** is a software birthmark toolkit designed for detecting software theft. It extracts unique characteristics (birthmarks) of software from binary formats and compares them to identify suspected plagiarism.
 
-Currently, **oinkie** supports extracting and comparing birthmarks from Ghidra Pcode, and planned support includes LLVM IR/BC and Binary Ninja.
+Currently, **oinkie** supports extracting and comparing birthmarks from Ghidra P-code. Support for Binary Ninja and IDA Pro is planned; the trade-offs are being worked out in the multi-lifter design note.
 
 ---
 

--- a/docs/content/about.md
+++ b/docs/content/about.md
@@ -16,7 +16,7 @@ Learn about the story behind **oinkie**, its playful branding, and the academic 
 The predecessor of **oinkie** is [**pochi**](https://github.com/tamada/pochi), a Java-centric software birthmark toolkit. 
 
 * **The Story of `pochi`:** In Japanese folklore ("The Old Man Who Made Flowers Bloom"), a faithful dog named **Pochi** digs in the ground saying *"dig dig here!"* and helps his kind owner find buried gold. Similarly, the `pochi` tool digs through compiled bytecode to uncover hidden software theft and plagiarism.
-* **The Story of `oinkie`:** Because **oinkie** was designed to extend birthmarking concepts into new domains (like LLVM IR and platform-agnostic P-code representations), a new animal mascot was needed. In the culinary world, pigs are famous for their unmatched ability to sniff out hidden, highly valuable truffles. When asked "What is a famous name for a truffle pig?", Microsoft Copilot suggested the name **oinkie**. Thus, **oinkie** was born—a pig sniffing out hidden code plagiarism inside binary executables.
+* **The Story of `oinkie`:** Because **oinkie** was designed to extend birthmarking concepts into new domains — binary executables, by way of the intermediate representations a decompiler lifts them to — a new animal mascot was needed. In the culinary world, pigs are famous for their unmatched ability to sniff out hidden, highly valuable truffles. When asked "What is a famous name for a truffle pig?", Microsoft Copilot suggested the name **oinkie**. Thus, **oinkie** was born—a pig sniffing out hidden code plagiarism inside binary executables.
 
 ---
 

--- a/docs/content/usage/info.md
+++ b/docs/content/usage/info.md
@@ -27,39 +27,56 @@ oinkie info [OPTIONS]
 Running the `info` command provides detailed listings of supported formats and algorithms in your current environment:
 
 ```text
-oinkie v0.2.0
-Detecting software theft, the birthmark toolkit for Ghidra Pcode, LLVM IR/BC, and Binary Ninja.
-
-Supported Birthmark Types:
-  - fc-seq (Function Calls Sequence)
-  - fc-freq (Function Calls Frequency)
-  - fc-set (Function Calls Set)
-  - op-seq (Opcode Sequence)
-  - op-freq (Opcode Frequency)
-  - op-set (Opcode Set)
-  - op-1gram-seq, op-1gram-freq, op-1gram-set (Opcode 1-gram variants)
-  - op-2gram-seq, op-2gram-freq, op-2gram-set (Opcode 2-gram variants)
-  - op-3gram-seq, op-3gram-freq, op-3gram-set (Opcode 3-gram variants)
-  - op-4gram-seq, op-4gram-freq, op-4gram-set (Opcode 4-gram variants)
-  - op-5gram-seq, op-5gram-freq, op-5gram-set (Opcode 5-gram variants)
-  - op-6gram-seq, op-6gram-freq, op-6gram-set (Opcode 6-gram variants)
-  - op-7gram-seq, op-7gram-freq, op-7gram-set (Opcode 7-gram variants)
-  - op-8gram-seq, op-8gram-freq, op-8gram-set (Opcode 8-gram variants)
-
-  info stops the listing at k = 8. Any k is accepted: op-12gram-set is a
-  birthmark type, it is simply not one info can list.
-
-Supported Similarity Algorithms:
-  - cosine (Cosine Similarity)
-  - dice (Dice Index)
-  - euclidean (Euclidean Distance)
-  - jaccard (Jaccard Index)
-  - levenshtein (Levenshtein Distance)
-  - lcs (Longest Common Subsequence)
-  - simpson (Simpson Index)
-  - weighted-jaccard (Weighted Jaccard Index)
-
-Supported Aggregators:
-  - hungarian (Bipartite Matching via Hungarian Algorithm)
-  - topn:N (Average of Top N Closest Matchings)
+=========== Oinkie Info ============
+Oinkie is a tool for detecting the code theft with Ghidra P-code as birthmarks.
+The birthmark is a unique characteristic of a program that can be used to identify it.
+Oinkie extracts birthmarks from given codes and compares them to calculate the similarities.
+============ Birthmarks =============
+- fc-seq                the sequence of method calls in a program
+- fc-freq               the frequency of method calls in a program
+- fc-set                the set of method calls in a program
+- op-seq                the sequence of operations in a program
+- op-set                the set of operations in a program
+- op-freq               the frequency of operations in a program
+- op-1gram-seq          the sequence of 1-grams of operations in a program
+- op-2gram-seq          the sequence of 2-grams of operations in a program
+- op-3gram-seq          the sequence of 3-grams of operations in a program
+- op-4gram-seq          the sequence of 4-grams of operations in a program
+- op-5gram-seq          the sequence of 5-grams of operations in a program
+- op-6gram-seq          the sequence of 6-grams of operations in a program
+- op-7gram-seq          the sequence of 7-grams of operations in a program
+- op-8gram-seq          the sequence of 8-grams of operations in a program
+- op-1gram-freq         the frequency of 1-grams of operations in a program
+- op-2gram-freq         the frequency of 2-grams of operations in a program
+- op-3gram-freq         the frequency of 3-grams of operations in a program
+- op-4gram-freq         the frequency of 4-grams of operations in a program
+- op-5gram-freq         the frequency of 5-grams of operations in a program
+- op-6gram-freq         the frequency of 6-grams of operations in a program
+- op-7gram-freq         the frequency of 7-grams of operations in a program
+- op-8gram-freq         the frequency of 8-grams of operations in a program
+- op-1gram-set          the set of 1-grams of operations in a program
+- op-2gram-set          the set of 2-grams of operations in a program
+- op-3gram-set          the set of 3-grams of operations in a program
+- op-4gram-set          the set of 4-grams of operations in a program
+- op-5gram-set          the set of 5-grams of operations in a program
+- op-6gram-set          the set of 6-grams of operations in a program
+- op-7gram-set          the set of 7-grams of operations in a program
+- op-8gram-set          the set of 8-grams of operations in a program
+======== Compare Algorithms ========
+- cosine                Cosine similarity based on term frequency vectors. Available: seq and freq
+- dice                  Dice coefficient. Available: seq, set and freq
+- euclidean             Euclidean distance between term frequency vectors. Available: seq and freq
+- jaccard               Jaccard index. Available: seq, set and freq
+- levenshtein           Levenshtein distance. Available: seq
+- lcs                   Longest Common Subsequence (LCS). Available: seq
+- simpson               Simpson's coefficient. Available: seq, set and freq
+- weighted-jaccard      Weighted Jaccard index based on term frequency vectors. Available: seq and freq
 ```
+
+The k-gram listing stops at \\(k = 8\\). That bound is only what `info` shows:
+any \\(k\\) is accepted, so `op-12gram-set` is a birthmark type even though it is
+not listed.
+
+`info` does not list the aggregators, which are given to `-A/--aggregator` on
+`compare`, `run` and `reaggregate` rather than named in an analysis. They are
+`hungarian` and `topn:N` (or `topn:all`); see those commands' `--help`.

--- a/docs/content/usage/lift.md
+++ b/docs/content/usage/lift.md
@@ -26,13 +26,17 @@ oinkie lift [OPTIONS] [FILES]...
 * `-d, --dest <DIRECTORY>`  
   Specify the directory to place the resulting JSON files of the lifted P-code. Defaults to the `./pcodes` directory. `[default: pcodes]`
 * `-l, --lifter-type <LIFTER_TYPE>`  
-  Specify the lifter type to use. `[default: ghidra]` `[possible values: ghidra, llvm, binary-ninja]`
+  Specify the lifter type to use. `[default: ghidra]` `[possible values: ghidra, angr, ida-pro, binary-ninja]`  
+  Only `ghidra` is implemented; the others are named so that the error says which one you asked for.
 * `-H, --home <HOME>`  
-  Specify the path to the home directory of the lifter (e.g., `GHIDRA_HOME` for Ghidra). If not specified, the application will search the respective environment variable or look for common default paths.
+  Path to the lifter's installation directory. If not specified, the lifter's own environment variable (`GHIDRA_HOME` for Ghidra) is read, then the usual install locations are searched. The error names which variable to set.
 * `-i, --intermediate <DIRECTORY>`  
   Specify a directory to keep intermediate lifter files (like Ghidra project directories). If not provided, a temporary directory is used and deleted automatically.
 * `--script <SCRIPT>`  
   Path to a custom lifting script. The script's interpretation depends on the lifter type. For Ghidra, it's the path to a Java script.
+* `-j, --jobs <JOBS>`  
+  How many files may be lifted at once. `[default: 1]`  
+  Lifting is serial by default: each lift is a whole decompiler process, and Ghidra compiles its language definitions into its own installation on first use, so parallel lifts against a fresh installation can corrupt that cache. Once it is built, `-j` is safe; the command prints a notice rather than refusing.
 * `-S, --skip`  
   Skip the lifting process if the output JSON file already exists in the destination directory.
 

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -6,7 +6,7 @@ theme = ["github.com/tamada/hugo_theme_mod", "github.com/nunocoracao/blowfish/v2
 
 [params]
 logo = "oinkie.png"
-description = "Detecting software theft, the birthmark toolkit for Ghidra Pcode, LLVM IR/BC, and Binary Ninja."
+description = "Detecting software theft, the birthmark toolkit for Ghidra P-code, with Binary Ninja and IDA Pro planned."
 dateFormat = "2006-01-02"
 copyright = "Copyright &copy; 2025 by Haruaki Tamada. Made with [Hugo](https://gohugo.io/). Deployed to [GitHub Pages](https://pages.github.com/)."
 


### PR DESCRIPTION
No issue — found while surveying the tree after #70. Not stacked; branches from `main`.

`cli/README.md` is a transcript of `--help` kept by hand, so it had drifted. The worst of it:

| where | said | actually |
| --- | --- | --- |
| `extract` | documents `-B/--binary-type` | **removed in v0.4.0** — the release notes say so |
| `lift` | — | missing `-j/--jobs` (#55) |
| `run` | — | missing `-A/--aggregator` |
| `lift -l` | `ghidra, llvm, binary-ninja` | `ghidra, angr, ida-pro, binary-ninja` |
| `run -s` | four strategies | five — `last-vs-others` was absent |

Someone reading the README would type `-B llvm` and get an unknown-argument error.

Three of the six blocks had been transcribed from `-h` and three from `--help`, for no reason anyone could reconstruct. **Every block is now generated from the binary and standardised on `--help`**, which is the fuller of the two and the right one for a reference page.

## The `oinkie info` sample was not stale so much as fictional

`docs/content/usage/info.md` showed:

```text
oinkie v0.2.0
Detecting software theft, the birthmark toolkit for Ghidra Pcode, LLVM IR/BC, and Binary Ninja.

Supported Birthmark Types:
  - fc-seq (Function Calls Sequence)
...
Supported Aggregators:
  - hungarian (Bipartite Matching via Hungarian Algorithm)
```

The command has never printed that banner in this format, and it **does not print an aggregator section at all**. Replaced with the real output.

The two things worth saying that are *not* in the output — that the k-gram listing stops at 8 while any k still parses, and where the aggregators actually live (`-A` on `compare`/`run`/`reaggregate`) — are prose beside the block rather than lines pretending to be output. That was the original sin: editorial notes and real output in one fence, indistinguishable.

`lift.md` gains `-j/--jobs` with the reason it defaults to one, and its lifter list and `--home` description are brought in line.

## Verification

Every option every command offers now appears on its page, checked by walking `--help` for each of the five:

```
lift         missing: none
extract      missing: none
compare      missing: none
run          missing: none
reaggregate  missing: none
```

Generated from the binary rather than edited, so the transcripts are the output rather than a copy of it.

**Rebased onto #72**, which merged after this was opened. Only the release-note entry conflicted, resolved by keeping both.

## LLVM IR/BC is no longer named as a target

Raised here as an open question at first; confirmed as no longer planned, so it is fixed in this PR too.

The tagline called oinkie *"the birthmark toolkit for Ghidra Pcode, LLVM IR/BC, and Binary Ninja"* and the landing page called LLVM planned support. LLVM is in neither `Ir` nor `LifterType`, and the multi-lifter design work is about Binary Ninja and IDA Pro.

```
Detecting software theft, the birthmark toolkit for Ghidra P-code,
with Binary Ninja and IDA Pro planned.
```

Five places said it — the tagline in `README.md`, `docs/hugo.toml` and `docs/content/_index.md`, the pipeline step in `README.md`, and "planned support" on the landing page.

**The naming story needed care rather than deletion.** It reads *"pochi is the toolkit for the JVM platform … the purpose of oinkie is the same as pochi's on the other platform: LLVM IR/BC"* — a present-tense claim about oinkie smuggled in through a sentence about pochi. It says *native binaries rather than the JVM* now, which is the distinction the story was actually drawing. `about.md` loses "like LLVM IR" from the same story for the same reason.

The one thing left untouched is `pochi` itself being the JVM toolkit, which is true.
