### PR TITLE
fix: anchor the version replace to what it is replacing

### DIFF
--- a/.github/release-notes/v0.4.0.md
+++ b/.github/release-notes/v0.4.0.md
@@ -441,6 +441,12 @@ now is.
   Ninja", but LLVM is in neither `Ir` nor `LifterType` and is not in the
   multi-lifter design work, which is about Binary Ninja and IDA Pro. The
   documentation says what is there and what is planned
+- **The release script no longer rewrites text that merely contains the old
+  version.** It replaced the bare number everywhere in `README.md` and the
+  landing page, so cutting 0.3.0 to 0.4.0 would have turned a cited paper's
+  NII CRID `1572824500.3.007232` into `...500.4.007232` — silently, in the
+  released README (#75). Each replacement is anchored to the badge or link it
+  belongs to
 - **The CLI reference matches the CLI.** `cli/README.md` documented
   `-B/--binary-type`, which this release removes, and was missing `lift -j`
   and `run -A`; `lift`'s lifter list still read `ghidra, llvm, binary-ninja`

--- a/.github/scripts/update_version.sh
+++ b/.github/scripts/update_version.sh
@@ -1,8 +1,35 @@
 #! /bin/sh
+#
+# Rewrites the version this repository claims about itself.
+#
+# Each replacement is anchored to what precedes the version, rather than
+# matching the previous version string anywhere it appears. It used to be
+# `sed "s/${FROM_VERSION}/${TO_VERSION}/g"` over the whole file, which
+# rewrites any text that happens to contain the old number: going 0.3.0 to
+# 0.4.0 would have turned the NII CRID 1572824500.3.007232 of a cited paper
+# into ...500.4.007232, silently, in the released README (#75).
+#
+# Matching the shape of a version rather than the literal old one also makes
+# this idempotent, so it does not matter whether Cargo.toml still holds the
+# previous version when it runs.
 
-FROM_VERSION=`grep '^version = ' Cargo.toml | sed 's/version = "\(.*\)"/\1/g'`
+set -eu
+
 TO_VERSION=$1
+V='[0-9]+\.[0-9]+\.[0-9]+'
 
-sed "s/^version = \".*\"/version = \"$TO_VERSION\"/" Cargo.toml > a ; mv a Cargo.toml
-sed "s/${FROM_VERSION}/$TO_VERSION/g" README.md > a ; mv a README.md
-sed "s/${FROM_VERSION}/$TO_VERSION/g" docs/content/_index.md > a ; mv a docs/content/_index.md
+replace_in() {
+    file=$1
+    sed -E \
+        -e "s|(badge/Version-)${V}|\1${TO_VERSION}|g" \
+        -e "s|(releases/tag/v)${V}|\1${TO_VERSION}|g" \
+        -e "s|(oinkie:)${V}|\1${TO_VERSION}|g" \
+        "$file" > "$file.tmp"
+    mv "$file.tmp" "$file"
+}
+
+sed -E "s/^version = \".*\"/version = \"${TO_VERSION}\"/" Cargo.toml > Cargo.toml.tmp
+mv Cargo.toml.tmp Cargo.toml
+
+replace_in README.md
+replace_in docs/content/_index.md

--- a/.github/scripts/update_version.sh
+++ b/.github/scripts/update_version.sh
@@ -15,21 +15,46 @@
 
 set -eu
 
-TO_VERSION=$1
-V='[0-9]+\.[0-9]+\.[0-9]+'
-
-replace_in() {
-    file=$1
-    sed -E \
-        -e "s|(badge/Version-)${V}|\1${TO_VERSION}|g" \
-        -e "s|(releases/tag/v)${V}|\1${TO_VERSION}|g" \
-        -e "s|(oinkie:)${V}|\1${TO_VERSION}|g" \
-        "$file" > "$file.tmp"
-    mv "$file.tmp" "$file"
+usage() {
+    echo "usage: $0 <version>        e.g. $0 0.4.0" >&2
+    echo "  the leading v of a tag name is accepted and ignored" >&2
+    exit 1
 }
 
-sed -E "s/^version = \".*\"/version = \"${TO_VERSION}\"/" Cargo.toml > Cargo.toml.tmp
-mv Cargo.toml.tmp Cargo.toml
+[ $# -eq 1 ] || usage
 
-replace_in README.md
-replace_in docs/content/_index.md
+# The caller is the release workflow, which derives this from the branch name
+# `releases/vX.Y.Z`. Checked anyway: an unchecked value reaches the right-hand
+# side of a `sed` s/// and could rewrite these files into anything, and this
+# runs on a release branch where the result is committed and pushed.
+TO_VERSION=$(printf '%s' "$1" | sed -E 's/^v//')
+case $TO_VERSION in
+    *[!0-9.]* | *..* | .* | *. ) usage ;;
+esac
+echo "$TO_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' || usage
+
+V='[0-9]+\.[0-9]+\.[0-9]+'
+TMP=
+
+# sed writes beside the file it is rewriting, so a failure part-way through
+# must not leave that behind for the commit step to pick up.
+cleanup() { [ -z "$TMP" ] || rm -f "$TMP"; }
+trap cleanup EXIT
+
+rewrite() {
+    file=$1
+    shift
+    TMP="$file.tmp"
+    sed -E "$@" "$file" > "$TMP"
+    mv "$TMP" "$file"
+    TMP=
+}
+
+rewrite Cargo.toml -e "s/^version = \".*\"/version = \"${TO_VERSION}\"/"
+
+for f in README.md docs/content/_index.md; do
+    rewrite "$f" \
+        -e "s|(badge/Version-)${V}|\1${TO_VERSION}|g" \
+        -e "s|(releases/tag/v)${V}|\1${TO_VERSION}|g" \
+        -e "s|(oinkie:)${V}|\1${TO_VERSION}|g"
+done


### PR DESCRIPTION
Closes #75. Branches from `main`; **worth merging before #74**, since the script runs on the release branch.

## It would have broken a citation in this release

`update_version.sh` rewrote the version with a global replace of the bare number:

```sh
sed "s/${FROM_VERSION}/$TO_VERSION/g" README.md > a ; mv a README.md
```

so any text that happens to contain the old version is rewritten, whether or not it is a version. Run against `README.md` as it stood at `25e5e3d`, for 0.3.0 → 0.4.0:

```
cir.nii.ac.jp/crid/1572824500.3.007232   →   cir.nii.ac.jp/crid/1572824500.4.007232
```

The NII CRID of a cited paper — `500.3.00` contains `0.3.0`. A broken link, silently, in the README, in a release.

It did not happen only because #74 bumps the files by hand against whole badge lines, so `FROM_VERSION` was already `0.4.0` and the script found nothing to do. Nothing about the script prevented it. And 0.4.0 → 0.5.0 happens to be safe for that particular CRID, so it would not have announced itself next time either.

## The fix

Each of the three replacements is anchored to what precedes the version — the version badge, the release-tag link, the container tag — and matches the *shape* of a version rather than the literal previous one. `Cargo.toml` was already anchored and is unchanged in behaviour.

Matching a shape also makes the script **idempotent**, so it no longer depends on `Cargo.toml` still holding the old version when it runs — which is exactly the state it finds on a release branch prepared by hand.

## Verification

On a copy of the tree at `25e5e3d`, running the new script with `0.4.0`:

| check | result |
| --- | --- |
| `Cargo.toml`, `README.md`, `docs/content/_index.md` | **byte-identical** to what #74 wrote by hand |
| all six badge / link / tag occurrences | updated |
| `crid/1572824500.3.007232` | **untouched** |
| a second run | changes nothing |

The first row is the one that matters: the script and the hand edit now agree exactly, so whichever runs first, the result is the same.
